### PR TITLE
Adding Ethnio activation code

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -6,3 +6,6 @@
   <![endif]-->
   <script src="{{ site.baseurl }}/assets-styleguide/js/vendor/prism.js"></script>
   <script src="{{ site.baseurl }}/assets-styleguide/js/styleguide.js"></script>
+
+  <!-- Ethnio Activation Code -->
+  <script type="text/javascript" language="javascript" src="//ethn.io/58707.js" async="true" charset="utf-8"></script>


### PR DESCRIPTION
This adds an ethn.io activation code to every page on the standards website. When ethn.io is enabled, visitors will see this invitation to give feedback and sign up for an interview:

<img width="300" alt="screen shot 2015-10-16 at 12 30 18 am" src="https://cloud.githubusercontent.com/assets/2092076/10536078/1ace4598-739d-11e5-8737-4be5879f3ea1.png">

Right now, ethn.io is not enabled, so nothing will show. 