### PR TITLE
Add alert role to error alert

### DIFF
--- a/_components/alerts.md
+++ b/_components/alerts.md
@@ -21,7 +21,7 @@ lead: Alerts keep users informed of important and sometimes time-sensitive chang
     </div>
   </div>
 
-  <div class="usa-alert usa-alert-error">
+  <div class="usa-alert usa-alert-error" role="alert">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Error Status</h3>
       <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>


### PR DESCRIPTION
This adds `role="alert"` to the error alert.

This resolves #727.

Do we need to add anything in the documentation stating we only added `role="alert"` to error alerts and not the others (i.e. success, warning, info)?