### PR TITLE
Change alert colors to use variables - issue #866

### DIFF
--- a/assets/_scss/components/_alerts.scss
+++ b/assets/_scss/components/_alerts.scss
@@ -2,7 +2,7 @@
   @include media($medium-screen) {
     background-size: 5.2rem;
   }
-  background-color: #eeeeee;  
+  background-color: $color-gray-lightest;  
   background-position: 1rem 2rem;
   background-repeat: no-repeat;
   background-size: 4rem;
@@ -50,25 +50,25 @@
 }
 
 .usa-alert-success {
-  background-color: #E5FCDE;
+  background-color: $color-green-lightest;
   background-image: url('../img/alerts/success.png');  
   background-image: url('../img/alerts/success.svg');  
 }
 
 .usa-alert-warning {
-  background-color: #FDF7DC;
+  background-color: $color-gold-lightest;
   background-image: url('../img/alerts/warning.png');  
   background-image: url('../img/alerts/warning.svg');   
 }
 
 .usa-alert-error {
-  background-color: #F9DEDE;
+  background-color: $color-secondary-lightest;
   background-image: url('../img/alerts/error.png');  
   background-image: url('../img/alerts/error.svg');   
 }
 
 .usa-alert-info {
-  background-color: #E8F5FA;
+  background-color: $color-primary-alt-lightest;
   background-image: url('../img/alerts/info.png');  
   background-image: url('../img/alerts/info.svg');   
 }


### PR DESCRIPTION
This changes the alert background colors to use our variables. It uses the lightest version of each color. You can see below that the colors are slightly different.

This is what it looks like now (using variables):

<img width="817" alt="screen shot 2015-10-27 at 8 44 04 pm" src="https://cloud.githubusercontent.com/assets/5249443/10779282/d8e3736c-7ceb-11e5-94d5-005e86e693b6.png">

This is what it looked like before (not using variables):

<img width="815" alt="screen shot 2015-10-27 at 8 44 12 pm" src="https://cloud.githubusercontent.com/assets/5249443/10779280/d4ae9722-7ceb-11e5-996d-989318a62bff.png">

Resolves: #866