### PR TITLE
Remove baseurl from config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,3 @@
-# 18F pages base url config
-baseurl: /web-design-standards
-
 # Markdown config
 markdown: redcarpet
 highlighter: rouge


### PR DESCRIPTION
This removes the baseurl from the config file.

Jekyll is now served locally from `http://127.0.0.1:4000/`