### PR TITLE
Add link underline lists

### DIFF
--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -118,7 +118,8 @@ dfn {
 
 // Custom typography
 
-p, li {
+p, 
+.usa-content li {
   a {
     text-decoration: underline;
   }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -118,7 +118,7 @@ dfn {
 
 // Custom typography
 
-p {
+p, li {
   a {
     text-decoration: underline;
   }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -119,7 +119,7 @@ dfn {
 // Custom typography
 
 p, 
-.usa-content li {
+.usa-content-list {
   a {
     text-decoration: underline;
   }

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -37,7 +37,7 @@ lead: The U.S. Web Design Standards are designed to set a new bar for simplicity
   <li><strong>Images</strong> and icons are located in: <code>assets/img</code>.</li>
 </ol>
 
-<strong>For more information, visit: <a href="https://pages.18f.gov/frontend/css-coding-styleguide/">https://pages.18f.gov/frontend/css-coding-styleguide/</a></strong>
+<p><strong>For more information, visit: <br><a href="https://pages.18f.gov/frontend/css-coding-styleguide/">https://pages.18f.gov/frontend/css-coding-styleguide/</a></strong></p>
 
 <h3 class="usa-heading">For designers</h3>
 
@@ -50,7 +50,7 @@ lead: The U.S. Web Design Standards are designed to set a new bar for simplicity
 <h4>UI components and patterns</h4>
 <p>The site contains HTML mockups of common UI components designed to follow the Web Design Standards visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
 <p>All of these designs are also available in a variety of design file formats for download:</p>
-<ul>
+<ul class="usa-content-list">
   <li><strong>Illustrator, EPS, Sketch and Omnigraffle</strong> art files of each component and pattern on this site are available at: <a href="https://github.com/18F/web-design-standards-assets">github.com/18F/web-design-standards-assets</a></li>
   <li><strong>.AI and .ASE color swatches</strong> are available at:</strong> <a href="https://github.com/18F/web-design-standards-assets/tree/master/Colors">github.com/18F/web-design-standards-assets/tree/master/Colors</a></li>
   <li><strong>.TTF files</strong> of the font families and weights we recommend are available at: <a href="https://github.com/18F/web-design-standards-assets/">github.com/18F/web-design-standards-assets/</a> (Note: all fonts used in the Web Design Standards are free, open source typefaces also available online).</li>


### PR DESCRIPTION
This gives lists the underline style. It'll only effect links inside `usa-content-list` since non-text related lists should not have this style.

This resolves #563.