### PR TITLE
Added the same margin-bottom on password inputs

### DIFF
--- a/assets/_scss/components/_forms.scss
+++ b/assets/_scss/components/_forms.scss
@@ -23,7 +23,7 @@ form {
     margin-bottom: 1.5em;
   }
 
-  input[name="password"] {
+  input[name="password"], input[name="confirmPassword"] {
     margin-bottom: 1.1rem;
   }
 }


### PR DESCRIPTION
Went with personal preference of adding a button margin to all inputs since it was a decision, but removing the ```margin-bottom``` on all inputs would be as easy as deleting line 30 in ```assets/_scss/elements/_inputs.scss```.