### PR TITLE
Fix sign in title

### DIFF
--- a/_components/form-templates.md
+++ b/_components/form-templates.md
@@ -212,7 +212,7 @@ lead: Patterns for some of the most commonly used forms on government websites
       </p>
 
       <input type="submit" value="Sign in" />
-      <p><a href="#" title="Forgot password">
+      <p><a href="#" title="Forgot username">
         Forgot username?</a></p>
       <p><a href="#" title="Forgot password">
         Forgot password?</a></p>


### PR DESCRIPTION
This fixes the forgot username title in the sign in form.

As noted in #827.