### PR TITLE
Add implementation docs (revert the revert)

### DIFF
--- a/_elements/buttons.md
+++ b/_elements/buttons.md
@@ -69,13 +69,26 @@ lead: Use buttons to signal actions.
     Documentation
   </button>
   <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
-    <h4 class="usa-heading">Accessibility</h4>
+    <h4 class="usa-heading">Implementation</h4>
+    <p>The examples demonstrate how to use button elements. To use a button style on an anchor link, add the <code>usa-button</code> class to your anchor link. 
+    <p>To use a different style button on your anchor link, add the special button class in addition to <code>usa-button</code>:</p>
     <ul>
+      <li><code>usa-button-primary-alt</code></li>
+      <li><code>usa-button-secondary</code></li>
+      <li><code>usa-button-gray</code></li>
+      <li><code>usa-button-outline</code></li>
+      <li><code>usa-button-outline-inverse</code></li>
+      <li><code>usa-button-disabled</code></li>
+      <li><code>usa-button-big</code></li>
+    </ul>
+    <p>For example, a secondary button style would use the following code:
+    <code>&lt;a class="usa-button usa-button-secondary" href="/my-link"&gt;My button&lt;/a&gt;</code></p>
+    <h4 class="usa-heading">Accessibility</h4>
+    <ul class="usa-content-list">
       <li>Buttons should display a visible focus state when users tab to them.</li>
       <li>Avoid using <code>&lt;div&gt;</code> or <code>&lt;img&gt;</code> tags to create buttons. Screen readers don't automatically know either is an usable button.</li>
       <li>When styling links to look like buttons, remember that screen readers handle links slightly differently than they do buttons. Pressing the Space key triggers a button, but pressing the Enter key triggers a link.</li>
     </ul>
-
     <h4 class="usa-heading">Usability</h4>
     <h5>When to use</h5>
     <ul class="usa-content-list">

--- a/_layout-system/grids.md
+++ b/_layout-system/grids.md
@@ -124,6 +124,11 @@ lead:  This 12 column responsive grid provides structure for website content.
     Documentation
   </button>
   <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+    <h4 class="usa-heading">Implementation</h4>
+    <p>To use the grid, wrap each grid row in a <code>&lt;div&gt;</code> with the <code>usa-grid</code> class. To use a grid without padding on the right and left, use the <code>usa-grid-full</code> class instead.</p>
+    <p>Each grid item is written semantically by its width. For example: <code>usa-width-one-half</code> = 1/2 grid item, <code>usa-width-two-thirds</code> = 2/3 grid item.</p>
+    <p>Medium breakpoints are used for 1/6 and 1/12 grid items, which both transform into a 1/3 grid item at medium screen sizes.</p> 
+    <p>All grid items are full-width at small screen sizes.</p>
     <h4 class="usa-heading">Accessibility</h3>
     <ul class="usa-content-list">
       <li>Low vision users should be able to increase the size of the text by up to 200 percent without breaking the layout.</li>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -907,6 +907,10 @@ order: 01
     Documentation
   </button>
   <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+    <h4 class="usa-heading">Implementation</h4>
+    <p>To get the max-width on body text, add the class <code>usa-content</code> to your document. Use at the specificity that best suits to your project's needs.</p>
+    <p>Lists must use <code>usa-content-list</code> for the above.</p>
+    <p>You can change the max-width value <code>$text-max-width</code> in <code>assets/_scss/core/variables.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>
     <ul class="usa-content-list">
       <li>Alignment: Type set flush left provides the eye a constant starting point for each line, making text easier to read.</li>
@@ -998,11 +1002,13 @@ order: 01
     Documentation
   </button>
   <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <h4 class="usa-heading">Implementation</h4>
+  <p>Lists are styled by default. For unstyled lists, use either the <code>usa-unstyled-list</code> class or unstyled list mixin: <code>@include unstyled-list;</code>. Both are located in <code>assets/_scss/core/utilities.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>
     <h5>When to use</h5>
     <ul class="usa-content-list">
-        <li>Use an ordered list when you need to display text in some ranking, hierarchy or series of steps.</li>
-        <li>Use unordered lists display text in no specific order.</li>
+      <li>Use an ordered list when you need to display text in some ranking, hierarchy or series of steps.</li>
+      <li>Use unordered lists display text in no specific order.</li>
     </ul>
     <h5>When to consider something different</h5>
     <ul class="usa-content-list">

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -908,7 +908,7 @@ order: 01
   </button>
   <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Implementation</h4>
-    <p>To get the max-width on body text, add the class <code>usa-content</code> to your document. Use at the specificity that best suits to your project's needs.</p>
+    <p>To get the max-width on body text, add the class <code>usa-content</code> to your document. Use at the specificity that best suits your project's needs.</p>
     <p>Lists must use <code>usa-content-list</code> for the above.</p>
     <p>You can change the max-width value <code>$text-max-width</code> in <code>assets/_scss/core/<wbr>variables.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -910,7 +910,7 @@ order: 01
     <h4 class="usa-heading">Implementation</h4>
     <p>To get the max-width on body text, add the class <code>usa-content</code> to your document. Use at the specificity that best suits to your project's needs.</p>
     <p>Lists must use <code>usa-content-list</code> for the above.</p>
-    <p>You can change the max-width value <code>$text-max-width</code> in <code>assets/_scss/core/variables.scss</code>.</p>
+    <p>You can change the max-width value <code>$text-max-width</code> in <code>assets/_scss/core/<wbr>variables.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>
     <ul class="usa-content-list">
       <li>Alignment: Type set flush left provides the eye a constant starting point for each line, making text easier to read.</li>
@@ -1003,7 +1003,7 @@ order: 01
   </button>
   <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
   <h4 class="usa-heading">Implementation</h4>
-  <p>Lists are styled by default. For unstyled lists, use either the <code>usa-unstyled-list</code> class or unstyled list mixin: <code>@include unstyled-list;</code>. Both are located in <code>assets/_scss/core/utilities.scss</code>.</p>
+  <p>Lists are styled by default. For unstyled lists, use either the <code>usa-unstyled-list</code> class or unstyled list mixin: <code>@include unstyled-list;</code>. Both are located in <code>assets/_scss/core/<wbr>utilities.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>
     <h5>When to use</h5>
     <ul class="usa-content-list">

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -33,7 +33,7 @@ lead: The U.S. Web Design Standards are designed to set a new bar for simplicity
 
 <ol class="usa-content-list">
   <li><strong>HTML</strong> markup for the components are located in: <code>_visual, _layout-system,  _elements, _components</code> in the site root.</li>
-  <li><strong>Sass</strong> styles are located in: <code>assets/_scss (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is located in: <code>_site/assets/css/styleguide.css</code>.</li>
+  <li><strong>Sass</strong> styles are located in: <code>assets/_scss (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is located in: <code>_site/assets/css/<wbr>styleguide.css</code>.</li>
   <li><strong>JS</strong> is located in: <code>assets/_js/components.js</code>.</li>
   <li><strong>Fonts</strong> are located in: <code>assets/fonts</code>.</li>
   <li><strong>Images</strong> and icons are located in: <code>assets/img</code>.</li>

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -33,7 +33,7 @@ lead: The U.S. Web Design Standards are designed to set a new bar for simplicity
 
 <ol class="usa-content-list">
   <li><strong>HTML</strong> markup for the components are located in: <code>_visual, _layout-system,  _elements, _components</code> in the site root.</li>
-  <li><strong>Sass</strong> styles are located in: <code>assets/_scss (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is found in: <code>_site/assets/css/styleguide.css</code>.</li>
+  <li><strong>Sass</strong> styles are located in: <code>assets/_scss (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is located in: <code>_site/assets/css/styleguide.css</code>.</li>
   <li><strong>JS</strong> is located in: <code>assets/_js/components.js</code>.</li>
   <li><strong>Fonts</strong> are located in: <code>assets/fonts</code>.</li>
   <li><strong>Images</strong> and icons are located in: <code>assets/img</code>.</li>


### PR DESCRIPTION
This re-adds implementation docs for max-width text, lists, buttons, and grids.

Original PR: #673.

This reverts commit d63bb18d588e5578834f332d587a21a649c02189, reversing
changes made to d3254536359678cca06c58f4841f9378f4bf4fa7.

This also adds in `<wbr>` tags so the pages display correctly (tested changes on iPhone 5 & 6).