### PR TITLE
Update "Getting Started" to refer to zip file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Include the Web Design Standards CSS and JavaScript files in each HTML page in y
 
 Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages and also include the font font:
 
-`<link rel="stylesheet" href="/path/to/your/assets/css/main.css">`
-`<link rel="stylesheet" href="/path/to/your/assets/css/google-fonts.css">`
-`<script src="/path/to/your/assets/js/components.js"></script>`
+```<link rel="stylesheet" href="/path/to/your/assets/css/main.css">
+<link rel="stylesheet" href="/path/to/your/assets/css/google-fonts.css">
+<script src="/path/to/your/assets/js/components.js"></script>```
 
 ## Setup for your local environment
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Much of the guidance in Web Design Standards leans on open source designs, code,
 
 ## Getting started
 
-To begin using the U.S. Web Design Standards, include the CSS and JavaScript files in each HTML page of your project. Copy the full `_site/assets/` directory to a relevant place in your code base `cp ./_site/assets/css/main.css /path/to/your/repo/static/dir`. Add the following `<link>` and `<script>` elements in your HTML:
+Include the Web Design Standards CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip Add them to your source code to host them yourself.
 
-- `<link rel="stylesheet" href="/path/to/your/assets/css/main.css">`
-- `<link rel="stylesheet" href="/path/to/your/assets/css/google-fonts.css">`
-- `<script src="/path/to/your/assets/js/components.js"></script>`
+Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages and also include the font font:
+
+`<link rel="stylesheet" href="/path/to/your/assets/css/main.css">`
+`<link rel="stylesheet" href="/path/to/your/assets/css/google-fonts.css">`
+`<script src="/path/to/your/assets/js/components.js"></script>`
 
 ## Setup for your local environment
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ Include the Web Design Standards CSS and JavaScript files in each HTML page in y
 
 Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages and also include the font font:
 
-```<link rel="stylesheet" href="/path/to/your/assets/css/main.css">
+```
+<link rel="stylesheet" href="/path/to/your/assets/css/main.css">
 <link rel="stylesheet" href="/path/to/your/assets/css/google-fonts.css">
-<script src="/path/to/your/assets/js/components.js"></script>```
+<script src="/path/to/your/assets/js/components.js"></script>
+```
 
 ## Setup for your local environment
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Much of the guidance in Web Design Standards leans on open source designs, code,
 
 ## Getting started
 
-Include the Web Design Standards CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip. Add them to your source code to host them yourself.
+Include the Web Design Standards CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip. Add the assets directory to a relevant place in your code base.
 
 Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Much of the guidance in Web Design Standards leans on open source designs, code,
 
 ## Getting started
 
-Include the Web Design Standards CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip Add them to your source code to host them yourself.
+Include the Web Design Standards CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip. Add them to your source code to host them yourself.
 
-Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages and also include the font font:
+Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
 
 ```
 <link rel="stylesheet" href="/path/to/your/assets/css/main.css">

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Much of the guidance in Web Design Standards leans on open source designs, code,
 
 ## Getting started
 
-To begin using the Web Design Standards, include the CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip. Add the assets directory to a relevant place in your code base.
+To begin using the Web Design Standards, include the CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.2.zip. Add the assets directory to a relevant place in your code base.
 
 Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Much of the guidance in Web Design Standards leans on open source designs, code,
 
 ## Getting started
 
-Include the Web Design Standards CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip. Add the assets directory to a relevant place in your code base.
+To begin using the Web Design Standards, include the CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.1.zip. Add the assets directory to a relevant place in your code base.
 
 Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
 


### PR DESCRIPTION
This changes the "Getting Started" section to instruct people to download the assets ZIP file.

This resolves #885.

Note: we're linking to the specific version, so we'll need to remember to update this on each release.