### PR TITLE
Fix radio buttons and checkboxes in IE8

### DIFF
--- a/assets/_scss/elements/_inputs.scss
+++ b/assets/_scss/elements/_inputs.scss
@@ -126,6 +126,14 @@ legend {
 input[type="checkbox"],
 input[type="radio"] {
   @include sr-only();
+
+  .lt-ie9 & {
+    border: 0;
+    float: left;
+    margin: .4em .4em 0 0;
+    position: static;
+    width: auto;
+  }
 }
 
 input[type="checkbox"] + label,


### PR DESCRIPTION
In IE8 no checkboxes or radio buttons are visible. This patch overrides the styles and shows the native ones again. They don’t look quite so snazzy, but at least IE8 users can access services that use them.

![screen shot 2015-09-23 at 16 30 18](https://cloud.githubusercontent.com/assets/7414/10049784/f7acec9c-6210-11e5-83f8-e8dd83a6b07f.png)
![screen shot 2015-09-23 at 16 30 47](https://cloud.githubusercontent.com/assets/7414/10049783/f7ac00e8-6210-11e5-99c8-cef5fc5fe9a9.png)
