### PR TITLE
Removes 'omnigraffle' mention

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -55,7 +55,7 @@ lead: The U.S. Web Design Standards are designed to set a new bar for simplicity
 <p>The site contains HTML mockups of common UI components designed to follow the Web Design Standards' visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
 <p>All of these designs are also available in a variety of design file formats for download:</p>
 <ul class="usa-content-list">
-  <li><strong>Illustrator, EPS, Sketch, and Omnigraffle</strong> art files of each component and pattern on this site are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a></li>
+  <li><strong>Illustrator, EPS, and Sketch</strong> art files of each component and pattern on this site are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a></li>
   <li><strong>.AI and .ASE color swatches</strong> are available at:</strong> <a href="{{ site.repos[1].url }}/tree/master/Colors">{{ site.repos[1].url }}/tree/master/Colors</a></li>
   <li><strong>.TTF files</strong> of the font families and weights we recommend are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a> (Note: all fonts used in the Web Design Standards are free, open source typefaces also available online).</li>
 </ul>


### PR DESCRIPTION
Per feedback in https://github.com/18F/web-design-standards-assets/issues/14, removes mention of omnigraffle until we are able to provide these assets. 

Note: leaving Sketch in as this will be added w/in 24 hrs.