### PR TITLE
Fix list bullets on older systems

### DIFF
--- a/src/stylesheets/elements/_list.scss
+++ b/src/stylesheets/elements/_list.scss
@@ -31,7 +31,7 @@ ul li {
   display: table-row;
 
   &:before {
-    content: "•";
+    content: "\2022";
     display: table-cell;
     padding-right: 0.4em;
   }


### PR DESCRIPTION
The list bullet character ("•") in this file is non-ASCII. On older systems that are not set to a UTF-8 locale, this character will be rendered strangely.

This appears to be the only .scss file with non-ASCII characters that does not already have a charset declaration. The others are all in Bourbon or Neat. (grep -rlP '[^\x00-\x7f]' . | grep scss | xargs head -n 1)