### PR TITLE
Remove duplicate selectors in buttons

### DIFF
--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -12,9 +12,6 @@ button,
 [type="button"],
 [type="submit"],
 [type="reset"],
-[type="button"],
-[type="submit"],
-[type="reset"],
 [type="image"] {
   appearance: none;
   background-color: $color-primary;


### PR DESCRIPTION
This removes duplicate selectors in `_buttons.scss`.

Resolves #805.