### PR TITLE
Fix focus state for UI Components and Visual Style Guide headers on homepage

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -46,21 +46,21 @@ title: U.S. Web Design Standards
   </div>
   <div class="usa-grid">
     <div class="usa-width-one-half">
-      <a href="{{ site.baseurl }}/getting-started">
-        <div class="usa-img-secondary">
-          <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_ui_components.png" alt="UI Components">
-        </div>
-        <h3>UI Components</h3>
-      </a>
+      <div class="usa-img-secondary">
+        <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_ui_components.png" alt="UI Components">
+      </div>
+      <h3>
+        <a href="{{ site.baseurl }}/getting-started">UI Components</a>
+      </h3>
       <p>Common web interactions (buttons, forms, navigation, etc.) with reusable and downloadable code</p>
     </div>
     <div class="usa-width-one-half">
-      <a href="{{ site.baseurl }}/visual-style/">
-        <div class="usa-img-secondary">
-          <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_visual_style_guide.png" alt="Visual Style Guide">
-        </div>
-        <h3>Visual Style Guide</h3>
-      </a>
+      <div class="usa-img-secondary">
+        <img src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_visual_style_guide.png" alt="Visual Style Guide">
+      </div>
+      <h3>
+        <a href="{{ site.baseurl }}/visual-style/">Visual Style Guide</a>
+      </h3>
       <p>508-compliant colors and typography designed to bring consistency to government web design</p>
     </div>
   </div>


### PR DESCRIPTION
This removes the anchor link wrapping around the images and around the heading, so focus states work now.

This resolves #526.

This is what it looks like:

<img width="498" alt="screen shot 2015-09-18 at 1 28 03 pm" src="https://cloud.githubusercontent.com/assets/5249443/9970333/635d1054-5e09-11e5-9bb5-7369ad40c50a.png">