### PR TITLE
Add fix for Firefox for media blocks - issue #863

### DIFF
--- a/assets/_scss/elements/_figure.scss
+++ b/assets/_scss/elements/_figure.scss
@@ -7,3 +7,13 @@ img {
   display: inline-block;
   line-height: 0;
 }
+
+// Patch for Firefox: max-width:100% is not respected within auto-width inline 
+// blocks
+@-moz-document url-prefix() {
+  .media_link {
+   display: table;
+   table-layout: fixed;
+   width: 100%;
+  }
+}

--- a/assets/_scss/elements/_figure.scss
+++ b/assets/_scss/elements/_figure.scss
@@ -12,8 +12,8 @@ img {
 // blocks
 @-moz-document url-prefix() {
   .media_link {
-   display: table;
-   table-layout: fixed;
-   width: 100%;
+    display: table;
+    table-layout: fixed;
+    width: 100%;
   }
 }


### PR DESCRIPTION
This adds a fix for Firefox where max-width:100% is not respected within auto-width inline blocks.

This bug has been documented on Mozilla: https://bugzilla.mozilla.org/show_bug.cgi?id=932996

Resolves #863.