### PR TITLE
Fix table line-height

### DIFF
--- a/assets/_scss/elements/_table.scss
+++ b/assets/_scss/elements/_table.scss
@@ -15,7 +15,6 @@ table {
 
   th, td {
     border: 1px solid $color-gray;
-    line-height: 1;
     padding: 1.5rem;
   }
 }


### PR DESCRIPTION
This updates the line-height of items in tables. 

This resolves #554.

This is what it looks like:

<img width="378" alt="screen shot 2015-09-16 at 2 49 59 pm" src="https://cloud.githubusercontent.com/assets/5249443/9919504/447d65cc-5c82-11e5-96cf-79dccbe23944.png">

