### PR TITLE
Ensure :focus shadow on sidenav is above :hover fill

### DIFF
--- a/assets/_scss/components/_sidenav.scss
+++ b/assets/_scss/components/_sidenav.scss
@@ -29,6 +29,11 @@
       text-decoration: none;
     }
 
+    &:focus {
+      position: relative;
+      z-index: 1;
+    }
+
     &.usa-current {
       color: $color-primary;
       font-weight: $font-bold;


### PR DESCRIPTION
Its a really minor thing, but it bothers me that the hover `background-color` in the sidebar overlaps the `box-shadow` of the previous `:focus`-ed element:

![screenshot 2015-09-28 16 13 20](https://cloud.githubusercontent.com/assets/1839748/10151510/23391eb8-65fd-11e5-96d9-8e29c5eff6bc.png)

This little change ensures that the `box-shadow` is always above the hovered elements:

![screenshot 2015-09-28 16 15 01](https://cloud.githubusercontent.com/assets/1839748/10151520/3d5452b8-65fd-11e5-9657-021ff5b80210.png)

Great work! So excited to see this. Looking forward to dive in when I have more time.
