### PR TITLE
Attempt to fix focus state on accordion hover.

### DIFF
--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -51,7 +51,7 @@
     width: 100%;
 
     &:focus {
-      box-shadow: $focus-shadow !important;
+      box-shadow: $focus-shadow;
     }
 
     &:hover {

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -51,6 +51,10 @@
     padding: 1.5rem 3rem;
     width: 100%;
 
+    &:focus {
+      box-shadow: $focus-shadow !important;
+    }
+
     &:hover {
       background-color: $color-gray-lighter;
       color: $color-base;

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -9,7 +9,6 @@
   > ul {
     color: $color-base;
     margin: 0;
-    overflow: hidden;
     padding: 0;
     width: 100%;
 

--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -175,6 +175,6 @@ button,
 
   &:focus,
   &:hover {
-    box-shadow: initial !important;
+    box-shadow: initial;
   }
 }


### PR DESCRIPTION
An important rule has to be used because theres another one on
"unstyled" button. We should address this at some point, possibly
now.

The other larger problem is the `<ul>` on the accordion has a
overflow: hidden on it. This means the the box shadow won't show
up on accordions using the `<ul>`. Is there a strong reason why we
need overflow:hidden on the accordion `<ul>`?

Fixes part of https://github.com/18F/web-design-standards/issues/534