### PR TITLE
Change graphic list to use grid instead

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -107,27 +107,35 @@ title: U.S. Web Design Standards
     </div>
   </div>
   <div class="usa-grid">
-    <div class="usa-width-one-half usa-width-one-half-top">
-      <img class="usa-img-circle"  src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_best_easiest.png" alt="Make the best thing the easiest thing">
-      <h3 class="usa-graphic-list-heading">Make the best thing <br>the easiest thing</h3>
-      <p class="usa-graphic-list-text">The web design standards are designed to provide designers and developers easy-to-use tools to most effectively deliver the highest quality government websites to the American people.</p>
+    <div class="usa-width-one-sixth usa-width-one-half-top">
+      <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_best_easiest.png" alt="Make the best thing the easiest thing">
     </div>
-    <div class="usa-width-one-half usa-width-one-half-top">
-      <img class="usa-img-circle" src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_508_box.png" alt="Accessibility">
-      <h3 class="usa-graphic-list-heading">Accessibility out of the box</h3>
-      <p class="usa-graphic-list-text">These standards were built with a priority on 508 compliance and ADA accessibility at every step of the design process. From colors to code, everything you need to meet the highest standards of accessibility are baked into these tools.</p>
+    <div class="usa-width-one-third usa-width-one-half-top">
+      <h3>Make the best thing <br>the easiest thing</h3>
+      <p>The web design standards are designed to provide designers and developers easy-to-use tools to most effectively deliver the highest quality government websites to the American people.</p>
+    </div>
+    <div class="usa-width-one-sixth usa-width-one-half-top">
+      <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_508_box.png" alt="Accessibility">
+    </div>
+    <div class="usa-width-one-third usa-width-one-half-top">
+      <h3>Accessibility out of the box</h3>
+      <p>These standards were built with a priority on 508 compliance and ADA accessibility at every step of the design process. From colors to code, everything you need to meet the highest standards of accessibility are baked into these tools.</p>
     </div>
   </div>
   <div class="usa-grid">
-    <div class="usa-width-one-half">
-      <img class="usa-img-circle" src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_flexible.png" alt="Design for flexibility">
-      <h3 class="usa-graphic-list-heading">Design for flexibility</h3>
-      <p class="usa-graphic-list-text">These patterns and designs are made to easily adapt. They are guidelines which encourage consistency over uniformity, to give the American people a sense of familiarity and ease when navigating government services, while also allowing for customization of each agency’s unique flavors.</p>
+    <div class="usa-width-one-sixth usa-width-one-half-top">
+      <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_flexible.png" alt="Design for flexibility">
     </div>
-    <div class="usa-width-one-half">
-      <img class="usa-img-circle" src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_reuse.png" alt="Reuse">
-      <h3 class="usa-graphic-list-heading">Reuse reuse reuse.</h3>
-      <p class="usa-graphic-list-text">We reviewed, tested, evaluated and repurposed patterns, code and designs from dozens of government and private sector style guides to make use of tried-and-true best practices.</p>
+    <div class="usa-width-one-third usa-width-one-half-top">
+      <h3>Design for flexibility</h3>
+      <p>These patterns and designs are made to easily adapt. They are guidelines which encourage consistency over uniformity, to give the American people a sense of familiarity and ease when navigating government services, while also allowing for customization of each agency’s unique flavors.</p>
+    </div>
+    <div class="usa-width-one-sixth usa-width-one-half-top">
+      <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_reuse.png" alt="Reuse">
+    </div>
+    <div class="usa-width-one-third usa-width-one-half-top">
+      <h3>Reuse reuse reuse.</h3>
+      <p>We reviewed, tested, evaluated and repurposed patterns, code and designs from dozens of government and private sector style guides to make use of tried-and-true best practices.</p>
     </div> 
   </div>
   <div class="usa-grid usa-cta">


### PR DESCRIPTION
This updates the graphic list on the homepage to use our grid instead of the technique I was using. 

The problem is that the middle grid setting breaks this from looking usable cc @msecret 

This would resolve: #591

BIG :heavy_check_mark: :ok: 

![screen shot 2015-09-17 at 3 36 02 pm](https://cloud.githubusercontent.com/assets/5249443/9947795/db86d334-5d51-11e5-93a1-ab60c7a02cea.png)

MEDIUM: :x: :fire: 

![screen shot 2015-09-17 at 3 31 12 pm](https://cloud.githubusercontent.com/assets/5249443/9947797/db8a53a6-5d51-11e5-9faf-1e5d42e2e15d.png)

SMALL:  :heavy_check_mark: :ok: 
![screen shot 2015-09-17 at 3 36 10 pm](https://cloud.githubusercontent.com/assets/5249443/9947796/db89d0ac-5d51-11e5-8731-341ef4eae8de.png)