### PR TITLE
Fix search input styling in iPhone

### DIFF
--- a/assets/_scss/components/_search.scss
+++ b/assets/_scss/components/_search.scss
@@ -16,6 +16,8 @@ $usa-btn-big-width:     11.6rem;
 
   [type="search"],
   .usa-search-input {
+    -moz-appearance: none;
+    -webkit-appearance: none;
     border: {
       bottom-right-radius: 0;
       right: none;

--- a/assets/_scss/components/_search.scss
+++ b/assets/_scss/components/_search.scss
@@ -16,7 +16,6 @@ $usa-btn-big-width:     11.6rem;
 
   [type="search"],
   .usa-search-input {
-    -moz-appearance: none;
     -webkit-appearance: none;
     border: {
       bottom-right-radius: 0;


### PR DESCRIPTION
This removes the safari ios styling of search inputs. 

This resolves: #578