### PR TITLE
Fix password reset submit button jumps when show/hide password is toggled

### DIFF
--- a/assets/_scss/components/_forms.scss
+++ b/assets/_scss/components/_forms.scss
@@ -18,7 +18,7 @@ form {
       }
       width: auto;
     }
-    clear: both;
+    display: block;
     margin-top: 2.5rem;
     margin-bottom: 1.5em;
   }


### PR DESCRIPTION
This adds `display: block` to submit button so that the submit button does not jump when show/hide password is toggled.

This resolves #484.