### PR TITLE
Extract base.scss from all.scss to fix icon paths

### DIFF
--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -3,9 +3,8 @@
 
 // Imports -------------- //
 
-@import 'lib/bourbon/bourbon';
-@import 'lib/neat/neat';
-@import 'all';
+@import 'base';
+@import url('{{ site.baseurl }}/assets/css/main.css');
 
 // Variables ------------ //
 

--- a/assets-styleguide/css/styleguide.scss
+++ b/assets-styleguide/css/styleguide.scss
@@ -3,9 +3,8 @@
 
 // Imports -------------- //
 
-@import 'lib/bourbon/bourbon';
-@import 'lib/neat/neat';
-@import 'all';
+@import 'base';
+@import url('{{ site.baseurl }}/assets/css/main.css');
 
 // Variables -------------- //
 

--- a/assets/_scss/all.scss
+++ b/assets/_scss/all.scss
@@ -1,19 +1,4 @@
-// Vendor -------------- //
-
-@import 'lib/bourbon/bourbon';
-@import 'lib/neat/neat';
-@import 'lib/normalize';
-
-
-// Core -------------- //
-
-@import 'core/grid-settings';
-@import 'core/defaults';
-@import 'core/variables';
-@import 'core/base';
-@import 'core/grid';
-@import 'core/utilities';
-
+@import 'base';
 
 // Elements -------------- //
 // Styles basic html elements

--- a/assets/_scss/all.scss
+++ b/assets/_scss/all.scss
@@ -1,4 +1,5 @@
 @import 'base';
+@import 'lib/normalize';
 
 // Elements -------------- //
 // Styles basic html elements

--- a/assets/_scss/base.scss
+++ b/assets/_scss/base.scss
@@ -1,0 +1,15 @@
+// Vendor -------------- //
+
+@import 'lib/bourbon/bourbon';
+@import 'lib/neat/neat';
+@import 'lib/normalize';
+
+
+// Core -------------- //
+
+@import 'core/grid-settings';
+@import 'core/defaults';
+@import 'core/variables';
+@import 'core/base';
+@import 'core/grid';
+@import 'core/utilities';

--- a/assets/_scss/base.scss
+++ b/assets/_scss/base.scss
@@ -2,7 +2,6 @@
 
 @import 'lib/bourbon/bourbon';
 @import 'lib/neat/neat';
-@import 'lib/normalize';
 
 
 // Core -------------- //

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -23,8 +23,8 @@
   }
 
   button[aria-expanded=false] {
-    background-image: url('/assets/img/plus.png');
-    background-image: url('/assets/img/plus.svg');
+    background-image: url('../img/plus.png');
+    background-image: url('../img/plus.svg');
     background-position: 90.5%;
     background-repeat: no-repeat;
     background-size: 13px;
@@ -38,8 +38,8 @@
       background-position: 96.5%;
     }
     background-color: $color-gray-lightest;
-    background-image: url('/assets/img/minus.png');
-    background-image: url('/assets/img/minus.svg');
+    background-image: url('../img/minus.png');
+    background-image: url('../img/minus.svg');
     background-position: 90.5%;
     background-repeat: no-repeat;
     background-size: 13px;

--- a/assets/_scss/components/_alerts.scss
+++ b/assets/_scss/components/_alerts.scss
@@ -1,5 +1,5 @@
 .usa-alert {
-  background-color: #eeeeee;  
+  background-color: #eeeeee;
   background-position: 1rem 2rem;
   background-repeat: no-repeat;
   background-size: 4rem;
@@ -53,28 +53,28 @@
 
 .usa-alert-success {
   background-color: #E5FCDE;
-  background-image: url('/assets/img/alerts/success.png');  
-  background-image: url('/assets/img/alerts/success.svg');  
+  background-image: url('../img/alerts/success.png');
+  background-image: url('../img/alerts/success.svg');
 }
 
 .usa-alert-warning {
   background-color: #FDF7DC;
-  background-image: url('/assets/img/alerts/warning.png');  
-  background-image: url('/assets/img/alerts/warning.svg');   
+  background-image: url('../img/alerts/warning.png');
+  background-image: url('../img/alerts/warning.svg');
 }
 
 .usa-alert-error {
   background-color: #F9DEDE;
-  background-image: url('/assets/img/alerts/error.png');  
-  background-image: url('/assets/img/alerts/error.svg');   
+  background-image: url('../img/alerts/error.png');
+  background-image: url('../img/alerts/error.svg');
 }
 
 .usa-alert-info {
   background-color: #E8F5FA;
-  background-image: url('/assets/img/alerts/info.png');  
-  background-image: url('/assets/img/alerts/info.svg');   
+  background-image: url('../img/alerts/info.png');
+  background-image: url('../img/alerts/info.svg');
 }
 
 .usa-alert-no_icon {
- background-image: none; 
+ background-image: none;
 }

--- a/assets/_scss/components/_footer.scss
+++ b/assets/_scss/components/_footer.scss
@@ -215,7 +215,7 @@ li.usa-footer-primary-content {
     }    
 
     .usa-footer-primary-link {
-      background: url('/assets/img/arrow-down.png') no-repeat;
+      background: url('../img/arrow-down.png') no-repeat;
       background-position: 1.5rem;
       padding-left: 3.5rem;
 
@@ -232,7 +232,7 @@ li.usa-footer-primary-content {
 
       .usa-footer-primary-link { 
         margin: 0; 
-        background: url('/assets/img/arrow-right.png') no-repeat;
+        background: url('../img/arrow-right.png') no-repeat;
         background-position: 1.5rem;
         cursor: pointer;
 

--- a/assets/_scss/components/_forms.scss
+++ b/assets/_scss/components/_forms.scss
@@ -170,8 +170,8 @@ input.usa-input-medium {
 
 .usa-checklist-checked {
   &:before {
-    background-image: url('/assets/img/correct9.png');
-    background-image: url('/assets/img/correct9.svg');
+    background-image: url('../img/correct9.png');
+    background-image: url('../img/correct9.svg');
     background-position: 100%;
     background-repeat: no-repeat;
     background-size: 100%;

--- a/assets/_scss/components/_search.scss
+++ b/assets/_scss/components/_search.scss
@@ -3,8 +3,8 @@ $usa-btn-medium-width:  8.5rem;
 $usa-btn-big-width:     11.6rem;
 
 @mixin search-icon {
-  background-image: url('/assets/img/search.png');
-  background-image: url('/assets/img/search.svg');
+  background-image: url('../img/search.png');
+  background-image: url('../img/search.svg');
   background-position: 50%;
   background-repeat: no-repeat;
 }

--- a/assets/_scss/elements/_inputs.scss
+++ b/assets/_scss/elements/_inputs.scss
@@ -171,8 +171,8 @@ input[type="radio"]:focus + label::before {
 }
 
 input[type="checkbox"]:checked + label::before {
-  background-image: url('/assets/img/correct8.png');
-  background-image: url('/assets/img/correct8.svg');
+  background-image: url('../img/correct8.png');
+  background-image: url('../img/correct8.svg');
   background-position: 50%;
   background-repeat: no-repeat;
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,6 +4,4 @@
 
 // Place list of your partial imports below, located in assets/_scss.
 
-@import 'lib/bourbon/bourbon';
-@import 'lib/neat/neat';
 @import 'all';


### PR DESCRIPTION
Closes #600.

The problem was that assets-styleguide/css/homepage.scss and
assets-styleguide/css/styleguide.scss were compiling assets/_scss/all.scss
inline, which meant that the relative paths that existed before #560 would be
relative to assets-styleguide/css, not assets/css. Furthermore, the absolute
paths introduced in #560 worked locally since `site.baseurl` was empty, but
were broken on https://pages-staging.18f.gov/web-design-standards because they
were not prefixed with `site.baseurl`, i.e. `/web-design-standards`.

The solution was to extract a new assets/_scss/base.scss file containing all
of the variables and mixins needed by all of the .scss files, and only include
base.css directly in the assets-styleguide .scss files. Then, the
assets-styleguide .scss files were updated to import the compiled
assets/_scss/all.scss file as a normal CSS import, i.e.
`@import url('{{ site.baseurl }}/assets/css/main.css');`. Since the
assets-styleguide .scss files are not part of the package intended for reuse,
and already had empty front matter that enabled Jekyll to perform Liquid
template rendering, this seemed a reasonable approach.

I also set `baseurl: /web-design-standards` in `_config.yml` to test the
changes locally, and verified that it also worked after removing `baseurl:`.

The tradeoff here is that the assets-styleguide CSS files are no longer
monolithic, and incur an extra request to import
`{{ site.baseurl}}/assets/css/main.css`. If there is a desire to maintain the
monolithic property, it is possible to use #{}-interpolation to inject
`{{ site.baseurl }}` as a prefix for the absolute paths by assigning it to a
SASS variable, per:

http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import

This wouldn't be that difficult or that ugly, but it seemed the current
approach was worth a try first.

cc: @maya @colinpmacarthur @angel