### PR TITLE
[ website ]: Remove older mobile meta tags

### DIFF
--- a/_includes/head-home.html
+++ b/_includes/head-home.html
@@ -2,12 +2,7 @@
 ================================================== -->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
-<!-- Mobile Specific Metas
-================================================== -->
-  <meta name="HandheldFriendly" content="True">
-  <meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <!-- Title and meta description
 ================================================== -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,12 +2,7 @@
 ================================================== -->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
-<!-- Mobile Specific Metas
-================================================== -->
-  <meta name="HandheldFriendly" content="True">
-  <meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <!-- Title and meta description
 ================================================== -->


### PR DESCRIPTION
I removed the older mobile meta tags form head.html and head-home.html. They specifically target Palm, Blackberry, and PocketPC devices. Seems pretty unnecessary these days. The viewport tag is all we need.