### PR TITLE
Removing the word 'h3' from alert titles

### DIFF
--- a/_components/alerts.md
+++ b/_components/alerts.md
@@ -9,35 +9,35 @@ lead: Alerts keep users informed of important and sometimes time-sensitive chang
 
   <div class="usa-alert usa-alert-success">
     <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Success Status h3</h3>
+      <h3 class="usa-alert-heading">Success Status</h3>
       <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-warning">
     <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Warning Status h3</h3>
+      <h3 class="usa-alert-heading">Warning Status</h3>
       <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-error">
     <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Error Status h3</h3>
+      <h3 class="usa-alert-heading">Error Status</h3>
       <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-info">
     <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Information Status h3</h3>
+      <h3 class="usa-alert-heading">Information Status</h3>
       <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-info">
     <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Information Status h3</h3>
+      <h3 class="usa-alert-heading">Information Status</h3>
       <p class="usa-alert-text">Multi line. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui atione voluptatem sequi nesciunt. Neque porro quisquam est, qui doloremipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
     </div>
   </div>


### PR DESCRIPTION
Removing the word "h3" from the titles of the alerts, so that they match the original design mockups.