### PR TITLE
Update $color-gray-lightest label to correct hex code

### DIFF
--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -169,7 +169,7 @@ order: 02
   <div class="color-small">
     <div class="usa-color-short usa-color-gray-lightest">
     </div>
-      <p class="usa-color-hex">#efefef</p>
+      <p class="usa-color-hex">#f1f1f1</p>
       <p class="usa-color-name">gray-lightest</p>
   </div>
 </div>


### PR DESCRIPTION
This updates `$color-gray-lightest` label to the correct hex code.

Resolves #836.