### PR TITLE
Fix outline button focus state

### DIFF
--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -121,6 +121,10 @@ button,
       box-shadow: $button-stroke $color-primary-darkest;
       color: $color-primary-darkest;
     }
+
+    &:focus {
+      box-shadow: $button-stroke $color-primary-darkest, $focus-shadow;
+    }
   }
 
   &.usa-button-outline-inverse {
@@ -138,6 +142,10 @@ button,
     &.usa-button-active {
       box-shadow: $button-stroke $color-gray-light;
       color: $color-gray-lighter;
+    }
+
+    &:focus {
+      box-shadow: $button-stroke $color-gray-light, $focus-shadow;
     }
   }
 

--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -122,7 +122,8 @@ button,
       color: $color-primary-darkest;
     }
 
-    &:focus {
+    &:focus,
+    &.usa-button-focus {
       box-shadow: $button-stroke $color-primary-darkest, $focus-shadow;
     }
   }
@@ -144,7 +145,8 @@ button,
       color: $color-gray-lighter;
     }
 
-    &:focus {
+    &:focus,
+    &.usa-button-focus {
       box-shadow: $button-stroke $color-gray-light, $focus-shadow;
     }
   }

--- a/pages/index.html
+++ b/pages/index.html
@@ -29,7 +29,7 @@ title: U.S. Web Design Standards
       </div>
         <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage splash');">View the standards</a>
         <div class="usa-button-block">
-          <a class="usa-button usa-button-big usa-button-outline-inverse" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button on homepage');">Download the components</a>
+          <a class="usa-button usa-button-big usa-button-outline-inverse" href="javascript:void(0)" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button on homepage');">Download the components</a>
           <p class="usa-text-small">Download a zip file with code and assets</p>
         </div>
     </div>


### PR DESCRIPTION
This adds a focus state to outline and outline inverse button styles.

This fixes #525.

This is what it looks like:

<img width="354" alt="screen shot 2015-09-18 at 2 07 53 pm" src="https://cloud.githubusercontent.com/assets/5249443/9971166/b3dae970-5e0e-11e5-8de8-d635609ac52e.png">
