### PR TITLE
Add typography tweaks

### DIFF
--- a/_components/accordions.md
+++ b/_components/accordions.md
@@ -7,7 +7,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
 
 <div class="preview">
 
-  <h3>Borderless</h3>
+  <h6>Borderless</h6>
 
   <div class="usa-accordion">
     <ul class="usa-unstyled-list">
@@ -69,7 +69,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
     </ul>
   </div>
 
-  <h3>Bordered</h3>
+  <h6>Bordered</h6>
 
   <div class="usa-accordion-bordered usa-accordion-docs">
     <ul class="usa-unstyled-list">

--- a/_components/footers.md
+++ b/_components/footers.md
@@ -7,7 +7,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
 
 <div class="preview">
 
-  <h3 class="usa-heading" id="big-footer">Big footer</h3>
+  <h6 class="usa-heading-alt" id="big-footer">Big footer</h6>
 
   <footer class="usa-footer usa-footer-big usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -102,7 +102,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     </div>
   </footer>
 
-  <h3 class="usa-heading" id="medium-footer">Medium footer</h3>
+  <h6 class="usa-heading-alt" id="medium-footer">Medium footer</h6>
 
   <footer class="usa-footer usa-footer-medium usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -177,7 +177,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     </div>
   </footer>
 
-  <h3 class="usa-heading" id="slim-footer">Slim footer</h3>
+  <h6 class="usa-heading-alt" id="slim-footer">Slim footer</h6>
 
   <footer class="usa-footer usa-footer-slim usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">

--- a/_components/form-templates.md
+++ b/_components/form-templates.md
@@ -290,7 +290,7 @@ lead: Patterns for some of the most commonly used forms on government websites.
       <label for="confirmPassword">Confirm password</label>
       <input id="confirmPassword" name="confirmPassword" type="password">
       <p class="usa-form-note">
-        <a title="Show My Typing" href="javascript:void(0)"
+        <a title="Show my typing" href="javascript:void(0)"
             class="usa-show_multipassword"
             aria-controls="password">
           Show my typing</a>

--- a/_components/form-templates.md
+++ b/_components/form-templates.md
@@ -278,7 +278,7 @@ lead: Patterns for some of the most commonly used forms on government websites.
         </ul>
       </div>
 
-      <label for="password">New Password</label>
+      <label for="password">New password</label>
       <input id="password" name="password" type="password"
         aria-describedby="validation_list"
         class="js-validate_password"
@@ -287,16 +287,16 @@ lead: Patterns for some of the most commonly used forms on government websites.
         data-validate-numerical="\d"
         data-validation-element="#validation_list">
 
-      <label for="confirmPassword">Confirm Password</label>
+      <label for="confirmPassword">Confirm password</label>
       <input id="confirmPassword" name="confirmPassword" type="password">
       <p class="usa-form-note">
         <a title="Show My Typing" href="javascript:void(0)"
             class="usa-show_multipassword"
             aria-controls="password">
-          Show My Typing</a>
+          Show my typing</a>
       </p>
 
-      <input type="submit" value="Reset Password" />
+      <input type="submit" value="Reset password" />
     </fieldset>
   </form>
 

--- a/_components/form-templates.md
+++ b/_components/form-templates.md
@@ -30,13 +30,13 @@ lead: Patterns for some of the most commonly used forms on government websites.
       <label for="title">Title</label>
       <input class="usa-input-tiny" id="title" name="title" type="text">
 
-      <label for="first-name">First Name <span class="usa-additional_text">Required</span></label>
+      <label for="first-name">First name <span class="usa-additional_text">Required</span></label>
       <input id="first-name" name="first-name" type="text">
 
-      <label for="middle-name">Middle Name</label>
+      <label for="middle-name">Middle name</label>
       <input id="middle-name" name="middle-name" type="text">
 
-      <label for="last-name">Last Name <span class="usa-additional_text">Required</span></label>
+      <label for="last-name">Last name <span class="usa-additional_text">Required</span></label>
       <input id="last-name" name="last-name" type="text">
 
       <label for="suffix">Suffix</label>

--- a/_components/form-templates.md
+++ b/_components/form-templates.md
@@ -75,10 +75,10 @@ lead: Patterns for some of the most commonly used forms on government websites.
   <form class="usa-form-large">
     <fieldset>
       <legend>Mailing address</legend>
-      <label for="mailing-address-1">Street Address 1</label>
+      <label for="mailing-address-1">Street address 1</label>
       <input id="mailing-address-1" name="mailing-address-1" type="text">
 
-      <label for="mailing-address-2">Street Address 2 <span class="usa-additional_text">Optional</span></label>
+      <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">Optional</span></label>
       <input id="mailing-address-2" name="mailing-address-2" type="text">
 
       <div>

--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -13,7 +13,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     <div class="usa-width-one-half">
       <form class="usa-search usa-search-big">
         <div role="search">
-          <label for="search-field-big">Search big</label>
+          <label class="usa-sr-only" for="search-field-big">Search big</label>
           <input type="search" id="search-field-big">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
@@ -29,7 +29,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     <div class="usa-width-one-half">
       <form class="usa-search">
         <div role="search">
-          <label for="search-field">Search medium</label>
+          <label class="usa-sr-only" for="search-field">Search medium</label>
           <input type="search" id="search-field">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
@@ -45,7 +45,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     <div class="usa-width-one-half">
       <form class="usa-search usa-search-small">
         <div role="search">
-          <label for="search-field-small">Search small</label>
+          <label class="usa-sr-only" for="search-field-small">Search small</label>
           <input type="search" id="search-field-small">
           <button type="submit">
             <span class="usa-sr-only">Search</span>

--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -6,11 +6,13 @@ lead: Intro text on what is included in this section and how to use it. No more 
 ---
 
 <div class="preview preview-search-bar">
+
+  <h6>Search big</h6>
+
   <div class="usa-grid">
     <div class="usa-width-one-half">
       <form class="usa-search usa-search-big">
         <div role="search">
-          <label for="search-field-big">Search Big</label>
           <input type="search" id="search-field-big">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
@@ -20,11 +22,12 @@ lead: Intro text on what is included in this section and how to use it. No more 
     </div>
   </div>
 
+  <h6>Search medium</h6>
+
   <div class="usa-grid">
     <div class="usa-width-one-half">
       <form class="usa-search">
         <div role="search">
-          <label for="search-field">Search Medium</label>
           <input type="search" id="search-field">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
@@ -34,11 +37,12 @@ lead: Intro text on what is included in this section and how to use it. No more 
     </div>
   </div>
 
+  <h6>Search small</h6>
+
   <div class="usa-grid">
     <div class="usa-width-one-half">
       <form class="usa-search usa-search-small">
         <div role="search">
-          <label for="search-field-small">Search Small</label>
           <input type="search" id="search-field-small">
           <button type="submit">
             <span class="usa-sr-only">Search</span>

--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -13,6 +13,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     <div class="usa-width-one-half">
       <form class="usa-search usa-search-big">
         <div role="search">
+          <label for="search-field-big">Search big</label>
           <input type="search" id="search-field-big">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
@@ -28,6 +29,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     <div class="usa-width-one-half">
       <form class="usa-search">
         <div role="search">
+          <label for="search-field">Search medium</label>
           <input type="search" id="search-field">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
@@ -43,6 +45,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     <div class="usa-width-one-half">
       <form class="usa-search usa-search-small">
         <div role="search">
+          <label for="search-field-small">Search small</label>
           <input type="search" id="search-field-small">
           <button type="submit">
             <span class="usa-sr-only">Search</span>

--- a/_components/sidenav.md
+++ b/_components/sidenav.md
@@ -7,7 +7,7 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: w
 
 <div class="preview">
   
-  <h3 class="usa-heading">Single level</h3>
+  <h6 class="usa-heading-alt">Single level</h6>
   
   <div class="usa-grid">
     <aside class="usa-width-one-fourth">
@@ -25,7 +25,7 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: w
     </aside>
   </div>
 
-  <h3 class="usa-heading">Two levels</h3>
+  <h6 class="usa-heading-alt">Two levels</h6>
 
   <div class="usa-grid">
     <aside class="usa-width-one-fourth">
@@ -60,7 +60,7 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: w
     </aside>
   </div>
 
-  <h3 class="usa-heading">Three levels</h3>
+  <h6 class="usa-heading-alt">Three levels</h6>
 
   <div class="usa-grid">
     <aside class="usa-width-one-fourth">

--- a/_elements/buttons.md
+++ b/_elements/buttons.md
@@ -7,7 +7,7 @@ lead: Use buttons to signal actions.
 
 <div class="preview">
   
-  <h3 class="usa-heading">Primary Buttons</h3>
+  <h6>Primary Buttons</h6>
   <div class="button_wrapper">
     <button>Default</button>
     <button class="usa-button-active">Active</button>
@@ -19,7 +19,7 @@ lead: Use buttons to signal actions.
     <button class="usa-button-primary-alt usa-button-hover">Hover</button>
   </div>
 
-  <h3 class="usa-heading">Secondary Buttons</h3>
+  <h6>Secondary Buttons</h6>
   <div class="button_wrapper">
     <button class="usa-button-secondary">Default</button>
     <button class="usa-button-secondary usa-button-active">Active</button>
@@ -44,19 +44,19 @@ lead: Use buttons to signal actions.
     <button class="usa-button-outline-inverse usa-button-hover">Hover</button>
   </div>
 
-  <h3 class="usa-heading">Button Focus</h3>
+  <h6>Button Focus</h6>
   <div class="button_wrapper">
     <button class="usa-button-focus">Default</button>
     <button class="usa-button-primary-alt usa-button-focus">Default</button>
     <button class="usa-button-secondary usa-button-focus">Default</button>
   </div>
 
-  <h3 class="usa-heading">Disabled Button</h3>
+  <h6>Disabled Button</h6>
   <div class="button_wrapper">
     <button class="usa-button-disabled">Default</button>
   </div>
 
-  <h3 class="usa-heading">Big Button</h3>
+  <h6>Big Button</h6>
   <div class="button_wrapper">
     <button class="usa-button-big" type="button">Default</button>
   </div>

--- a/_elements/form-controls.md
+++ b/_elements/form-controls.md
@@ -81,7 +81,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
 
 <div class="preview">
 <form>
-  <label for="options">Dropdown Label h4</label>
+  <label for="options">Dropdown label</label>
   <select name="options" id="options">
     <option value="value1">Option A</option>
     <option value="value2">Option B</option>

--- a/_elements/form-controls.md
+++ b/_elements/form-controls.md
@@ -22,22 +22,22 @@ lead: Intro text on what is included in this section and how to use it. No more 
 <p class="usa-font-lead">Text inputs allow people to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted). Text input boxes can span single or multiple lines.</p>
 <div class="preview">
 
-  <label for="input-type-text">Text Input Label</label>
+  <label for="input-type-text">Text input label</label>
   <input id="input-type-text" name="input-type-text" type="text">
 
-  <label for="input-focus">Text Input Focused</label>
+  <label for="input-focus">Text input focused</label>
   <input class="usa-input-focus" id="input-focus" name="input-focus" type="text">
 
   <div class="usa-input-error">
-    <label class="usa-input-error-label" for="input-error">Text Input Error</label>
+    <label class="usa-input-error-label" for="input-error">Text input error</label>
     <span class="usa-input-error-message" id="input-error-message" role="alert">Helpful error message</span>
     <input id="input-error" name="input-error" type="text" aria-describedby="input-error-message">
   </div>
 
-  <label for="input-success">Text Input Success</label>
+  <label for="input-success">Text input success</label>
   <input class="usa-input-success" id="input-success" name="input-success" type="text">
 
-  <label for="input-type-textarea">Text Area Label</label>
+  <label for="input-type-textarea">Text area label</label>
   <textarea id="input-type-textarea" name="input-type-textarea"></textarea>
 
 </div>

--- a/_elements/labels.md
+++ b/_elements/labels.md
@@ -7,10 +7,10 @@ lead: Labels draw attention to new or important content.
 
 <div class="preview">
 
-  <h4>Small</h4>
+  <h6>Small</h6>
   <span class="usa-label">New</span>
 
-  <h4>Large</h4>
+  <h6>Large</h6>
   <span class="usa-label-big">New</span>
 
 </div>

--- a/_elements/tables.md
+++ b/_elements/tables.md
@@ -7,7 +7,7 @@ lead: Tables show tabular data in columns and rows.
 
 <div class="preview">
 
-  <h3 class="usa-heading">Bordered Table</h3>
+  <h6>Bordered Table</h6>
 
   <table>
     <thead>
@@ -51,7 +51,7 @@ lead: Tables show tabular data in columns and rows.
     </tbody>
   </table>
 
-  <h3 class="usa-heading">Borderless Table</h3>
+  <h6>Borderless Table</h6>
 
   <table class="usa-table-borderless">
     <thead>

--- a/_layout-system/grids.md
+++ b/_layout-system/grids.md
@@ -6,7 +6,7 @@ lead:  This 12 column responsive grid provides structure for website content.
 
 <div class="preview preview-no_border">
 
-  <h3 class="usa-heading">Grid</h3>
+  <h2 class="usa-heading">Grid</h2>
   <div class="usa-grid usa-grid-example usa-grid-example-blank">
     <div class="usa-width-one-whole">1/1</div>
   </div>
@@ -48,7 +48,7 @@ lead:  This 12 column responsive grid provides structure for website content.
     <div class="usa-width-one-twelfth">1/12</div>
   </div>
 
-  <h3 class="usa-heading">Grid Examples</h3>
+  <h2 class="usa-heading">Grid Examples</h2>
   <div class="usa-grid usa-grid-example usa-grid-text">
     <div class="usa-width-one-half">
       <h3>One Half</h3>

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -291,7 +291,7 @@ function toggleMultiPassword($el) {
   $el.on('click', function(ev) {
     ev.preventDefault();
     toggleFieldMask($fields, showing);
-    $el.text(showing ? 'Show My Typing' : 'Hide My Typing');
+    $el.text(showing ? 'Show my typing' : 'Hide my typing');
     showing = !showing;
   });
 }


### PR DESCRIPTION
Changed the example headings for various components to be h6s instead of h3s, which fixes #572, and updated some form labels to be sentence case, which fixes #570. 