### PR TITLE
Add more space between GitHub link and page title on mobile

### DIFF
--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -70,6 +70,7 @@ p {
       padding-top: 4.5rem;
     }
     color: $color-white;
+    padding-top: 1.5rem;
   }
 
   .usa-text-small {

--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -65,12 +65,11 @@ p {
   }
 
   h1 {
-    color: $color-white;
-
     @include media($medium-screen) {
       font-size: 5.6rem;
       padding-top: 4.5rem;
     }
+    color: $color-white;
   }
 
   .usa-text-small {


### PR DESCRIPTION
Adds more space between GitHub link and page title on mobile.

Resolves #593.

This is what it looks like:

<img width="365" alt="screen shot 2015-09-18 at 8 17 17 am" src="https://cloud.githubusercontent.com/assets/5249443/9963036/d120bf4a-5ddd-11e5-9f93-e8e0d2420372.png">