### PR TITLE
Update `./go` script to use `go_script` gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.0
+  - 2.2.3
 
 script: ./go build
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 
-gem 'rouge'
+gem 'rouge', '1.9'
 gem 'redcarpet'
 
 gem 'go_script'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gem 'jekyll'
 
 gem 'rouge'
 gem 'redcarpet'
+
+gem 'go_script'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.2)
-    rouge (1.9.1)
+    rouge (1.9.0)
     safe_yaml (1.0.4)
     sass (3.4.16)
     timers (4.0.1)
@@ -74,7 +74,7 @@ DEPENDENCIES
   go_script
   jekyll
   redcarpet
-  rouge
+  rouge (= 1.9)
 
 BUNDLED WITH
    1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
     execjs (2.6.0)
     fast-stemmer (1.0.2)
     ffi (1.9.10)
+    go_script (0.1.5)
+      bundler (~> 1.10)
+      safe_yaml (~> 1.0)
     hitimes (1.2.2)
     jekyll (2.5.3)
       classifier-reborn (~> 2.0)
@@ -68,6 +71,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  go_script
   jekyll
   redcarpet
   rouge
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ following [go script](https://github.com/18F/go_script) commands to initialize a
 ```shell
 $ git clone git@github.com:18F/web-design-standards.git
 $ cd web-design-standards
-$ ./go init
 $ ./go serve
 ```
 

--- a/go
+++ b/go
@@ -1,141 +1,44 @@
 #! /usr/bin/env ruby
-#
-# 18F Guides Jekyll template
-#
-# Written in 2015 by Mike Bland (michael.bland@gsa.gov)
-# on behalf of the 18F team, part of the US General Services Administration:
-# https://18f.gsa.gov/
-#
-# To the extent possible under law, the author(s) have dedicated all copyright
-# and related and neighboring rights to this software to the public domain
-# worldwide. This software is distributed without any warranty.
-#
-# You should have received a copy of the CC0 Public Domain Dedication along
-# with this software. If not, see
-# <https://creativecommons.org/publicdomain/zero/1.0/>.
-#
-# @author Mike Bland (michael.bland@gsa.gov)
-#
-# ----
-#
-# ./go script: unified development environment interface
-#
-# Inspired by:
-# http://www.thoughtworks.com/insights/blog/praise-go-script-part-i
-# http://www.thoughtworks.com/insights/blog/praise-go-script-part-ii
-#
-# Author: Mike Bland (michael.bland@gsa.gov)
-# Date:   2015-04-15
 
-MIN_VERSION = "2.1.5"
+require 'English'
 
-unless RUBY_VERSION >= MIN_VERSION
-  puts <<EOF
+Dir.chdir File.dirname(__FILE__)
 
-*** ABORTING: Unsupported Ruby version ***
-
-Ruby version #{MIN_VERSION} or greater is required to work with the Hub, but
-this Ruby is version #{RUBY_VERSION}. Consider using a version manager such as
-rbenv (https://github.com/sstephenson/rbenv) or rvm (https://rvm.io/)
-to install a Ruby version specifically for Hub development.
-
-EOF
-  exit 1
+def try_command_and_restart(command)
+  exit $CHILD_STATUS.exitstatus unless system command
+  exec RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV)
 end
 
-def exec_cmd(cmd)
-  exit $?.exitstatus unless system(cmd)
+begin
+  require 'bundler/setup' if File.exist? 'Gemfile'
+rescue LoadError
+  try_command_and_restart 'gem install bundler'
+rescue SystemExit
+  try_command_and_restart 'bundle install'
 end
 
-def init
-  begin
-    require 'bundler'
-  rescue LoadError
-    puts "Installing Bundler gem..."
-    exec_cmd 'gem install bundler'
-    puts "Bundler installed; installing gems"
-  end
-  exec_cmd 'bundle install'
+begin
+  require 'go_script'
+rescue LoadError
+  try_command_and_restart 'gem install go_script' unless File.exist? 'Gemfile'
+  abort "Please add \"gem 'go_script'\" to your Gemfile"
 end
 
-def update_gems
-  exec_cmd 'bundle update'
-  exec_cmd 'git add Gemfile.lock'
+extend GoScript
+check_ruby_version '2.2.3'
+
+command_group :dev, 'Development commands'
+
+def_command :update_gems, 'Update Ruby gems' do |gems|
+  update_gems gems
 end
 
-JEKYLL_BUILD_CMD = "exec jekyll build --trace"
-JEKYLL_SERVE_CMD = "exec jekyll serve --trace"
-
-def serve
-  exec "bundle #{JEKYLL_SERVE_CMD}"
+def_command :serve, 'Serve the site at localhost:4000' do |args|
+  serve_jekyll args
 end
 
-def build
-  exec_cmd "bundle #{JEKYLL_BUILD_CMD}"
+def_command :build, 'Build the site' do |args|
+  build_jekyll args
 end
 
-# Groups a set of commands by common function.
-class CommandGroup
-  attr_accessor :description, :commands
-  private_class_method :new
-  @@groups = Array.new
-
-  # @param description [String] short description of the group
-  # @param commands [Hash<Symbol,String>] mapping from command function name
-  #   to a brief description; each key must be the name of a function in this
-  #   script
-  def initialize(description, commands)
-    @description = description
-    @commands = commands
-  end
-
-  def to_s
-    padding = @commands.keys.max_by {|i| i.size}.size + 2
-    ["\n#{@description}"].concat(
-      @commands.map {|name, desc| "  %-#{padding}s#{desc}" % name}).join("\n")
-  end
-
-  def self.add_group(description, commands)
-    @@groups << new(description, commands)
-  end
-
-  def self.groups
-    @@groups
-  end
-
-  def self.check_command_exists(command_symbol)
-    all_commands = @@groups.map {|i| i.commands.keys}.flatten
-    unless all_commands.member? command_symbol
-      puts "Unknown option or command: #{command_symbol}"
-      usage(exitstatus: 1)
-    end
-  end
-end
-
-CommandGroup.add_group(
-  'Development commands',
-  {
-    :init => 'Set up the dev environment',
-    :update_gems => 'Execute Bundler to update gem set',
-    :serve => 'Serves the site at localhost:4000',
-    :build => 'Builds the site',
-  })
-
-def usage(exitstatus: 0)
-  puts <<EOF
-Usage: #{$0} [options] [command]
-
-options:
-  -h,--help  Show this help
-EOF
-  CommandGroup.groups.each {|s| puts s}
-  exit exitstatus
-end
-
-usage(exitstatus: 1) unless ARGV.size == 1
-command = ARGV.shift
-usage if ['-h', '--help'].include? command
-
-command = command.to_sym
-CommandGroup.check_command_exists command
-send command
+execute_command ARGV


### PR DESCRIPTION
This also eliminates the `./go init` command, as it's no longer needed.

Makes good on my promise from #744. Also related: #748.

cc: @maya @liquiddandruff @dyanarose