### PR TITLE
Updates to the sidebar navigation

### DIFF
--- a/_elements/form-controls.md
+++ b/_elements/form-controls.md
@@ -198,7 +198,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
   </div>
 </div>
 
-<h2 class="usa-heading">Radio buttons</h2>
+<h2 class="usa-heading" id="radiobuttons">Radio buttons</h2>
 <p class="usa-font-lead">Radio buttons allow users to see all available choices at once and select exactly one option.</p>
 
 <div class="preview">

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -43,7 +43,7 @@
         </ul>
       </li> 
       <li>
-        <a {% if current[1] == 'grids' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/grids/">Grids</a>
+        <a {% if current[1] == 'grids' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/grids/">Grid</a>
       </li>
       <li>
         <a {% if current[1] == 'buttons' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/buttons/">Buttons</a>
@@ -70,7 +70,10 @@
             <a href="{{ site.baseurl }}/form-controls/#dropdown">Dropdown</a>
           </li>
           <li>
-            <a href="{{ site.baseurl }}/form-controls/#checkboxes">Radio buttons and checkboxes</a>
+            <a href="{{ site.baseurl }}/form-controls/#checkboxes">Checkboxes</a>
+          </li>
+          <li>
+            <a href="{{ site.baseurl }}/form-controls/#radiobuttons">Radio buttons</a>
           </li>
           <li>
             <a href="{{ site.baseurl }}/form-controls/#date-input">Date input</a>
@@ -87,7 +90,7 @@
             <a href="{{ site.baseurl }}/form-templates/#address-form">Address form</a>
           </li>
           <li>
-            <a href="{{ site.baseurl }}/form-templates/#login-form">Login form</a>
+            <a href="{{ site.baseurl }}/form-templates/#login-form">Sign-in form</a>
           </li>
           <li>
             <a href="{{ site.baseurl }}/form-templates/#password-reset-form">Password reset form</a>


### PR DESCRIPTION
This PR:
- **Renames "Grids" to "Grid"** to be consistent with our use of singular/plural on the rest of the navigation. In general, if there is more than one version of the component shown in the example (e.g. many types of buttons, alerts), it's plural. If there only one shown in the example (e.g. "dropdown"), it's singular. There is only one grid, so it should be singular.
- **Split "Radio buttons and checkboxes" into two separate components in the navigation**, like they are in the form controls page itself.
- **Rename "login form" to "sign-in form"** to match its documentation.