### PR TITLE
Add image links

### DIFF
--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -76,8 +76,10 @@ order: 01
             <p>Ideal number of fonts. Will allow for optimal page load performance.</p>
             <h6 class="usa-heading-alt">Example</h6>
             <p>
-              <img src="{{ site.baseurl }}/assets-styleguide/img/default_example_emanifest.png" alt="EPA eManifest example">
-              <a href="{{ site.baseurl }}/assets-styleguide/img/epa-emanifest-screenshot.png">EPA eManifest  (screenshot of non-public site)</a>
+              <a class="media_link" href="{{ site.baseurl }}/assets-styleguide/img/epa-emanifest-screenshot.png">
+                <img src="{{ site.baseurl }}/assets-styleguide/img/default_example_emanifest.png" alt="EPA eManifest example">
+              </a>
+              <a href="{{ site.baseurl }}/assets-styleguide/img/epa-emanifest-screenshot.png">EPA eManifest (screenshot of non-public site)</a>
             </p>
           </aside>
           <h6 class="usa-heading-alt">Web Hierarchy</h6>
@@ -230,7 +232,9 @@ order: 01
             <p>Exceeds ideal number of fonts by one. May negatively impact page load performance.</p>
             <h6 class="usa-heading-alt">Example</h6>
             <p>
-              <img src="{{ site.baseurl }}/assets-styleguide/img/robust_example_standardshome.png" alt="U.S. Web Design Standards homepage example">
+              <a class="media_link" href="/">
+                <img src="{{ site.baseurl }}/assets-styleguide/img/robust_example_standardshome.png" alt="U.S. Web Design Standards homepage example">
+              </a>
               <a href="/">U.S. Web Design Standards homepage</a>
             </p>
           </aside>
@@ -407,7 +411,9 @@ order: 01
             <p>Exceeds ideal number of fonts by two. May negatively impact page load performance.</p>
             <h6 class="usa-heading-alt">Example</h6>
             <p>
-              <img src="{{ site.baseurl }}/assets-styleguide/img/merriweatheronly_example_playbook.png" alt="U.S. Digital Service Playbook example">
+              <a class="media_link" href="http://playbook.cio.gov">
+                <img src="{{ site.baseurl }}/assets-styleguide/img/merriweatheronly_example_playbook.png" alt="U.S. Digital Service Playbook example">
+              </a>
               <a href="http://playbook.cio.gov">U.S. Digital Service Playbook</a>
             </p>
           </aside>
@@ -743,7 +749,9 @@ order: 01
             <p>Ideal number of fonts. Will allow for optimal page load performance.</p>
             <h6 class="usa-heading-alt">Example</h6>
             <p>
-              <img src="{{ site.baseurl }}/assets-styleguide/img/ssponly_example_va.png" alt="Veterans Affairs appeals review example">
+              <a class="media_link" href="{{ site.baseurl }}/assets-styleguide/img/va-appeals-screenshot.png">
+                <img src="{{ site.baseurl }}/assets-styleguide/img/ssponly_example_va.png" alt="Veterans Affairs appeals review example">
+              </a>
               <a href="{{ site.baseurl }}/assets-styleguide/img/va-appeals-screenshot.png">Department of Veterans Affairs appeals review (screenshot of non-public site)</a>
             </p>
           </aside>

--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -202,7 +202,11 @@ a {
     margin-bottom: 1.6rem;
   }
 
-  .usa-img-example {
-    margin-bottom: 5rem;
+  .usa-example-link {
+    margin-top: 5rem;
+    
+    &:first-of-type {
+      margin-top: 0;
+    }
   }
 }

--- a/assets/_scss/elements/_figure.scss
+++ b/assets/_scss/elements/_figure.scss
@@ -1,3 +1,8 @@
 img {
   max-width: 100%;
 }
+
+.media_link {
+  display: inline-block;
+  line-height: 0;
+}

--- a/assets/_scss/elements/_figure.scss
+++ b/assets/_scss/elements/_figure.scss
@@ -2,7 +2,7 @@ img {
   max-width: 100%;
 }
 
-// TODO: add in documentation instructions for using this class on image links
+// TODO: Add documentation instructions for using this class on image links
 .media_link {
   display: inline-block;
   line-height: 0;

--- a/assets/_scss/elements/_figure.scss
+++ b/assets/_scss/elements/_figure.scss
@@ -2,6 +2,7 @@ img {
   max-width: 100%;
 }
 
+// TODO: add in documentation instructions for using this class on image links
 .media_link {
   display: inline-block;
   line-height: 0;

--- a/pages/index.html
+++ b/pages/index.html
@@ -152,24 +152,24 @@ title: U.S. Web Design Standards
     </div>
   </div>
   <div class="usa-grid">
-    <h3 class="usa-example-heading usa-link-external">
-      <a class="usa-example-link" href="https://vote.usa.gov/">
+    <a class="usa-example-link media_link" href="https://vote.usa.gov/">
+      <h3 class="usa-example-heading usa-link-external">
         vote.usa.gov
-      </a>
-    </h3>
-    <img class="usa-img-example" src="{{ site.baseurl }}/assets-styleguide/img/home/example_voteUSAgov.jpg" alt="vote.usa.gov homepage">
-    <h3 class="usa-example-heading usa-link-external">
-      <a class="usa-example-link" href="{{ site.baseurl }}/assets-styleguide/img/home/example_VAappeals_full_mock.png">
+      </h3>
+      <img class="usa-img-example" src="{{ site.baseurl }}/assets-styleguide/img/home/example_voteUSAgov.jpg" alt="vote.usa.gov homepage">
+    </a>
+    <a class="usa-example-link media_link" href="{{ site.baseurl }}/assets-styleguide/img/home/example_VAappeals_full_mock.png">
+      <h3 class="usa-example-heading usa-link-external">
         Mockup of VA Appeals Modernization Screen
-      </a>
-    </h3>
-    <img class="usa-img-example" src="{{ site.baseurl }}/assets-styleguide/img/home/example_VAappeals_mock.png" alt="VA Appeals Modernization Screen">
-    <h3 class="usa-example-heading usa-link-external">
-      <a class="usa-example-link" href="https://playbook.cio.gov">
+      </h3>
+      <img class="usa-img-example" src="{{ site.baseurl }}/assets-styleguide/img/home/example_VAappeals_mock.png" alt="VA Appeals Modernization Screen">
+    </a>
+    <a class="usa-example-link media_link" href="https://playbook.cio.gov">
+      <h3 class="usa-example-heading usa-link-external">
         U.S. Digital Service Playbook
-      </a>
-    </h3>
-    <img class="usa-img-example" src="{{ site.baseurl }}/assets-styleguide/img/home/example_playbook.jpg" alt="U.S. Digital Service Playbook homepage">
+      </h3>
+      <img class="usa-img-example" src="{{ site.baseurl }}/assets-styleguide/img/home/example_playbook.jpg" alt="U.S. Digital Service Playbook homepage">
+    </a>
   </div>
   <div class="usa-grid usa-cta">
     <a class="usa-button usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage body');"


### PR DESCRIPTION
This adds a class for image links and wraps links around example images on the homepage and typography page.

TODO: If we ever have a page for images, we should add implementation guidelines for image links. Added note in scss for now.

Resolves #698.