### PR TITLE
Add note in documentation about using caption tag inside table element

### DIFF
--- a/_elements/tables.md
+++ b/_elements/tables.md
@@ -87,6 +87,7 @@ lead: Tables show tabular data in columns and rows.
     <ul class="usa-content-list">
       <li>Simple tables can have two levels of headers. Each header cell should have <code>scope=<wbr>'col'</code> or <code>scope=<wbr>'row'</code>.</li>
       <li>Complex tables are tables with more than two levels of headers. Each header should be given a unique <code>id</code> and each data cell should have a <code>headers</code> attribute with each related header cell’s <code>id</code> listed.</li>
+      <li>When adding a title to a table, include it in a <code>&lt;caption&gt;</code> tag inside of the <code>&lt;table&gt;</code> element.</li>
     </ul>
 
     <h4 class="usa-heading">Usability</h4>


### PR DESCRIPTION
This adds a note in the accessibility documentation about using `<caption>` tag inside `<table>` element.

Resolves #791.