### PR TITLE
Enable npm packaging, including .css and .scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "assets/js/components.js",
   "scripts": {
     "build-sass": "node-sass assets/_scss/all.scss > assets/css/uswds.css",
-    "prepublish": "npm run build-sass build"
+    "prepublish": "npm run build-sass"
   },
   "assets": "assets/",
+  "style": "assets/css/uswds.css",
   "css": "assets/css/uswds.css",
   "scss": "assets/_scss/all.scss",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "uswds",
   "version": "0.9.0",
   "description": "Open source UI components and visual style guide for U.S. government websites",
-  "main": "package.json",
+  "main": "assets/js/components.js",
   "scripts": {
     "build-sass": "node-sass assets/_scss/all.scss > assets/css/uswds.css",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "prepublish": "npm run build-sass build"
   },
   "assets": "assets/",
-  "scss": "assets/_scss",
+  "css": "assets/css/uswds.css",
+  "scss": "assets/_scss/all.scss",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/18F/web-design-standards.git"


### PR DESCRIPTION
Per the discussion on #925. Still needs documentation regarding how to use the `css` and `scss` keys. For reference, here's some source material for the forthcoming documentation:

- http://stackoverflow.com/questions/32037150/style-field-in-package-json
- http://techwraith.com/your-css-needs-a-dependency-graph-too/
- https://www.npmjs.com/package/rework-npm
- https://www.npmjs.com/package/resin
- https://www.npmjs.com/package/parcelify

cc: @maya @msecret @jeremiak 