### PR TITLE
Fix style-less sidenav/ due to front matter error

### DIFF
--- a/_components/sidenav.md
+++ b/_components/sidenav.md
@@ -2,7 +2,7 @@
 layout: styleguide
 type: component
 title: Side navigation
-lead: Hierarchical, vertical navigation to place at the side of a page. Note: we are currently developing horizontal navigation and headers for the top of a page.
+lead: "Hierarchical, vertical navigation to place at the side of a page. Note: we are currently developing horizontal navigation and headers for the top of a page."
 ---
 
 <div class="preview">


### PR DESCRIPTION
The `lead:` value contains a `:` character. This caused the front matter to
fail to parse, and consequently the page was rendering without any styles
applied. The fix is to wrap the `lead:` value string in quotation marks.

cc: @maya @mollieru @carodew @colinpmacarthur