### PR TITLE
Fix home link color

### DIFF
--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -151,6 +151,13 @@ a:hover {
   border-bottom: 0;
 }
 
+a {
+  > h3,
+  &:visited  {
+    color: $color-primary;
+  }
+}
+
 .usa-img-circle {
   float: left;
   margin-right: 3rem;
@@ -177,13 +184,6 @@ a:hover {
 
   .usa-img-example {
     margin-bottom: 5rem;
-  }
-}
-
-a {
-  > h3,
-  &:visited  {
-    color: $color-primary;
   }
 }
 

--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -180,8 +180,11 @@ a:hover {
   }
 }
 
-a > h3 {
-  color: $color-primary;
+a {
+  > h3,
+  &:visited  {
+    color: $color-primary;
+  }
 }
 
 .usa-img-secondary {


### PR DESCRIPTION
This ensures that visited links on the homepage will always be blue.

This resolves #543.

This is what it looks like on hover:

![screen shot 2015-09-17 at 4 24 33 pm](https://cloud.githubusercontent.com/assets/5249443/9948510/9d847a8a-5d58-11e5-9ece-91f29da22aeb.png)
