### PR TITLE
Changing header button wording

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -20,12 +20,12 @@
       </div>
       <ul class="usa-button-list usa-unstyled-list">
         <li>
-          <a class="usa-button" href="#" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button inside site');">Download</a>
+          <a class="usa-button" href="#" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button inside site');">Download code</a>
         </li>
         <li>
           <a class="usa-button usa-button-outline" href="https://github.com/18F/usfwds/" onclick="ga('send', 'event', 'Viewed on Github', 'Clicked View on Github from inside site');"
 >
-            View on GitHub
+            View code on GitHub
           </a>
           </li>
       </ul>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -25,7 +25,7 @@
         <li>
           <a class="usa-button usa-button-outline" href="https://github.com/18F/usfwds/" onclick="ga('send', 'event', 'Viewed on Github', 'Clicked View on Github from inside site');"
 >
-            View code on GitHub
+            View on GitHub
           </a>
           </li>
       </ul>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -23,8 +23,7 @@
           <a class="usa-button" href="#" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button inside site');">Download code</a>
         </li>
         <li>
-          <a class="usa-button usa-button-outline" href="https://github.com/18F/usfwds/" onclick="ga('send', 'event', 'Viewed on Github', 'Clicked View on Github from inside site');"
->
+          <a class="usa-button usa-button-outline" href="https://github.com/18F/usfwds/" onclick="ga('send', 'event', 'Viewed on Github', 'Clicked View on Github from inside site');">
             View on GitHub
           </a>
           </li>


### PR DESCRIPTION
At @mollieru's request, changing the buttons in the heading to match the original design files:
- "Download" changed to "Download code"
- "View on GitHub" to "View code on GitHub"

Background: There are links to download various types of things throughout the site (palettes, fonts, design files, etc.) and it’s not clear what these “download” button leads to vs. the others. 

The original design files also include icons in those buttons. I'm not sure how we're handling icons within buttons (or icons, in general) and am certainly not qualified to make that decision. If someone has suggestions, I'm happy to revise the PR.