### PR TITLE
Add space to website preview boxes

### DIFF
--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -7,7 +7,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
 
 <div class="preview">
 
-  <h6 class="styleguide">Borderless</h6>
+  <h6 class="preview-first">Borderless</h6>
 
   <div class="usa-accordion">
     <ul class="usa-unstyled-list">

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -7,7 +7,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
 
 <div class="preview">
 
-  <h6>Borderless</h6>
+  <h6 class="styleguide">Borderless</h6>
 
   <div class="usa-accordion">
     <ul class="usa-unstyled-list">

--- a/docs/_components/alerts.md
+++ b/docs/_components/alerts.md
@@ -7,7 +7,7 @@ lead: Alerts keep users informed of important and sometimes time-sensitive chang
 
 <div class="preview">
 
-  <div class="usa-alert usa-alert-success styleguide">
+  <div class="usa-alert usa-alert-success preview-first">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Success Status</h3>
       <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>

--- a/docs/_components/alerts.md
+++ b/docs/_components/alerts.md
@@ -7,7 +7,7 @@ lead: Alerts keep users informed of important and sometimes time-sensitive chang
 
 <div class="preview">
 
-  <div class="usa-alert usa-alert-success">
+  <div class="usa-alert usa-alert-success styleguide">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Success Status</h3>
       <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>

--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -7,7 +7,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
 
 <div class="preview">
 
-  <h6 class="usa-heading-alt" id="big-footer">Big footer</h6>
+  <h6 class="usa-heading-alt styleguide" id="big-footer">Big footer</h6>
 
   <footer class="usa-footer usa-footer-big usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">

--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -78,7 +78,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form class="usa-form-large styleguide">
+  <form class="usa-form-large preview-first">
     <fieldset>
       <legend>Mailing address</legend>
       <label for="mailing-address-1">Street address 1</label>

--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -24,7 +24,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form class="styleguide">
+  <form class="preview-first">
     <fieldset>
       <legend>Name</legend>
       <label for="title">Title</label>
@@ -194,7 +194,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form class="styleguide">
+  <form class="preview-first">
     <fieldset>
       <legend class="usa-drop_text">Sign in</legend>
       <span>or <a href="#">create an account</a></span>
@@ -256,7 +256,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 <p class="usa-font-lead">A standard template for resetting a password</p>
 
 <div class="preview">  
-  <form class="styleguide">
+  <form class="preview-first">
     <fieldset>
       <legend class="usa-drop_text">Reset password</legend>
       <span class="usa-serif">Please enter your new password</span>

--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -24,7 +24,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form>
+  <form class="styleguide">
     <fieldset>
       <legend>Name</legend>
       <label for="title">Title</label>
@@ -78,7 +78,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form class="usa-form-large">
+  <form class="usa-form-large styleguide">
     <fieldset>
       <legend>Mailing address</legend>
       <label for="mailing-address-1">Street address 1</label>
@@ -194,7 +194,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form>
+  <form class="styleguide">
     <fieldset>
       <legend class="usa-drop_text">Sign in</legend>
       <span>or <a href="#">create an account</a></span>
@@ -255,9 +255,8 @@ lead: Patterns for some of the most commonly used forms on government websites
 <h2 class="usa-heading" id="password-reset-form">Password reset form</h2>
 <p class="usa-font-lead">A standard template for resetting a password</p>
 
-<div class="preview">
-
-  <form>
+<div class="preview">  
+  <form class="styleguide">
     <fieldset>
       <legend class="usa-drop_text">Reset password</legend>
       <span class="usa-serif">Please enter your new password</span>

--- a/docs/_components/search-bar.md
+++ b/docs/_components/search-bar.md
@@ -7,7 +7,7 @@ lead: A block that allows users to search for specific content if they know what
 
 <div class="preview preview-search-bar">
 
-  <h6>Search big</h6>
+  <h6 class="styleguide">Search big</h6>
 
   <div class="usa-grid">
     <div class="usa-width-one-half">

--- a/docs/_components/search-bar.md
+++ b/docs/_components/search-bar.md
@@ -7,7 +7,7 @@ lead: A block that allows users to search for specific content if they know what
 
 <div class="preview preview-search-bar">
 
-  <h6 class="styleguide">Search big</h6>
+  <h6 class="preview-first">Search big</h6>
 
   <div class="usa-grid">
     <div class="usa-width-one-half">

--- a/docs/_components/sidenav.md
+++ b/docs/_components/sidenav.md
@@ -7,7 +7,7 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: W
 
 <div class="preview">
   
-  <h6 class="usa-heading-alt styleguide">Single level</h6>
+  <h6 class="usa-heading-alt preview-first">Single level</h6>
   
   <div class="usa-grid">
     <aside class="usa-width-one-fourth">

--- a/docs/_components/sidenav.md
+++ b/docs/_components/sidenav.md
@@ -6,9 +6,9 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: W
 ---
 
 <div class="preview">
-
-  <h6 class="usa-heading-alt">Single level</h6>
-
+  
+  <h6 class="usa-heading-alt styleguide">Single level</h6>
+  
   <div class="usa-grid">
     <aside class="usa-width-one-fourth">
       <ul class="usa-sidenav-list">

--- a/docs/_elements/buttons.md
+++ b/docs/_elements/buttons.md
@@ -7,7 +7,7 @@ lead: Use buttons to signal actions.
 
 <div class="preview">
   
-  <h6 class="styleguide">Primary Buttons</h6>
+  <h6 class="preview-first">Primary Buttons</h6>
   <div class="button_wrapper">
     <button>Default</button>
     <button class="usa-button-active">Active</button>

--- a/docs/_elements/buttons.md
+++ b/docs/_elements/buttons.md
@@ -7,7 +7,7 @@ lead: Use buttons to signal actions.
 
 <div class="preview">
   
-  <h6>Primary Buttons</h6>
+  <h6 class="styleguide">Primary Buttons</h6>
   <div class="button_wrapper">
     <button>Default</button>
     <button class="usa-button-active">Active</button>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -129,7 +129,7 @@ lead: Form controls allow users to enter information into a page.
 
 <div class="preview">
 
-  <fieldset class="usa-fieldset-inputs usa-sans styleguide">
+  <fieldset class="usa-fieldset-inputs usa-sans preview-first">
 
     <legend class="usa-sr-only">Historical figures 1</legend>
 
@@ -198,7 +198,7 @@ lead: Form controls allow users to enter information into a page.
 
 <div class="preview">
 
-  <fieldset class="usa-fieldset-inputs usa-sans styleguide">
+  <fieldset class="usa-fieldset-inputs usa-sans preview-first">
 
     <legend class="usa-sr-only">Historical figures 2</legend>
 

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -22,7 +22,7 @@ lead: Form controls allow users to enter information into a page.
 <p class="usa-font-lead">Text inputs allow people to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted). Text input boxes can span single or multiple lines.</p>
 <div class="preview">
 
-  <label class="styleguide" for="input-type-text">Text input label</label>
+  <label class="preview-first" for="input-type-text">Text input label</label>
   <input id="input-type-text" name="input-type-text" type="text">
 
   <label for="input-focus">Text input focused</label>
@@ -262,7 +262,7 @@ lead: Form controls allow users to enter information into a page.
 
 <div class="preview">
 
-  <fieldset class="styleguide">
+  <fieldset class="preview-first">
     <legend>Date of birth</legend>
     <span class="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
 

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -22,7 +22,7 @@ lead: Form controls allow users to enter information into a page.
 <p class="usa-font-lead">Text inputs allow people to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted). Text input boxes can span single or multiple lines.</p>
 <div class="preview">
 
-  <label for="input-type-text">Text input label</label>
+  <label class="styleguide" for="input-type-text">Text input label</label>
   <input id="input-type-text" name="input-type-text" type="text">
 
   <label for="input-focus">Text input focused</label>
@@ -129,7 +129,7 @@ lead: Form controls allow users to enter information into a page.
 
 <div class="preview">
 
-  <fieldset class="usa-fieldset-inputs usa-sans">
+  <fieldset class="usa-fieldset-inputs usa-sans styleguide">
 
     <legend class="usa-sr-only">Historical figures 1</legend>
 
@@ -198,7 +198,7 @@ lead: Form controls allow users to enter information into a page.
 
 <div class="preview">
 
-  <fieldset class="usa-fieldset-inputs usa-sans">
+  <fieldset class="usa-fieldset-inputs usa-sans styleguide">
 
     <legend class="usa-sr-only">Historical figures 2</legend>
 
@@ -262,7 +262,7 @@ lead: Form controls allow users to enter information into a page.
 
 <div class="preview">
 
-  <fieldset>
+  <fieldset class="styleguide">
     <legend>Date of birth</legend>
     <span class="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
 

--- a/docs/_elements/labels.md
+++ b/docs/_elements/labels.md
@@ -7,7 +7,7 @@ lead: Labels draw attention to new or important content.
 
 <div class="preview">
 
-  <h6 class="styleguide">Small</h6>
+  <h6 class="preview-first">Small</h6>
   <span class="usa-label">New</span>
 
   <h6>Large</h6>

--- a/docs/_elements/labels.md
+++ b/docs/_elements/labels.md
@@ -7,7 +7,7 @@ lead: Labels draw attention to new or important content.
 
 <div class="preview">
 
-  <h6>Small</h6>
+  <h6 class="styleguide">Small</h6>
   <span class="usa-label">New</span>
 
   <h6>Large</h6>

--- a/docs/_elements/tables.md
+++ b/docs/_elements/tables.md
@@ -7,7 +7,7 @@ lead: Tables show tabular data in columns and rows.
 
 <div class="preview">
 
-  <h6>Bordered Table</h6>
+  <h6 class="styleguide">Bordered Table</h6>
 
   <table>
     <thead>

--- a/docs/_elements/tables.md
+++ b/docs/_elements/tables.md
@@ -7,7 +7,7 @@ lead: Tables show tabular data in columns and rows.
 
 <div class="preview">
 
-  <h6 class="styleguide">Bordered Table</h6>
+  <h6 class="preview-first">Bordered Table</h6>
 
   <table>
     <thead>

--- a/docs/_visual/typography.md
+++ b/docs/_visual/typography.md
@@ -990,7 +990,7 @@ order: 01
   <div class="usa-grid">
     <div class="usa-width-one-third">
 
-      <h6 class="usa-heading-alt styleguide">Unordered list</h6>
+      <h6 class="usa-heading-alt preview-first">Unordered list</h6>
 
       <ul>
         <li>Unordered list item</li>

--- a/docs/_visual/typography.md
+++ b/docs/_visual/typography.md
@@ -949,8 +949,8 @@ order: 01
 
 <div class="preview">
 
-  <a href="#">This is a link without surrounding text.</a>
-  <p><a href="#">This</a> is a text link on a light background.</p>
+  <a class="styleguide" href="#">This is a link without surrounding text</a>
+  <p><a href="#">This</a> is a text link on light background</p>
 
   <p><a class="usa-color-text-visited" href="#">This</a> is a visited link.</p>
 
@@ -990,7 +990,7 @@ order: 01
   <div class="usa-grid">
     <div class="usa-width-one-third">
 
-      <h6 class="usa-heading-alt">Unordered list</h6>
+      <h6 class="usa-heading-alt styleguide">Unordered list</h6>
 
       <ul>
         <li>Unordered list item</li>

--- a/docs/_visual/typography.md
+++ b/docs/_visual/typography.md
@@ -949,7 +949,7 @@ order: 01
 
 <div class="preview">
 
-  <a class="styleguide" href="#">This is a link without surrounding text</a>
+  <a class="preview-first" href="#">This is a link without surrounding text</a>
   <p><a href="#">This</a> is a text link on light background</p>
 
   <p><a class="usa-color-text-visited" href="#">This</a> is a visited link.</p>

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -332,6 +332,7 @@ $site-top:           124px;
       right: 1em;
     }
   }
+
   .preview-first {
     margin-top: 3rem;
     display: block;

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -276,7 +276,7 @@ $site-top:           124px;
     > h1 {
       margin-top: 3.4rem;
     }
-    
+
     padding: {
       left: 3em;
       right: 3em;
@@ -318,11 +318,22 @@ $site-top:           124px;
     top: 2em;
     bottom: 2em;
   }
-  padding: 1em $site-margins;
-  border: 1px solid #eeeeee;
+  padding: $site-margins;
+  border: 1px solid $color-gray-warm-light;
   .is-peripheral {
     opacity: .2;
   }
+
+  .usa-background-dark {
+    display: inline-block;
+    padding: {
+      left: 1em;
+      right: 1em;
+    }
+  h6:first-child {
+    margin-top: 0;
+  }
+>>>>>>> Removed top margin of first h6 in preview box to have more consistent spacing:src/stylesheets/css/styleguide.scss
 }
 
 .preview-no_border {

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -333,6 +333,7 @@ $site-top:           124px;
     }
   }
   .preview-first {
+
     margin-top: 3rem;
     display: block;
   }

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -332,7 +332,6 @@ $site-top:           124px;
       right: 1em;
     }
   }
-
   .preview-first {
     margin-top: 3rem;
     display: block;

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -333,7 +333,6 @@ $site-top:           124px;
     }
   }
   .preview-first {
-
     margin-top: 3rem;
     display: block;
   }
@@ -849,8 +848,11 @@ h3 + .button_wrapper {
   padding-bottom: .8rem;
 }
 
+<<<<<<< 9bfe7b8204ce27b9276eab89aa9e7e7ab97bdd63:docs/assets/css/styleguide.scss
 
 // scss-lint:disable QualifyingElement
+=======
+>>>>>>> Added at styleguide class to solve styleguide only space issues:src/stylesheets/css/styleguide.scss
 h6, h6.usa-heading-alt {
   margin-top: 4rem;
 }

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -313,15 +313,16 @@ $site-top:           124px;
 
 .preview {
   @include clearfix();
-  background-color: #fff;
+  background-color: $color-white;
   margin: {
-    top: 2em;
     bottom: 2em;
+    top: 2em;
   }
-  padding: $site-margins;
+  padding: 0 $site-margins $site-margins;
   border: 1px solid $color-gray-warm-light;
-  .is-peripheral {
-    opacity: .2;
+
+  .is-peripheral { 
+    opacity: .2; 
   }
 
   .usa-background-dark {
@@ -330,17 +331,18 @@ $site-top:           124px;
       left: 1em;
       right: 1em;
     }
-  h6:first-child {
-    margin-top: 0;
   }
->>>>>>> Removed top margin of first h6 in preview box to have more consistent spacing:src/stylesheets/css/styleguide.scss
+  .preview-first {
+    margin-top: 3rem;
+    display: block;
+  }
 }
 
 .preview-no_border {
   border: 0;
   margin: {
-    top: 0;
     bottom: 2em;
+    top: 0;
   }
   padding: 0;
 }
@@ -846,7 +848,9 @@ h3 + .button_wrapper {
   padding-bottom: .8rem;
 }
 
-h6.usa-heading-alt {
+
+// scss-lint:disable QualifyingElement
+h6, h6.usa-heading-alt {
   margin-top: 4rem;
 }
 

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -848,11 +848,8 @@ h3 + .button_wrapper {
   padding-bottom: .8rem;
 }
 
-<<<<<<< 9bfe7b8204ce27b9276eab89aa9e7e7ab97bdd63:docs/assets/css/styleguide.scss
 
 // scss-lint:disable QualifyingElement
-=======
->>>>>>> Added at styleguide class to solve styleguide only space issues:src/stylesheets/css/styleguide.scss
 h6, h6.usa-heading-alt {
   margin-top: 4rem;
 }

--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -267,12 +267,16 @@ $site-top:           124px;
   position: relative;
 
   > h1 {
-    margin-top: 3.4rem;
+    margin-top: 5.4rem;
     &:not(:first-child) {
       margin-top: 1.5em;
     }
   }
   @media (min-width: $medium-screen + $width-nav-sidebar) {
+    > h1 {
+      margin-top: 3.4rem;
+    }
+    
     padding: {
       left: 3em;
       right: 3em;

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -38,7 +38,7 @@ h1, h2, h3, h4, h5, h6 {
   font-family: $font-serif;
   line-height: $heading-line-height;
   margin-bottom: .5em;
-  margin-top: 1.5em;
+  margin-top: 2.3em;
 }
 
 // Create heading mixins 


### PR DESCRIPTION
Updated spacing to be a little more consistent for the preview boxes to address this #564.

An example:
![image](https://cloud.githubusercontent.com/assets/103496/9973349/4d4e1160-5e26-11e5-9f2d-83d7e8ffb1ba.png)

Resolves: #564.