### PR TITLE
Updated explanation in accessibility callout

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -119,7 +119,7 @@ title: U.S. Web Design Standards
         <img class="usa-img-circle" src="{{ site.baseurl }}/assets-styleguide/img/home/homepage_illustrations_508_box_2x.png" alt="Accessibility">
       </div>
       <h3 class="usa-graphic-list-heading">Accessibility out of the box</h3>
-      <p class="usa-graphic-list-text">These guidelines were built with a priority on accessibility at every step of the design process in conformance with Section 508 Standards. From colors to code, everything you need to meet high standards of accessibility are baked into these tools.</p>
+      <p class="usa-graphic-list-text">These guidelines focus on accessibility at every step of the design process, setting you on the path to building a usable, accessible site. From colors to code, these tools help you meet high standards of accessibility and conform to Section 508 Standards.</p>
     </div>
   </div>
   <div class="usa-grid">


### PR DESCRIPTION
Clarified the language under "Accessibility out of the box" to clarify, per #840: the standards help set folks on the right path to accessibility, but don't necessarily guarantee accessibility — people will need to continue being aware of accessibility as they change the code or create content.

I left the header as-is, because it's pretty clear. We can always revisit to make it a verb phrase.