### PR TITLE
Remove reference to Americans with Disabilities Act (ADA) on homepage - issue #884

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -119,7 +119,7 @@ title: U.S. Web Design Standards
         <img class="usa-img-circle" src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_508_box_2x.png" alt="Accessibility">
       </div>
       <h3 class="usa-graphic-list-heading">Accessibility out of the box</h3>
-      <p class="usa-graphic-list-text">These standards were built with a priority on 508 compliance and accessibility at every step of the design process. From colors to code, everything you need to meet high standards of accessibility are baked into these tools.</p>
+      <p class="usa-graphic-list-text">These guidelines were built with a priority on accessibility at every step of the design process in conformance with Section 508 Standards. From colors to code, everything you need to meet high standards of accessibility are baked into these tools.</p>
     </div>
   </div>
   <div class="usa-grid">

--- a/pages/index.html
+++ b/pages/index.html
@@ -119,7 +119,7 @@ title: U.S. Web Design Standards
         <img class="usa-img-circle" src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_508_box_2x.png" alt="Accessibility">
       </div>
       <h3 class="usa-graphic-list-heading">Accessibility out of the box</h3>
-      <p class="usa-graphic-list-text">These standards were built with a priority on 508 compliance and ADA accessibility at every step of the design process. From colors to code, everything you need to meet high standards of accessibility are baked into these tools.</p>
+      <p class="usa-graphic-list-text">These standards were built with a priority on 508 compliance and accessibility at every step of the design process. From colors to code, everything you need to meet high standards of accessibility are baked into these tools.</p>
     </div>
   </div>
   <div class="usa-grid">


### PR DESCRIPTION
This removes the reference to the Americans with Disabilities Act (ADA) on the homepage and makes a few other improvements to the sentence.

Fixes #884.