### PR TITLE
Update GitHub link capitalization in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <p>Feedback? Create an issue on the <a href="https://github.com/18F/usfwds" target="_blank">GitHub repository</a>.</p>
+    <p>Feedback? Create an issue on the <a href="https://github.com/18F/usfwds">GitHub repository</a>.</p>
     <p>Have an idea? Read our <a href="https://github.com/18F/usfwds/blob/18f-pages/CONTRIBUTING.md">contribution guidelines</a>.</p>
   </div>
   <div class="usa-width-one-half usa-end-row">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <p>Feedback? Create an issue on the <a href="https://github.com/18F/usfwds">Github repository</a>.</p>
+    <p>Feedback? Create an issue on the <a href="https://github.com/18F/usfwds" target="_blank">GitHub repository</a>.</p>
     <p>Have an idea? Read our <a href="https://github.com/18F/usfwds/blob/18f-pages/CONTRIBUTING.md">contribution guidelines</a>.</p>
   </div>
   <div class="usa-width-one-half usa-end-row">


### PR DESCRIPTION
Like in the header. Also makes GitHub link's capitalization consistent with the header.