### PR TITLE
Remove extra jQuery link on homepage - issue #853

### DIFF
--- a/_includes/head-home.html
+++ b/_includes/head-home.html
@@ -59,7 +59,3 @@
 ================================================== -->
   <link rel="stylesheet" href="{{ "/assets/css/google-fonts.css" | prepend: site.baseurl }}">
   <link rel="stylesheet" href="{{ "/assets-styleguide/css/homepage.css" | prepend: site.baseurl }}">
-
-<!-- Scripts
-================================================== -->
-  <script src="{{ site.baseurl }}/assets/js/vendor/jquery-1.11.3.min.js"></script>


### PR DESCRIPTION
This removes the extra jQuery link from the head on the homepage.

Resolves #853.