### PR TITLE
Fix logo focus state

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -13,9 +13,10 @@
     <nav class="usa-site-navbar">
       <a href="#" id="menu-btn">&#9776; MENU</a>
       <div class="logo" id="logo">
-        <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
-          <h1>U.S. Federal Web Design Standards</h1>
-        </a>
+        <h1>
+          <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
+          U.S. Federal Web Design Standards</a>
+        </h1>
       </div>
       <ul class="usa-button-list usa-unstyled-list">
         <li>

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -56,7 +56,6 @@ $site-top:           124px;
 
     h1 {
       @include media($medium-screen) {
-
         max-width: 20rem;
       }
       float: left;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -47,15 +47,18 @@ $site-top:           124px;
     }
 
     .logo {
-        padding-left: $site-margins;
+      padding-left: $site-margins;
+
+      a {
+        color: $color-gray;
       }
+    }
 
     h1 {
       @include media($medium-screen) {
 
         max-width: 20rem;
       }
-      color: $color-gray;
       float: left;
       margin: 0;
       font-size: $base-font-size * 1.25;


### PR DESCRIPTION
This move the h1 tag around the logo link, it was inside before. Doing this makes sure the link will focus. This resolves #483.

This is what it looks like:

![screen shot 2015-09-14 at 2 57 19 pm](https://cloud.githubusercontent.com/assets/5249443/9863012/6f2e882e-5af1-11e5-9f25-6923b4031414.png)
