### PR TITLE
Adding Ethnio activation code

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -6,3 +6,6 @@
   <![endif]-->
   <script src="{{ site.baseurl }}/assets-styleguide/js/vendor/prism.js"></script>
   <script src="{{ site.baseurl }}/assets-styleguide/js/styleguide.js"></script>
+
+  <!-- Ethnio Activation Code -->
+  <script type="text/javascript" language="javascript" src="//ethn.io/58707.js" async="true" charset="utf-8"></script>


### PR DESCRIPTION
This PR adds an Ethn.io screener widget to our home page. People who sign up may be invited to participate in an interview about their experience with the standards.

<img width="1050" alt="screen shot 2015-10-05 at 5 26 37 pm" src="https://cloud.githubusercontent.com/assets/2092076/10294127/6a9b2db2-6b86-11e5-9dfa-48c8d147a983.png">
