### PR TITLE
Remove tabindex="0" on inputs

### DIFF
--- a/_elements/form-controls.md
+++ b/_elements/form-controls.md
@@ -135,15 +135,15 @@ lead: Form controls allow users to enter information into a page.
 
     <ul class="usa-unstyled-list">
       <li>
-        <input id="apple-pie" type="checkbox" name="apple-pie" value="apple-pie" tabindex="0" checked />
+        <input id="apple-pie" type="checkbox" name="apple-pie" value="apple-pie" checked />
         <label for="apple-pie">Sojourner Truth</label>
       </li>
       <li>
-        <input id="key-lime-pie" type="checkbox" name="key-lime-pie" value="key-lime-pie" tabindex="0">
+        <input id="key-lime-pie" type="checkbox" name="key-lime-pie" value="key-lime-pie">
         <label for="key-lime-pie">Frederick Douglass</label>
       </li>
       <li>
-        <input id="peach-pie" type="checkbox" name="peach-pie" value="peach-pie" tabindex="0">
+        <input id="peach-pie" type="checkbox" name="peach-pie" value="peach-pie">
         <label for="peach-pie">Booker T. Washington</label>
       </li>
       <li>
@@ -204,15 +204,15 @@ lead: Form controls allow users to enter information into a page.
 
     <ul class="usa-unstyled-list">
       <li>
-        <input id="pea-soup" type="radio" checked name="soup" value="pea" tabindex="0">
+        <input id="pea-soup" type="radio" checked name="soup" value="pea">
         <label for="pea-soup">Elizabeth Cady Stanton</label>
       </li>
       <li>
-        <input id="chicken-noodle" type="radio" name="soup" value="chicken-noodle" tabindex="0">
+        <input id="chicken-noodle" type="radio" name="soup" value="chicken-noodle">
         <label for="chicken-noodle">Susan B. Anthony</label>
       </li>
       <li>
-        <input id="tomato" type="radio" name="soup" value="tomato" tabindex="0">
+        <input id="tomato" type="radio" name="soup" value="tomato">
         <label for="tomato">Harriet Tubman</label>
       </li>
     </ul>


### PR DESCRIPTION
This removes `tabindex="0"` on radio buttons and checkboxes bc it's not needed - they are already focusable. 

Resolves: #793.