### PR TITLE
Revert "Link to Sass"

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -14,7 +14,7 @@ lead: The U.S. Web Design Standards are designed to set a new bar for simplicity
 <h4>CSS architecture</h4>
 
 <ol class="usa-content-list">
-  <li>The CSS foundation of this site is built with the <strong><a href="http://http://sass-lang.com">Sass</a></strong> preprocessor language.</li>
+  <li>The CSS foundation of this site is built with the <strong>Sass</strong> preprocessor language.</li>
   <li>Uses <strong><a href="http://bourbon.io/">Bourbon</a></strong> for its simple and lightweight Sass mixin library, and the <strong><a href="http://neat.bourbon.io/">Neat</a></strong> library for the grid framework. Bourbon and Neat are open-source products from <strong><a href="https://thoughtbot.com/">thoughtbot</a></strong>.</li>
   <li>The CSS organization and naming conventions follow <strong><a href="https://pages.18f.gov/frontend/css-coding-styleguide/">18F's CSS Coding Styleguide</a></strong>.</li>
   <li>CSS selectors are <strong>prefixed</strong> with <code>usa</code> (For example: <code>.usa-button</code>).</li>


### PR DESCRIPTION
Reverts 18F/web-design-standards#856

The base branch was set to `18f-pages` instead of `18f-pages-staging` so needs to be reverted.