### PR TITLE
Fix validation checkmarks not working

### DIFF
--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -319,10 +319,10 @@ function validator($el) {
             validatorName.toLowerCase() + ']');
 
         if (!validatorPattern.test($el.val())) {
-          $validatorCheckbox.toggleClass('usa-check_list-checked', false);
+          $validatorCheckbox.toggleClass('usa-checklist-checked', false);
         }
         else {
-          $validatorCheckbox.toggleClass('usa-check_list-checked', true);
+          $validatorCheckbox.toggleClass('usa-checklist-checked', true);
         }
       }
     }


### PR DESCRIPTION
Was from a regression here: ff5e04f963dba94ae0d59ba2743a5747e30dc1b9
where we changed the class name.

Not a browser specific bug, didn't work on Chrome either.