### PR TITLE
Override default `baseurl:` with /designstandards

### DIFF
--- a/_config_18f_pages.yml
+++ b/_config_18f_pages.yml
@@ -1,0 +1,1 @@
+baseurl: /designstandards


### PR DESCRIPTION
Now that 18F/pages#39 is deployed, this should finally work as advertised. See also #671 and #672.

cc: @maya @mollieru 