### PR TITLE
Adding Google Analytics event listeners

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -19,10 +19,11 @@
       </div>
       <ul class="usa-button-list usa-unstyled-list">
         <li>
-          <a class="usa-button" href="#">Download</a>
+          <a class="usa-button" href="#" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button inside site');">Download</a>
         </li>
         <li>
-          <a class="usa-button usa-button-outline" href="https://github.com/18F/usfwds/" target="_blank">
+          <a class="usa-button usa-button-outline" href="https://github.com/18F/usfwds/" target="_blank" onclick="ga('send', 'event', 'Viewed on Github', 'Clicked View on Github from inside site');"
+>
             View on Github
           </a>
           </li>

--- a/pages/index.html
+++ b/pages/index.html
@@ -27,9 +27,9 @@ title: U.S. Federal Web Design Standards
         <h1>U.S. Federal Web Design Standards</h1>
         <h2 class="usa-font-lead">Open source UI components, visual style guide and content style guide for U.S. federal government websites.</h2>
       </div>
-        <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/getting-started">View the standards</a>
+        <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage splash');">View the standards</a>
         <div class="usa-button-block">
-          <a class="usa-button usa-button-big usa-button-outline-inverse">Download the components</a>
+          <a class="usa-button usa-button-big usa-button-outline-inverse" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button on homepage');">Download the components</a>
           <p class="usa-text-small">Download a zip file with the assets of this library</p>
         </div>
     </div>
@@ -65,7 +65,8 @@ title: U.S. Federal Web Design Standards
     </div>
   </div>
   <div class="usa-grid usa-cta">
-    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started">View the standards</a>
+    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage body');"
+>View the standards</a>
   </div>
 </section>
 
@@ -93,7 +94,8 @@ title: U.S. Federal Web Design Standards
     </div>
   </div>
   <div class="usa-grid usa-cta">
-    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started">View the standards</a>
+    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage body');"
+>View the standards</a>
   </div>
 </section>
 
@@ -129,7 +131,8 @@ title: U.S. Federal Web Design Standards
     </div> 
   </div>
   <div class="usa-grid usa-cta">
-    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started">View the standards</a>
+    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage body');"
+>View the standards</a>
   </div>
 </section>
 
@@ -157,7 +160,8 @@ title: U.S. Federal Web Design Standards
     </div>
   </div>
   <div class="usa-grid usa-cta">
-    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started">View the standards</a>
+    <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage body');"
+>View the standards</a>
   </div>
 </section>
 
@@ -172,6 +176,6 @@ title: U.S. Federal Web Design Standards
     <div class="usa-cta">
       <a class="usa-button usa-button-secondary" href="#">Contribute on Github</a>
     </div>
-    <a href="#">Or view the standards</a>
+    <a href="#" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards link at the bottom of the homepage');">Or view the standards</a>
   </div>
 </section>


### PR DESCRIPTION
This PR adds Google Analytics event listeners to the download buttons, "View on Github" buttons or links, and the "View the standards" buttons on the homepage.

Event listeners are our way of reliably telling when the download buttons and the "View on Github" buttons are clicked. GA doesn't  automatically register *which* site people go to when they leave an Analytics tracked page. And it doesn't automatically track downloaded files either.

I'd also like to track the "View the standards" buttons to see whether the buttons farther down the page are ever clicked. Good knowledge for future iterations.