### PR TITLE
Change overflow to auto on styleguide sidenav

### DIFF
--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -188,7 +188,7 @@ $site-top:           124px;
   width: $width-nav-sidebar;
   border-right: 1px solid $color-gray-light;
   padding: 5rem 3rem 3rem 3rem;
-  overflow: scroll;
+  overflow: auto;
   display: none;
   z-index: -1;
   


### PR DESCRIPTION
This makes it so the scrollbar only appears when the height of the sidebar navigation is not tall enough for the content. Otherwise, we just see a nice, solid line.

When it's tall enough:

![screen shot 2015-10-19 at 2 01 23 pm](https://cloud.githubusercontent.com/assets/5249443/10591261/1fe03cce-766a-11e5-87c7-d66cab3db7e8.png)

When it's short:

![screen shot 2015-10-19 at 2 01 34 pm](https://cloud.githubusercontent.com/assets/5249443/10591278/359f0d1a-766a-11e5-9cea-b88336131a7d.png)

h/t to @shawnbot for figuring this out!