### PR TITLE
Change name to draft standards 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ ./go serve
 ```
 
 You should now be able to visit `http://127.0.0.1:4000/`
-and view the web design draft standards locally.
+and view the draft web design standards locally.
 
 Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# U.S. Web Design Draft Standards
+# Draft U.S. Web Design Standards
 
 [![Build Status](https://api.travis-ci.org/18F/web-design-standards.svg?branch=18f-pages-staging)](https://travis-ci.org/18F/web-design-standards)
 
-The [U.S. Web Design Draft Standards](https://playbook.cio.gov/designstandards) is a library of open source UI components and a visual style guide for U.S. federal government websites.
+The [Draft U.S. Web Design Standards](https://playbook.cio.gov/designstandards) is a library of open source UI components and a visual style guide for U.S. federal government websites.
 
 These tools follow industry-standard web accessibility guidelines and reuse the best practices of existing style libraries and modern web design. Created and maintained by [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service) and [18F](https://18f.gsa.gov) designers and developers, the Web Design Draft Standards are designed to support government product teams in creating beautiful and easy-to-use online experiences for the American people. Learn more about this project in our announcement [blog post](https://18f.gsa.gov/2015/09/28/web-design-standards/).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The [Draft U.S. Web Design Standards](https://playbook.cio.gov/designstandards) is a library of open source UI components and a visual style guide for U.S. federal government websites.
 
-These tools follow industry-standard web accessibility guidelines and reuse the best practices of existing style libraries and modern web design. Created and maintained by [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service) and [18F](https://18f.gsa.gov) designers and developers, the Web Design Draft Standards are designed to support government product teams in creating beautiful and easy-to-use online experiences for the American people. Learn more about this project in our announcement [blog post](https://18f.gsa.gov/2015/09/28/web-design-standards/).
+These tools follow industry-standard web accessibility guidelines and reuse the best practices of existing style libraries and modern web design. Created and maintained by [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service) and [18F](https://18f.gsa.gov) designers and developers, the Draft Web Design Standards are designed to support government product teams in creating beautiful and easy-to-use online experiences for the American people. Learn more about this project in our announcement [blog post](https://18f.gsa.gov/2015/09/28/web-design-standards/).
 
 Design files of all the assets included on this site are available for download here: [https://github.com/18F/web-design-standards-assets](https://github.com/18F/web-design-standards-assets).
 
@@ -12,7 +12,7 @@ The structural setup of this repo is based off of [https://github.com/18F/pages]
 
 ### Reuse of open source style guides
 
-Much of the guidance in Web Design Draft Standards leans on open source designs, code, and patterns from other civic and government organizations, including:
+Much of the guidance in Draft Web Design Standards leans on open source designs, code, and patterns from other civic and government organizations, including:
 - Consumer Financial Protection Bureau’s [Design Manual](https://cfpb.github.io/design-manual/)
 - U.S. Patent and Trademark Office’s [Design Patterns](http://uspto.github.io/designpatterns/)
 - Healthcare.gov [Style Guide](http://styleguide.healthcare.gov/)
@@ -22,7 +22,7 @@ Much of the guidance in Web Design Draft Standards leans on open source designs,
 
 ## Getting started
 
-To begin using the Web Design Draft Standards, include the CSS and JavaScript files in each HTML page in your project. Download the the Web Design Draft Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.2.zip. Add the assets directory to a relevant place in your code base.
+To begin using the Draft Web Design Standards, include the CSS and JavaScript files in each HTML page in your project. Download the the Draft Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.2.zip. Add the assets directory to a relevant place in your code base.
 
 Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# U.S. Web Design Standards
+# U.S. Web Design Draft Standards
 
 [![Build Status](https://api.travis-ci.org/18F/web-design-standards.svg?branch=18f-pages-staging)](https://travis-ci.org/18F/web-design-standards)
 
-The [U.S. Web Design Standards](https://playbook.cio.gov/designstandards) is a library of open source UI components and a visual style guide for U.S. federal government websites.
+The [U.S. Web Design Draft Standards](https://playbook.cio.gov/designstandards) is a library of open source UI components and a visual style guide for U.S. federal government websites.
 
-These tools follow industry-standard web accessibility guidelines and reuse the best practices of existing style libraries and modern web design. Created and maintained by [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service) and [18F](https://18f.gsa.gov) designers and developers, the Web Design Standards are designed to support government product teams in creating beautiful and easy-to-use online experiences for the American people. Learn more about this project in our announcement [blog post](https://18f.gsa.gov/2015/09/28/web-design-standards/).
+These tools follow industry-standard web accessibility guidelines and reuse the best practices of existing style libraries and modern web design. Created and maintained by [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service) and [18F](https://18f.gsa.gov) designers and developers, the Web Design Draft Standards are designed to support government product teams in creating beautiful and easy-to-use online experiences for the American people. Learn more about this project in our announcement [blog post](https://18f.gsa.gov/2015/09/28/web-design-standards/).
 
 Design files of all the assets included on this site are available for download here: [https://github.com/18F/web-design-standards-assets](https://github.com/18F/web-design-standards-assets).
 
@@ -12,7 +12,7 @@ The structural setup of this repo is based off of [https://github.com/18F/pages]
 
 ### Reuse of open source style guides
 
-Much of the guidance in Web Design Standards leans on open source designs, code, and patterns from other civic and government organizations, including:
+Much of the guidance in Web Design Draft Standards leans on open source designs, code, and patterns from other civic and government organizations, including:
 - Consumer Financial Protection Bureau’s [Design Manual](https://cfpb.github.io/design-manual/)
 - U.S. Patent and Trademark Office’s [Design Patterns](http://uspto.github.io/designpatterns/)
 - Healthcare.gov [Style Guide](http://styleguide.healthcare.gov/)
@@ -22,7 +22,7 @@ Much of the guidance in Web Design Standards leans on open source designs, code,
 
 ## Getting started
 
-To begin using the Web Design Standards, include the CSS and JavaScript files in each HTML page in your project. Download the the Web Design Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.2.zip. Add the assets directory to a relevant place in your code base.
+To begin using the Web Design Draft Standards, include the CSS and JavaScript files in each HTML page in your project. Download the the Web Design Draft Standards assets: https://playbook.cio.gov/designstandards/assets/releases/wds-v0.8.2.zip. Add the assets directory to a relevant place in your code base.
 
 Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
 
@@ -63,7 +63,7 @@ $ ./go serve
 ```
 
 You should now be able to visit `http://127.0.0.1:4000/`
-and view the web design standards locally.
+and view the web design draft standards locally.
 
 Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
 

--- a/_config.yml
+++ b/_config.yml
@@ -15,14 +15,6 @@ exclude:
 
 permalink: pretty
 
-repos:
-- name: U.S. Web Design Standards
-  description: Main repository for the U.S. Web Design Standards.
-  url: https://github.com/18F/web-design-standards
-- name: U.S. Federal Web Design Standards Assets
-  description: U.S. Federal Web Design Standards visual design assets
-  url: https://github.com/18F/web-design-standards-assets
-
 google_analytics_ua: UA-48605964-33
 
 sass:

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Markdown config
 markdown: redcarpet
 highlighter: rouge
-name: U.S. Web Design Draft Standards
+name: Draft U.S. Web Design Standards
 exclude:
 - go
 - Gemfile

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Markdown config
 markdown: redcarpet
 highlighter: rouge
-name: U.S. Web Design Standards
+name: U.S. Web Design Draft Standards
 exclude:
 - go
 - Gemfile

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -15,7 +15,7 @@
       <div class="logo" id="logo">
         <h1>
           <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
-          U.S. Web Design Draft Standards</a>
+          Draft U.S. Web Design Standards</a>
         </h1>
       </div>
       <ul class="usa-button-list usa-unstyled-list">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -15,7 +15,7 @@
       <div class="logo" id="logo">
         <h1>
           <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
-          U.S. Web Design Standards</a>
+          U.S. Web Design Draft Standards</a>
         </h1>
       </div>
       <ul class="usa-button-list usa-unstyled-list">

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -233,9 +233,9 @@ order: 01
             <h6 class="usa-heading-alt">Example</h6>
             <p>
               <a class="media_link" href="/">
-                <img src="{{ site.baseurl }}/assets-styleguide/img/robust_example_standardshome.png" alt="U.S. Web Design Standards homepage example">
+                <img src="{{ site.baseurl }}/assets-styleguide/img/robust_example_standardshome.png" alt="U.S. Web Design Draft Standards homepage example">
               </a>
-              <a href="/">U.S. Web Design Standards homepage</a>
+              <a href="/">U.S. Web Design Draft Standards homepage</a>
             </p>
           </aside>
           <h6 class="usa-heading-alt">Web Hierarchy</h6>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -233,9 +233,9 @@ order: 01
             <h6 class="usa-heading-alt">Example</h6>
             <p>
               <a class="media_link" href="/">
-                <img src="{{ site.baseurl }}/assets-styleguide/img/robust_example_standardshome.png" alt="U.S. Web Design Draft Standards homepage example">
+                <img src="{{ site.baseurl }}/assets-styleguide/img/robust_example_standardshome.png" alt="Draft U.S. Web Design Standards homepage example">
               </a>
-              <a href="/">U.S. Web Design Draft Standards homepage</a>
+              <a href="/">Draft U.S. Web Design Standards homepage</a>
             </p>
           </aside>
           <h6 class="usa-heading-alt">Web Hierarchy</h6>

--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -51,6 +51,7 @@ p {
     background-position: right bottom;
     background-repeat: no-repeat;
     background-size: 582px auto;
+    padding-bottom: 6.8rem;
   }
   background-color: $color-primary-darkest;
   background-image: none;
@@ -94,7 +95,7 @@ p {
 }
 
 .usa-banner-content {
-  max-width: 48rem;
+  max-width: 52rem;
 }
 
 .usa-section-alt {

--- a/assets-styleguide/css/homepage.scss
+++ b/assets-styleguide/css/homepage.scss
@@ -51,7 +51,6 @@ p {
     background-position: right bottom;
     background-repeat: no-repeat;
     background-size: 582px auto;
-    padding-bottom: 6.8rem;
   }
   background-color: $color-primary-darkest;
   background-image: none;
@@ -59,6 +58,13 @@ p {
   padding: {
     bottom: 3.7rem;
     top: 2rem;
+  }
+
+  .usa-label {
+    display: table;
+    font-family: $font-sans;
+    font-weight: $font-normal;
+    margin-bottom: 1rem;
   }
 
   .usa-font-lead {
@@ -69,7 +75,7 @@ p {
   h1 {
     @include media($medium-screen) {
       font-size: 5.6rem;
-      padding-top: 4.5rem;
+      padding-top: 1.2rem;
     }
     color: $color-white;
     padding-top: 1.5rem;
@@ -95,7 +101,7 @@ p {
 }
 
 .usa-banner-content {
-  max-width: 52rem;
+  max-width: 48rem;
 }
 
 .usa-section-alt {

--- a/pages/about.html
+++ b/pages/about.html
@@ -6,9 +6,9 @@ title: About
 
 <p>Welcome to the alpha site for the Draft U.S. Web Design Standards.</p>
 
-<p><strong>Disclaimer: This site is actively under development.</strong> If you would like to make use of the Web Design Draft Standards and are having difficulty, please contact Mollie Ruskin at mruskin@omb.eop.gov.</p>
+<p><strong>Disclaimer: This site is actively under development.</strong> If you would like to make use of the Draft Web Design Standards and are having difficulty, please contact Mollie Ruskin at mruskin@omb.eop.gov.</p>
 
-<p>The Web Design Draft Standards are intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of government websites.</p>
+<p>The Draft Web Design Standards are intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of government websites.</p>
 
 <p>Your feedback is important to us. We encourage you to contribute your input at <a href="{{ site.repos[0].url }}/issues">{{ site.repos[0].url }}/issues</a>.</p>
 

--- a/pages/about.html
+++ b/pages/about.html
@@ -4,12 +4,12 @@ layout: styleguide
 title: About
 ---
 
-<p>Welcome to the alpha site for the U.S. Web Design Standards.</p>
+<p>Welcome to the alpha site for the U.S. Web Design Draft Standards.</p>
 
-<p><strong>Disclaimer: This site is actively under development.</strong> If you would like to make use of the Web Design Standards and are having difficulty, please contact Mollie Ruskin at mruskin@omb.eop.gov.</p>
+<p><strong>Disclaimer: This site is actively under development.</strong> If you would like to make use of the Web Design Draft Standards and are having difficulty, please contact Mollie Ruskin at mruskin@omb.eop.gov.</p>
 
-<p>The Web Design Standards are intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of government websites.</p>
+<p>The Web Design Draft Standards are intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of government websites.</p>
 
 <p>Your feedback is important to us. We encourage you to contribute your input at <a href="{{ site.repos[0].url }}/issues">{{ site.repos[0].url }}/issues</a>.</p>
 
-<p>The U.S. Web Design Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
+<p>The U.S. Web Design Draft Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>

--- a/pages/about.html
+++ b/pages/about.html
@@ -4,7 +4,7 @@ layout: styleguide
 title: About
 ---
 
-<p>Welcome to the alpha site for the U.S. Web Design Draft Standards.</p>
+<p>Welcome to the alpha site for the Draft U.S. Web Design Standards.</p>
 
 <p><strong>Disclaimer: This site is actively under development.</strong> If you would like to make use of the Web Design Draft Standards and are having difficulty, please contact Mollie Ruskin at mruskin@omb.eop.gov.</p>
 
@@ -12,4 +12,4 @@ title: About
 
 <p>Your feedback is important to us. We encourage you to contribute your input at <a href="{{ site.repos[0].url }}/issues">{{ site.repos[0].url }}/issues</a>.</p>
 
-<p>The U.S. Web Design Draft Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
+<p>The Draft U.S. Web Design Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>

--- a/pages/all.html
+++ b/pages/all.html
@@ -1,18 +1,18 @@
 ---
 permalink: /all/
 layout: styleguide
-title: U.S. Federal Web Design Standards
+title: U.S. Web Design Draft Standards
 ---
 
 <h1>About this Guide</h1>
 
-<p>Welcome to the alpha site for the U.S. Federal Web Design Standards project.</p>
+<p>Welcome to the alpha site for the U.S. Web Design Draft Standards project.</p>
 
-<p>This Web Design Standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
+<p>This Web Design Draft Standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
 
 <p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="{{ site.repos[0].url }}/issues">{{ site.repos[0].url }}/issues</a>.</p>
 
-<p>The U.S. Web Design Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
+<p>The U.S. Web Design Draft Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
 
 <h1>Visual Style</h1>
 

--- a/pages/all.html
+++ b/pages/all.html
@@ -8,7 +8,7 @@ title: Draft U.S. Web Design Standards
 
 <p>Welcome to the alpha site for the Draft U.S. Web Design Standards project.</p>
 
-<p>This Web Design Draft Standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
+<p>This Draft Web Design Standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
 
 <p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="{{ site.repos[0].url }}/issues">{{ site.repos[0].url }}/issues</a>.</p>
 

--- a/pages/all.html
+++ b/pages/all.html
@@ -1,18 +1,18 @@
 ---
 permalink: /all/
 layout: styleguide
-title: U.S. Web Design Draft Standards
+title: Draft U.S. Web Design Standards
 ---
 
 <h1>About this Guide</h1>
 
-<p>Welcome to the alpha site for the U.S. Web Design Draft Standards project.</p>
+<p>Welcome to the alpha site for the Draft U.S. Web Design Standards project.</p>
 
 <p>This Web Design Draft Standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
 
 <p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="{{ site.repos[0].url }}/issues">{{ site.repos[0].url }}/issues</a>.</p>
 
-<p>The U.S. Web Design Draft Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
+<p>The Draft U.S. Web Design Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
 
 <h1>Visual Style</h1>
 

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -2,7 +2,7 @@
 permalink: /getting-started/
 layout: styleguide
 title: Getting started
-lead: The U.S. Web Design Standards are designed to set a new bar for simplicity and consistency across government services, while providing you with plug-and-play design and code.
+lead: The U.S. Web Design Draft Standards are designed to set a new bar for simplicity and consistency across government services, while providing you with plug-and-play design and code.
 ---
 
 <p>Learn more about why designing consistent digital services matters in our <a href="https://18f.gsa.gov/2015/09/28/web-design-standards/">blog post introducing the standards</a>.</p>
@@ -52,11 +52,11 @@ lead: The U.S. Web Design Standards are designed to set a new bar for simplicity
 <p>As a complement to this visual style guidance, we strongly recommend you use <a href="https://pages.18f.gov/content-guide/">18F’s Content Guide</a> when writing language for government services.</p>
 
 <h4>UI components and patterns</h4>
-<p>The site contains HTML mockups of common UI components designed to follow the Web Design Standards' visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
+<p>The site contains HTML mockups of common UI components designed to follow the Web Design Draft Standards' visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
 <p>All of these designs are also available in a variety of design file formats for download:</p>
 <ul class="usa-content-list">
   <li><strong>Illustrator, EPS, Sketch, and OmniGraffle</strong> art files of each component and pattern on this site are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a></li>
   <li><strong>.AI and .ASE color swatches</strong> are available at: <a href="{{ site.repos[1].url }}/tree/master/Colors">{{ site.repos[1].url }}/tree/master/Colors</a></li>
-  <li><strong>.TTF files</strong> of the font families and weights we recommend are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a> (Note: all fonts used in the Web Design Standards are free, open source typefaces also available online).</li>
+  <li><strong>.TTF files</strong> of the font families and weights we recommend are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a> (Note: all fonts used in the Web Design Draft Standards are free, open source typefaces also available online).</li>
 </ul>
 <p>All of the designs meet the <a href="http://www.w3.org/TR/WCAG20/">WCAG 2.0 AA accessibility guidelines</a> and are compliant with <a href="http://www.section508.gov/">Section 508 of the Rehabilitation Act</a>. <strong>If you choose to customize them, ensure they continue to meet the requirements listed in the “Accessibility” section of each design.</strong></p>

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -52,11 +52,11 @@ lead: The Draft U.S. Web Design Standards are designed to set a new bar for simp
 <p>As a complement to this visual style guidance, we strongly recommend you use <a href="https://pages.18f.gov/content-guide/">18F’s Content Guide</a> when writing language for government services.</p>
 
 <h4>UI components and patterns</h4>
-<p>The site contains HTML mockups of common UI components designed to follow the Web Design Draft Standards' visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
+<p>The site contains HTML mockups of common UI components designed to follow the Draft Web Design Standards' visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
 <p>All of these designs are also available in a variety of design file formats for download:</p>
 <ul class="usa-content-list">
   <li><strong>Illustrator, EPS, Sketch, and OmniGraffle</strong> art files of each component and pattern on this site are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a></li>
   <li><strong>.AI and .ASE color swatches</strong> are available at: <a href="{{ site.repos[1].url }}/tree/master/Colors">{{ site.repos[1].url }}/tree/master/Colors</a></li>
-  <li><strong>.TTF files</strong> of the font families and weights we recommend are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a> (Note: all fonts used in the Web Design Draft Standards are free, open source typefaces also available online).</li>
+  <li><strong>.TTF files</strong> of the font families and weights we recommend are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a> (Note: all fonts used in the Draft Web Design Standards are free, open source typefaces also available online).</li>
 </ul>
 <p>All of the designs meet the <a href="http://www.w3.org/TR/WCAG20/">WCAG 2.0 AA accessibility guidelines</a> and are compliant with <a href="http://www.section508.gov/">Section 508 of the Rehabilitation Act</a>. <strong>If you choose to customize them, ensure they continue to meet the requirements listed in the “Accessibility” section of each design.</strong></p>

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -2,7 +2,7 @@
 permalink: /getting-started/
 layout: styleguide
 title: Getting started
-lead: The U.S. Web Design Draft Standards are designed to set a new bar for simplicity and consistency across government services, while providing you with plug-and-play design and code.
+lead: The Draft U.S. Web Design Standards are designed to set a new bar for simplicity and consistency across government services, while providing you with plug-and-play design and code.
 ---
 
 <p>Learn more about why designing consistent digital services matters in our <a href="https://18f.gsa.gov/2015/09/28/web-design-standards/">blog post introducing the standards</a>.</p>

--- a/pages/index.html
+++ b/pages/index.html
@@ -74,7 +74,7 @@ title: Draft U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro">
       <h2>How to use these tools</h2>
-      <h3 class="usa-font-lead">Use a little, use a lot, use it all.<br> Here’s how the web design draft standards may help you:</h3>
+      <h3 class="usa-font-lead">Use a little, use a lot, use it all.<br> Here’s how the draft web design standards may help you:</h3>
     </div>
   </div>
   <div class="usa-grid">
@@ -112,7 +112,7 @@ title: Draft U.S. Web Design Standards
         <img class="usa-img-circle"  src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_best_easiest_2x.png" alt="Make the best thing the easiest thing">
       </div>
       <h3 class="usa-graphic-list-heading">Make the best thing the easiest thing</h3>
-      <p class="usa-graphic-list-text">The web design draft standards are designed to provide designers and developers easy-to-use tools to most effectively deliver the highest quality government websites to the American people.</p>
+      <p class="usa-graphic-list-text">The draft web design standards are designed to provide designers and developers easy-to-use tools to most effectively deliver the highest quality government websites to the American people.</p>
     </div>
     <div class="usa-width-one-half usa-width-one-half-top">
       <div class="usa-circle-block">
@@ -148,7 +148,7 @@ title: Draft U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro">
       <h2>Examples</h2>
-      <h3 class="usa-font-lead">A few samples of the web design draft standards at work:</h3>
+      <h3 class="usa-font-lead">A few samples of the draft web design standards at work:</h3>
     </div>
   </div>
   <div class="usa-grid">
@@ -181,7 +181,7 @@ title: Draft U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro usa-standlast">
       <h2>Contribute</h2>
-      <p>The web design draft standards alpha was created during the summer of 2015 by designers and developers at the U.S. Digital Service and 18F. We will continue to maintain and update these resources as we learn what works best for the people we serve.</p>
+      <p>The draft web design standards alpha was created during the summer of 2015 by designers and developers at the U.S. Digital Service and 18F. We will continue to maintain and update these resources as we learn what works best for the people we serve.</p>
       <p>Help us make it better.</p>
     </div>
     <div class="usa-cta">

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,7 +1,7 @@
 ---
 permalink: /
 layout: homepage
-title: U.S. Web Design Standards
+title: U.S. Web Design Draft Standards
 ---
 
 <a class="skipnav" href="#main-content">Skip main navigation</a>
@@ -24,7 +24,7 @@ title: U.S. Web Design Standards
         <a class="usa-banner-link-top" href="{{ site.repos[0].url }}">View on GitHub</a>
       </nav>
       <div class="usa-banner-content" id="main-content">
-        <h1>U.S. Web Design Standards</h1>
+        <h1>U.S. Web Design Draft Standards</h1>
         <h2 class="usa-font-lead">Open source UI components and visual style guide to create consistency and beautiful user experiences across U.S. federal government websites</h2>
       </div>
         <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage splash');">View the standards</a>
@@ -74,7 +74,7 @@ title: U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro">
       <h2>How to use these tools</h2>
-      <h3 class="usa-font-lead">Use a little, use a lot, use it all.<br> Here’s how the web design standards may help you:</h3>
+      <h3 class="usa-font-lead">Use a little, use a lot, use it all.<br> Here’s how the web design draft standards may help you:</h3>
     </div>
   </div>
   <div class="usa-grid">
@@ -103,7 +103,7 @@ title: U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro">
       <h2>Principles</h2>
-      <h3 class="usa-font-lead">The U.S. Web Design Standards are designed to create better online experiences for the American people. These are the principles guiding these tools:</h3>
+      <h3 class="usa-font-lead">The U.S. Web Design Draft Standards are designed to create better online experiences for the American people. These are the principles guiding these tools:</h3>
     </div>
   </div>
   <div class="usa-grid">
@@ -112,7 +112,7 @@ title: U.S. Web Design Standards
         <img class="usa-img-circle"  src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_best_easiest_2x.png" alt="Make the best thing the easiest thing">
       </div>
       <h3 class="usa-graphic-list-heading">Make the best thing the easiest thing</h3>
-      <p class="usa-graphic-list-text">The web design standards are designed to provide designers and developers easy-to-use tools to most effectively deliver the highest quality government websites to the American people.</p>
+      <p class="usa-graphic-list-text">The web design draft standards are designed to provide designers and developers easy-to-use tools to most effectively deliver the highest quality government websites to the American people.</p>
     </div>
     <div class="usa-width-one-half usa-width-one-half-top">
       <div class="usa-circle-block">
@@ -148,7 +148,7 @@ title: U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro">
       <h2>Examples</h2>
-      <h3 class="usa-font-lead">A few samples of the web design standards at work:</h3>
+      <h3 class="usa-font-lead">A few samples of the web design draft standards at work:</h3>
     </div>
   </div>
   <div class="usa-grid">
@@ -181,7 +181,7 @@ title: U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro usa-standlast">
       <h2>Contribute</h2>
-      <p>The web design standards alpha was created during the summer of 2015 by designers and developers at the U.S. Digital Service and 18F. We will continue to maintain and update these resources as we learn what works best for the people we serve.</p>
+      <p>The web design draft standards alpha was created during the summer of 2015 by designers and developers at the U.S. Digital Service and 18F. We will continue to maintain and update these resources as we learn what works best for the people we serve.</p>
       <p>Help us make it better.</p>
     </div>
     <div class="usa-cta">

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,7 +1,7 @@
 ---
 permalink: /
 layout: homepage
-title: U.S. Web Design Draft Standards
+title: Draft U.S. Web Design Standards
 ---
 
 <a class="skipnav" href="#main-content">Skip main navigation</a>
@@ -24,7 +24,7 @@ title: U.S. Web Design Draft Standards
         <a class="usa-banner-link-top" href="{{ site.repos[0].url }}">View on GitHub</a>
       </nav>
       <div class="usa-banner-content" id="main-content">
-        <h1>U.S. Web Design Draft Standards</h1>
+        <h1>Draft U.S. Web Design Standards</h1>
         <h2 class="usa-font-lead">Open source UI components and visual style guide to create consistency and beautiful user experiences across U.S. federal government websites</h2>
       </div>
         <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage splash');">View the standards</a>
@@ -103,7 +103,7 @@ title: U.S. Web Design Draft Standards
   <div class="usa-grid">
     <div class="usa-intro">
       <h2>Principles</h2>
-      <h3 class="usa-font-lead">The U.S. Web Design Draft Standards are designed to create better online experiences for the American people. These are the principles guiding these tools:</h3>
+      <h3 class="usa-font-lead">The Draft U.S. Web Design Standards are designed to create better online experiences for the American people. These are the principles guiding these tools:</h3>
     </div>
   </div>
   <div class="usa-grid">

--- a/pages/index.html
+++ b/pages/index.html
@@ -24,7 +24,7 @@ title: Draft U.S. Web Design Standards
         <a class="usa-banner-link-top" href="{{ site.repos[0].url }}">View on GitHub</a>
       </nav>
       <div class="usa-banner-content" id="main-content">
-        <h1>Draft U.S. Web Design Standards</h1>
+        <h1><span class="usa-label">Draft</span>U.S. Web Design Standards</h1>
         <h2 class="usa-font-lead">Open source UI components and visual style guide to create consistency and beautiful user experiences across U.S. federal government websites</h2>
       </div>
         <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage splash');">View the standards</a>


### PR DESCRIPTION
This changes the name from U.S. Web Design Standards to Draft U.S. Web Design Standards.

This is what the homepage will look like:

<img width="1114" alt="screen shot 2015-12-02 at 2 40 53 pm" src="https://cloud.githubusercontent.com/assets/5249443/11546600/26b7c146-9903-11e5-911d-8f4199566131.png">
