### PR TITLE
Update tables to use a table header in each row

### DIFF
--- a/_elements/tables.md
+++ b/_elements/tables.md
@@ -19,22 +19,22 @@ lead: Tables show tabular data in columns and rows.
     </thead>
     <tbody>
       <tr>
-        <td scope='row'>Declaration of Independence</td>
+        <th scope='row'>Declaration of Independence</th>
         <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
         <td>1776</td>
       </tr>
       <tr>
-        <td scope='row'>Bill of Rights</td>
+        <th scope='row'>Bill of Rights</th>
         <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
         <td>1791</td>
       </tr>
       <tr>
-        <td scope='row'>Declaration of Sentiments</td>
+        <th scope='row'>Declaration of Sentiments</th>
         <td>A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
         <td>1848</td>
       </tr>
       <tr>
-        <td scope='row'>Emancipation Proclamation</td>
+        <th scope='row'>Emancipation Proclamation</th>
         <td>An executive order granting freedom to slaves in designated southern states.</td>
         <td>1863</td>
       </tr>
@@ -53,22 +53,22 @@ lead: Tables show tabular data in columns and rows.
     </thead>
     <tbody>
       <tr>
-        <td scope='row'>Declaration of Independence</td>
+        <th scope='row'>Declaration of Independence</th>
         <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
         <td>1776</td>
       </tr>
       <tr>
-        <td scope='row'>Bill of Rights</td>
+        <th scope='row'>Bill of Rights</th>
         <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
         <td>1791</td>
       </tr>
       <tr>
-        <td scope='row'>Declaration of Sentiments</td>
+        <th scope='row'>Declaration of Sentiments</th>
         <td>MadeA document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
         <td>1848</td>
       </tr>
       <tr>
-        <td scope='row'>Emancipation Proclamation</td>
+        <th scope='row'>Emancipation Proclamation</th>
         <td>An executive order granting freedom to slaves in designated southern states.</td>
         <td>1863</td>
       </tr>      

--- a/assets/_scss/elements/_table.scss
+++ b/assets/_scss/elements/_table.scss
@@ -13,6 +13,12 @@ table {
     }
   }
 
+  tbody {
+    th {
+      font-weight: $font-normal;
+    }
+  }
+
   th, td {
     border: 1px solid $color-gray;
     padding: 1.5rem;


### PR DESCRIPTION
This changes the first row item in `tbody` to `th` since scope on a `td` is being deprecated in HTML5.

Resolves #905.