### PR TITLE
Update footer colors to use our variables

### DIFF
--- a/assets/_scss/components/_disclaimer.scss
+++ b/assets/_scss/components/_disclaimer.scss
@@ -2,7 +2,7 @@
   @include media($small-screen) {
     font-size: $h5-font-size;
   }
-  background-color: $color-gray-lighter;
+  background-color: $color-gray-lightest;
   font-size: $h6-font-size;
   padding: {
     bottom: .5rem;

--- a/assets/_scss/components/_footer.scss
+++ b/assets/_scss/components/_footer.scss
@@ -159,7 +159,7 @@ li.usa-footer-primary-content {
 }
 
 .usa-footer-secondary_section {
-  background-color: #e0e0e0;
+  background-color: $color-gray-lighter;
   padding: {
     top: 3rem;
     bottom: 3rem;

--- a/assets/_scss/components/_footer.scss
+++ b/assets/_scss/components/_footer.scss
@@ -115,10 +115,10 @@
 ul.usa-footer-primary-content,
 li.usa-footer-primary-content,
 li.usa-footer-primary-content {
-  border-top: 1px solid #000;      
+  border-top: 1px solid $color-base;      
 
   &:last-child {
-    border-bottom: 1px solid #000;
+    border-bottom: 1px solid $color-base;
     @include media($medium-screen) {
       border-bottom: none;
     }
@@ -196,7 +196,7 @@ li.usa-footer-primary-content {
     padding-bottom: 2.5rem;
 
     &:last-child {
-      border-bottom: 1px solid #000;
+      border-bottom: 1px solid $color-base;
 
       @include media($medium-screen) {
         border-bottom: none;

--- a/assets/_scss/components/_footer.scss
+++ b/assets/_scss/components/_footer.scss
@@ -164,6 +164,10 @@ li.usa-footer-primary-content {
     top: 3rem;
     bottom: 3rem;
   }
+
+  a {
+    color: $color-base;
+  }
 }
 
 .usa-footer-big-secondary-section {

--- a/assets/_scss/core/_defaults.scss
+++ b/assets/_scss/core/_defaults.scss
@@ -49,7 +49,7 @@ $color-gray-dark:            #323a45 !default;
 $color-gray:                 #205493 !default; // lighten($color-gray-dark, 20%)
 $color-gray-light:           #aeb0b5 !default; // lighten($color-gray-dark, 60%)
 $color-gray-lighter:         #d6d7d9 !default; // lighten($color-gray-dark, 80%)
-$color-gray-lightest:        #efefef !default; // lighten($color-gray-dark, 90%)
+$color-gray-lightest:        #f1f1f1 !default; // lighten($color-gray-dark, 91%)
 
 $color-gray-warm-dark:       #494440 !default;
 $color-gray-warm-light:      #e4e2e0 !default; // lighten($color-gray-warm-dark, 90%)

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -45,7 +45,7 @@ $color-gray-dark:            #323a45;
 $color-gray:                 #5b616b; // lighten($color-gray-dark, 20%)
 $color-gray-light:           #aeb0b5; // lighten($color-gray-dark, 60%)
 $color-gray-lighter:         #d6d7d9; // lighten($color-gray-dark, 80%)
-$color-gray-lightest:        #efefef; // lighten($color-gray-dark, 90%)
+$color-gray-lightest:        #f1f1f1; // lighten($color-gray-dark, 91%)
 
 $color-gray-warm-dark:       #494440;
 $color-gray-warm-light:      #e4e2e0; // lighten($color-gray-warm-dark, 90%)


### PR DESCRIPTION
This makes a few updates to the footer:

- This updates the footer colors to use our color variables rather than hex codes. 
- This resolves color contrast issue with links on the footer and its background color.
- This uses a base/black link against the darker gray background.
- This lightens our `$color-gray-lightest` variable by 1% so that default blue links will pass color contrast requirements on this background.