### PR TITLE
Add package.json for npm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site/
 .sass-cache/
+node_modules/
 .DS_store
 .*.swp

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Refer to these files by adding a `<link>` and a `<script>` element into your HTM
 <script src="/path/to/your/assets/js/components.js"></script>
 ```
 
+### Install with NPM
+
+If you have `node` installed on your machine, you can use `npm` to install the Web Design Standards. In your `package.json` list the following under `dependencies`:
+
+```json
+  "uswds": "git@github.com:18F/web-design-standards.git#v0.9.0"
+```
+
+On subsequent runs of `npm install`, the package will be installed in `node_modules` under `uswds`. The CSS will be compiled after it is installed, and the final CSS file will be named `uswds.css`. You should be able to find it in `node_modules/uswds/assets/css/uswds.css`.
+
+*Note:* You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.
+
 ## Setup for your local environment
 
 ### Requirements
@@ -84,7 +96,7 @@ Deployments to production will be done by site admins, using pull requests from 
 
 ## Got feedback?
 
-Please create a [GitHub Issue](https://github.com/18F/web-design-standards/issues). 
+Please create a [GitHub Issue](https://github.com/18F/web-design-standards/issues).
 
 If you'd rather email, you can reach us at uswebdesignstandards@gsa.gov.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "package.json",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "uswds",
+  "version": "0.8.3",
+  "description": "Open source UI components and visual style guide for U.S. government websites",
+  "main": "package.json",
+  "scripts": {
+    "postinstall": "npm run build-sass",
+    "build-sass": "node-sass assets/_scss/all.scss > assets/css/uswds.css",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "assets": "assets/",
+  "scss": "assets/_scss",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/18F/web-design-standards.git"
+  },
+  "author": "18F",
+  "contributors": [
+    "Maya Benari <maya.ben-ari@gsa.gov>",
+    "Marco Segreto <marco.segreto@gsa.gov>"
+  ],
+  "license": "SEE LICENSE in LICENSE.md",
+  "bugs": {
+    "url": "https://github.com/18F/web-design-standards/issues"
+  },
+  "homepage": "https://github.com/18F/web-design-standards#readme",
+  "dependencies": {
+    "node-sass": "^3.4.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "author": "18F",
   "contributors": [
     "Maya Benari <maya.ben-ari@gsa.gov>",
-    "Marco Segreto <marco.segreto@gsa.gov>"
+    "Marco Segreto <marco.segreto@gsa.gov>",
+    "Jeremia Kimelman <jeremia.kimelman@gsa.gov>"
   ],
   "license": "SEE LICENSE in LICENSE.md",
   "bugs": {


### PR DESCRIPTION
Added the `package.json` so that the library can be installed through `npm`, which should close #767. I included `node-sass` as a dependency, which is run after the library is installed as a dependency for another project. This enables the CSS to be compiled using a Javascript dependency instead of requiring Ruby/Jekyll.

The difference number in the `package.json` is bumped to `0.8.3` because using release tags to install from Github is really easy in `npm`. Since there is already a packaged up `0.8.2` release, the `0.8.3` (or higher) release will enable users to be able to install by adding something like the following to their `dependencies`:
`"uswds": "git@github.com:18F/web-design-standards.git#v0.8.3"`

It can also be published to the npm registry at some point to enable something like `$ npm install uswds`