### PR TITLE
Re-add items to config for linking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,14 @@ exclude:
 
 permalink: pretty
 
+repos:
+- name: Draft U.S. Web Design Standards
+  description: Main repository for the Draft U.S. Web Design Standards
+  url: https://github.com/18F/web-design-standards
+- name: Draft U.S. Web Design Standards Assets
+  description: Draft U.S. Web Design Standards visual design assets
+  url: https://github.com/18F/web-design-standards-assets
+
 google_analytics_ua: UA-48605964-33
 
 sass:


### PR DESCRIPTION
The site was keeping all web-design-standards URLs in sync via `_config.yml` and this was erroneously removed. This PR re-adds them so links to GitHub work again.