### PR TITLE
Override default `baseurl:` with /designstandards

### DIFF
--- a/_config_18f_pages.yml
+++ b/_config_18f_pages.yml
@@ -1,0 +1,1 @@
+baseurl: /designstandards


### PR DESCRIPTION
Supersedes #643 by merging into `18f-pages-staging` rather than `18f-pages`. That means that the new staging URL will be https://pages-staging.18f.gov/designstandards/, and once `18f-pages-staging` is merged into `18f-pages`, the 18F Pages URL will be https://pages.18f.gov/designstandards/.

cc: @maya @mollieru 