### PR TITLE
Remove postinstall script, users will have to compile Sass on their own

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ If you have `node` installed on your machine, you can use `npm` to install the W
 
 On subsequent runs of `npm install`, the package will be installed in `node_modules` under `uswds`. The CSS will be *not* compiled after it is installed. Instead, you are able to compile it however it fits into your project.
 
-An `npm` task called `build-sass` is supplied, though you are not required to use it, that will compile the SASS to a CSS file named `uswds.css` (in `node_modules/uswds/assets/css/uswds.css`).
+An `npm` task called `build-sass` is supplied, though you are not required to use it, that will compile the Sass to a CSS file named `uswds.css` (in `node_modules/uswds/assets/css/uswds.css`).
 
-If you simply want to compile the SASS you could do something like:
+If you simply want to compile the Sass you could do something like:
 
 `cd node_modules/uswds && npm run build-sass`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ If you have `node` installed on your machine, you can use `npm` to install the W
   "uswds": "git@github.com:18F/web-design-standards.git#v0.9.0"
 ```
 
-On subsequent runs of `npm install`, the package will be installed in `node_modules` under `uswds`. The CSS will be compiled after it is installed, and the final CSS file will be named `uswds.css`. You should be able to find it in `node_modules/uswds/assets/css/uswds.css`.
+On subsequent runs of `npm install`, the package will be installed in `node_modules` under `uswds`. The CSS will be *not* compiled after it is installed. Instead, you are able to compile it however it fits into your project.
+
+An `npm` task called `build-sass` is supplied, though you are not required to use it, that will compile the SASS to a CSS file named `uswds.css` (in `node_modules/uswds/assets/css/uswds.css`).
+
+If you simply want to compile the SASS you could do something like:
+
+`cd node_modules/uswds && npm run build-sass`
 
 *Note:* You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "package.json",
   "scripts": {
-    "postinstall": "npm run build-sass",
     "build-sass": "node-sass assets/_scss/all.scss > assets/css/uswds.css",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I ran into a frustrating problem integrating the pattern library with Federalist, which also has a dependency on `node-sass`. When the pattern library would install, it wasn't assured that `node-sass` would be, but the `postinstall` script would still run. This would cause the `npm install` command issued within the Federalist project to fail, but on subsequent runs it would succeed.

I removed the postinstall script and updated the usage instructions. Now, users are free to compile the sass in whatever method they want. There is still the `build-sass` npm script for them to use, if they wish to do so. For instance, in Federalist we have a command like this to compile the pattern library:

`"uswds:css:sass": "cd node_modules/uswds && npm run build-sass && cd ../..",`

I think that the best way to do this is to use the `prepublish` script and publish compiled CSS to npm, but not commit it to Github.