### PR TITLE
_footer.scss uses $medium instead of $medium-screen

### DIFF
--- a/assets/_scss/components/_footer.scss
+++ b/assets/_scss/components/_footer.scss
@@ -56,7 +56,7 @@
 }
 
 .width-one-sixth {
-  @include media($medium) {
+  @include media($medium-screen) {
     @include span-columns(2);
   }  
 }


### PR DESCRIPTION
The current version of the file generates a final CSS snippet of 

```css
@media screen and (min-width: min-width 600px 6) {
  .width-one-sixth {
    float: left;
    display: block;
    margin-right: 2.35765%;
    width: 14.70196%; }
    .width-one-sixth:last-child {
      margin-right: 0; } }
```

The problematic part is the `min-width: min-width 600px 6`. Changing `$medium` to `$medium-screen` makes it `min-width: 600px`. I admit that I am new to SCSS programming, but that seems like the right thing by analogy to the other calls.