### PR TITLE
Update text input success to lighter green

### DIFF
--- a/assets/_scss/elements/_inputs.scss
+++ b/assets/_scss/elements/_inputs.scss
@@ -34,7 +34,7 @@ select  {
   }
 
   &.usa-input-success {
-    border: 3px solid $color-green;
+    border: 3px solid $color-green-light;
   }
 }
 


### PR DESCRIPTION
This updates the green to use a lighter shade: `$color-green-light`.

This resolves #337.

This is what it looks like:

![screen shot 2015-09-15 at 11 50 41 am](https://cloud.githubusercontent.com/assets/5249443/9886684/637a26fa-5ba0-11e5-9a94-660d97f7ca9d.png)
