### PR TITLE
Update link values to use hashes #

### DIFF
--- a/_components/footers.md
+++ b/_components/footers.md
@@ -18,31 +18,31 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
         <nav class="usa-footer-nav usa-width-two-thirds">
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
             <h4 class="usa-footer-primary-link">Topic</h4>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
             <h4 class="usa-footer-primary-link">Topic</h4>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
             <h4 class="usa-footer-primary-link">Topic</h4>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
             <h4 class="usa-footer-primary-link">Topic</h4>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
-            <li><a href="javascript:void(0)">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
+            <li><a href="#">Secondary link</a></li>
           </ul>
         </nav>
 
@@ -66,25 +66,25 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
 
         <div class="usa-footer-contact-links usa-width-one-half">
           <div class="usa-social-links">
-            <a href="javascript:void(0)">
+            <a href="#">
               <svg width="26" height="39" role="img" aria-label="Facebook">
                 <title>Facebook</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/facebook25.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/facebook25.png" width="26" height="39" />
               </svg>
             </a>
-            <a href="javascript:void(0)">            
+            <a href="#">            
               <svg width="26" height="39" role="img" aria-label="Twitter">
                 <title>Twitter</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/twitter16.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/twitter16.png" width="26" height="39" />
               </svg>
             </a>
-            <a href="javascript:void(0)">
+            <a href="#">
               <svg width="26" height="39" role="img" aria-label="YouTube">
                 <title>YouTube</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/youtube15.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/youtube15.png" width="26" height="39" />
               </svg>
             </a>
-            <a href="javascript:void(0)">
+            <a href="#">
               <svg width="26" height="39" role="img" aria-label="RSS">
                 <title>RSS</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/rss25.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/rss25.png" width="26" height="39" />
@@ -95,7 +95,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
           <address>
             <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
             <p>(800) CALL-GOVT</p>
-            <a href="mailto:javascript:void(0)">info@agency.gov</a>
+            <a href="mailto:#">info@agency.gov</a>
           </address>
         </div>
       </div>
@@ -141,25 +141,25 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
 
         <div class="usa-footer-contact-links usa-width-one-half">
           <div class="usa-social-links">
-            <a href="javascript:void(0)">
+            <a href="#">
               <svg width="26" height="39" role="img" aria-label="Facebook">
                 <title>Facebook</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/facebook25.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/facebook25.png" width="26" height="39" />
               </svg>
             </a>
-            <a href="javascript:void(0)">            
+            <a href="#">            
               <svg width="26" height="39" role="img" aria-label="Twitter">
                 <title>Twitter</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/twitter16.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/twitter16.png" width="26" height="39" />
               </svg>
             </a>
-            <a href="javascript:void(0)">
+            <a href="#">
               <svg width="26" height="39" role="img" aria-label="YouTube">
                 <title>YouTube</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/youtube15.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/youtube15.png" width="26" height="39" />
               </svg>
             </a>
-            <a href="javascript:void(0)">
+            <a href="#">
               <svg width="26" height="39" role="img" aria-label="RSS">
                 <title>RSS</title>
                 <image xlink:href="{{ site.baseurl }}/assets/img/social-icons/svg/rss25.svg" src="{{ site.baseurl }}/assets/img/social-icons/png/rss25.png" width="26" height="39" />
@@ -170,7 +170,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
           <address>
             <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
             <p>(800) CALL-GOVT</p>
-            <a href="mailto:javascript:void(0)">info@agency.gov</a>
+            <a href="mailto:#">info@agency.gov</a>
           </address>
         </div>
       </div>
@@ -205,7 +205,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
           <p>(800) CALL-GOVT</p>
         </div>
         <div class="usa-width-one-sixth usa-footer-primary-content">
-          <a href="mailto:javascript:void(0)">info@agency.gov</a>
+          <a href="mailto:#">info@agency.gov</a>
         </div>          
       </div>
     </div>

--- a/_components/form-templates.md
+++ b/_components/form-templates.md
@@ -197,7 +197,7 @@ lead: Patterns for some of the most commonly used forms on government websites
   <form>
     <fieldset>
       <legend class="usa-drop_text">Sign in</legend>
-      <span>or <a href="javascript:void(0)">create an account</a></span>
+      <span>or <a href="#">create an account</a></span>
 
       <label for="username">Username or email address</label>
       <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off">
@@ -205,16 +205,16 @@ lead: Patterns for some of the most commonly used forms on government websites
       <label for="password">Password</label>
       <input id="password" name="password" type="password">
       <p class="usa-form-note">
-        <a title="Show password" href="javascript:void(0)"
+        <a title="Show password" href="#"
             class="usa-show_password"
             aria-controls="password">
           Show password</a>
       </p>
 
       <input type="submit" value="Sign in" />
-      <p><a href="javascript:void(0)" title="Forgot password">
+      <p><a href="#" title="Forgot password">
         Forgot username?</a></p>
-      <p><a href="javascript:void(0)" title="Forgot password">
+      <p><a href="#" title="Forgot password">
         Forgot password?</a></p>
     </fieldset>
   </form>
@@ -286,7 +286,7 @@ lead: Patterns for some of the most commonly used forms on government websites
       <label for="confirmPassword">Confirm password</label>
       <input id="confirmPassword" name="confirmPassword" type="password">
       <p class="usa-form-note">
-        <a title="Show my typing" href="javascript:void(0)"
+        <a title="Show my typing" href="#"
             class="usa-show_multipassword"
             aria-controls="password">
           Show my typing</a>

--- a/_components/sidenav.md
+++ b/_components/sidenav.md
@@ -13,13 +13,13 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: W
     <aside class="usa-width-one-fourth">
       <ul class="usa-sidenav-list">
         <li>
-          <a class="usa-current" href="javascript:void(0)">Current page</a>
+          <a class="usa-current" href="#">Current page</a>
         </li>
         <li>
-          <a href="javascript:void(0)">Parent link</a>
+          <a href="#">Parent link</a>
         </li>
         <li>
-          <a href="javascript:void(0)">Parent link</a>
+          <a href="#">Parent link</a>
         </li>
       </ul>
     </aside>
@@ -31,30 +31,30 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: W
     <aside class="usa-width-one-fourth">
       <ul class="usa-sidenav-list">
         <li>
-          <a href="javascript:void(0)">Parent link</a>
+          <a href="#">Parent link</a>
         </li>
         <li>
-          <a class="usa-current" href="javascript:void(0)">Current page</a>
+          <a class="usa-current" href="#">Current page</a>
           <ul class="usa-sidenav-sub_list">
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
             <li>
-              <a class="usa-current" href="javascript:void(0)">Child Link</a>
+              <a class="usa-current" href="#">Child Link</a>
             </li>
           </ul>
         </li>
         <li>
-          <a href="javascript:void(0)">Parent link</a>
+          <a href="#">Parent link</a>
         </li>
       </ul>
     </aside>
@@ -66,41 +66,41 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: W
     <aside class="usa-width-one-fourth">
       <ul class="usa-sidenav-list">
         <li>
-          <a href="javascript:void(0)">Parent link</a>
+          <a href="#">Parent link</a>
         </li>
         <li>
-          <a class="usa-current" href="javascript:void(0)">Current page</a>
+          <a class="usa-current" href="#">Current page</a>
           <ul class="usa-sidenav-sub_list">
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
               <ul class="usa-sidenav-sub_list">
                 <li>
-                  <a href="javascript:void(0)">Grandchild link</a>
+                  <a href="#">Grandchild link</a>
                 </li>
                 <li>
-                  <a href="javascript:void(0)">Grandchild link</a>
+                  <a href="#">Grandchild link</a>
                 </li>
                 <li>
-                  <a class="usa-current" href="javascript:void(0)">Grandchild link</a>
+                  <a class="usa-current" href="#">Grandchild link</a>
                 </li>
               </ul>
             </li>
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
             <li>
-              <a href="javascript:void(0)">Child link</a>
+              <a href="#">Child link</a>
             </li>
           </ul>
         </li>
         <li>
-          <a href="javascript:void(0)">Parent link</a>
+          <a href="#">Parent link</a>
         </li>
       </ul>
     </aside>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -941,15 +941,15 @@ order: 01
 
 <div class="preview">
 
-  <a href="javascript:void(0)">This is a link without surrounding text.</a>
-  <p><a href="javascript:void(0)">This</a> is a text link on a light background.</p>
+  <a href="#">This is a link without surrounding text.</a>
+  <p><a href="#">This</a> is a text link on a light background.</p>
 
-  <p><a class="usa-color-text-visited" href="javascript:void(0)">This</a> is a visited link.</p>
+  <p><a class="usa-color-text-visited" href="#">This</a> is a visited link.</p>
 
   <p>This is a link which opens in a <a href="http://media.giphy.com/media/8sgNa77Dvj7tC/giphy.gif" target="_blank">new tab</a>.</p>
 
   <div class="usa-background-dark">
-    <p><a href="javascript:void(0)">This</a> is a text link on a dark background.</p>
+    <p><a href="#">This</a> is a text link on a dark background.</p>
   </div>
 </div>
 

--- a/assets-styleguide/js/styleguide.js
+++ b/assets-styleguide/js/styleguide.js
@@ -4,6 +4,14 @@ $(function(){
     e.preventDefault();
   });
   
+  function handleDisabledLinks() {
+    $(document).on('click', 'a[href="#"]', function (event) {
+      // Stop default browser action which would likely return to the top of the page
+      event.preventDefault();
+    });
+  }
+  handleDisabledLinks()
+
   // TODO restructure function so the use of "this" makes sense.
   var generateCodeSnippets = function(content, previewBox) {
 


### PR DESCRIPTION
This changes our links to use `#`'s instead of `javascript:void(0)`. This adds an event handler to prevent the default behavior of links jumping to the top of the page.

This resolves #743 and #557.

Thanks @dylanvalade!