### PR TITLE
Add blog post URL to Getting Started page

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -5,7 +5,7 @@ title: Getting started
 lead: The U.S. Web Design Standards are designed to set a new bar for simplicity and consistency across government services, while providing you with plug-and-play design and code.
 ---
 
-<p>Learn more about why designing consistent digital services matters in our <a href="https://18f.gsa.gov/blog/">blog post introducing the standards</a>.</p>
+<p>Learn more about why designing consistent digital services matters in our <a href="https://18f.gsa.gov/2015/09/28/web-design-standards/">blog post introducing the standards</a>.</p>
 
 <h3 class="usa-heading">For developers</h3>
 


### PR DESCRIPTION
This adds the blog post URL https://18f.gsa.gov/2015/09/28/web-design-standards/ to the getting started page.