### PR TITLE
Vertical line space in accordions

### DIFF
--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -82,7 +82,7 @@
     margin-top: 0;
   }
 
-  *:last-child {
+  > *:last-child {
     margin-bottom: 0;
   }
 }

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -78,7 +78,7 @@
   overflow: auto;
   padding: 3rem;
 
-  *:first-child {
+  > *:first-child {
     margin-top: 0;
   }
 


### PR DESCRIPTION
The line space in accordions was broken because every nested last-child
was having it's margins removed, which it requires. This ensures only
the first child last child does.

Fixes https://github.com/18F/web-design-standards/issues/445