### PR TITLE
Publishing `uswds` package to NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ node_modules/
 .DS_store
 .*.swp
 npm-debug.log
+
+# Ignore generated files
+#
+assets/css/uswds.css

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site/
 node_modules/
 .DS_store
 .*.swp
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+_components/
+_elements/
+_includes/
+_layout-system/
+_layouts/
+_visual/
+assets-styleguide/
+pages/
+.ruby-version
+.travis.yml
+_config.yml
+_config_18f_pages.yml
+Gemfile
+Gemfile.lock
+go
+

--- a/.npmignore
+++ b/.npmignore
@@ -1,13 +1,23 @@
+# Jekyll files and directories
+#
 _components/
 _elements/
 _includes/
 _layout-system/
 _layouts/
 _visual/
+pages/
 assets-styleguide/
 assets/css/styelguide.css
+assets/css/main.scss
+assets/css/main.css
+
+# Releases
+#
 assets/releases/
-pages/
+
+# Configuration and scripts
+#
 .ruby-version
 .travis.yml
 _config.yml

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ _layouts/
 _visual/
 assets-styleguide/
 assets/css/styelguide.css
+assets/releases/
 pages/
 .ruby-version
 .travis.yml

--- a/.npmignore
+++ b/.npmignore
@@ -1,20 +1,11 @@
 # Jekyll files and directories
 #
-_components/
-_elements/
-_includes/
-_layout-system/
-_layouts/
-_visual/
-pages/
-assets-styleguide/
-assets/css/styelguide.css
-assets/css/main.scss
-assets/css/main.css
+docs/
+_site/
 
-# Releases
+# Gem releases
 #
-assets/releases/
+dist-gem/
 
 # Configuration and scripts
 #
@@ -22,7 +13,14 @@ assets/releases/
 .travis.yml
 _config.yml
 _config_18f_pages.yml
+.scss-lint.yml
 Gemfile
 Gemfile.lock
 go
+.sass-cache/
+.bundle/
 
+# Ensure that src and dist are published
+#
+!dist/
+!src/

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ _layout-system/
 _layouts/
 _visual/
 assets-styleguide/
+assets/css/styelguide.css
 pages/
 .ruby-version
 .travis.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,9 @@ If you have a clone of this repository locally and would like to use it on
 another project without using the published version, you can use `npm link`.
 
 **Please note** that this use case is primarily useful if you're developing on the
-Web Design Standards locally and would like to see those changes in another
+Draft Web Design Standards locally and would like to see those changes in another
 project that is using them. Using `npm link` _should not be done_ if you are using
-a release version of the Web Design Standards. Please follow the `npm install`
+a release version of the Draft Web Design Standards. Please follow the `npm install`
 instructions above if you are using a release version.
 
 The following commands will link your local `web-design-standards` project to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,7 @@ another project without using the published version, you can use `npm link`.
 
 **Please note** that this use case is primarily useful if you're developing on the
 Draft Web Design Standards locally and would like to see those changes in another
-project that is using them. Using `npm link` _should not be done_ if you are using
-a release version of the Draft Web Design Standards. Please follow the `npm install`
-instructions above if you are using a release version.
+project that is using them.
 
 The following commands will link your local `web-design-standards` project to
 another project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,26 +70,6 @@ contents of the `web-design-standards` project under `node_modules/uswds` within
 the `project-using-npm`. For more information on `npm-link`, you can read about
 it in the [`npm-link` documentation](https://docs.npmjs.com/cli/link).
 
-### Using `uswds` with `npm`
-
-With the `uswds` package installed in your `node_modules` directory, you can
-access various included dependencies from the package itself.
-
-Running `require( 'uswds' )` will include the contents of the `components.js`
-file in your project. This file does not export currently export anything so it
-doesn't need to be assigned to a variable. This library depends on `jQuery` and
-`$` to be on the `window` object before it is required. So please be sure that
-you include the jQuery dependency from the `uswds` package before `components.js`
-is loaded via the `require()` statement.
-
-```html
-<script src="./node_modules/uswds/assets/js/vendor/jquery-1.11.3.min.js"></script>
-<!-- Loading the components.js file directly from the package -->
-<script src="./node_modules/uswds/assets/js/components.js"></script>
-<!-- Or loading the components.js file via `require()` within your project's npm-asset-pipeline -->
-<script src="path/to/project/all.js"></script>
-```
-
 ## Licenses and attribution
 
 ### A few parts of this project are not in the public domain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We're so glad you're thinking about contributing to an 18F open source project! 
 
 We want to ensure a welcoming environment for all of our projects. Our staff follows the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
 
-We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md). 
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
 
 If you have any questions or want to read more, check out the [18F Open Source Policy GitHub repository]( https://github.com/18f/open-source-policy), or just [shoot us an email](mailto:18f@gsa.gov).
 
@@ -36,13 +36,61 @@ To help us get a better understanding of the issue you are submitting, please le
 Here are a few guidelines to follow when submitting a pull request:
 
 1. Create a GitHub account or sign in to your existing account.
-2. Fork this repo into your GitHub account (or just clone it if you're an 18F team member). Read more about forking a repo here on GitHub:
+1. Fork this repo into your GitHub account (or just clone it if you're an 18F team member). Read more about forking a repo here on GitHub:
 [https://help.github.com/articles/fork-a-repo/](https://help.github.com/articles/fork-a-repo/)
-3. Create a branch that lightly defines what you're working on (e.g. add-styles).
-4. Once you're ready to submit a pull request, push your branch up to the repo.
-5. Submit your pull request against the `18f-pages-staging` branch.
+1. Create a branch that lightly defines what you're working on (e.g. add-styles).
+1. Ensure that your contribution works via `npm`, if applicable. See below under
+   _Install the package locally via `npm-link`_.
+1. Once you're ready to submit a pull request, push your branch up to the repo.
+1. Submit your pull request against the `18f-pages-staging` branch.
 
 Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
+
+## Install the package locally via `npm-link`
+
+If you have a clone of this repository locally and would like to use it on
+another project without using the published version, you can use `npm link`.
+
+**Please note** that this use case is primarily useful if you're developing on the
+Web Design Standards locally and would like to see those changes in another
+project that is using them. Using `npm link` _should not be done_ if you are using
+a release version of the Web Design Standards. Please follow the `npm install`
+instructions above if you are using a release version.
+
+The following commands will link your local `web-design-standards` project to
+another project.
+
+```
+cd path/to/web-design-standards # note: your paths will differ
+npm link
+cd path/to/another/project-using-npm # note: this project name is reused below
+npm link uswds
+```
+
+The `node_modules` directory in your project will contain a symbolic link of the
+contents of the `web-design-standards` project under `node_modules/uswds` within
+the `project-using-npm`. For more information on `npm-link`, you can read about
+it in the [`npm-link` documentation](https://docs.npmjs.com/cli/link).
+
+### Using `uswds` with `npm`
+
+With the `uswds` package installed in your `node_modules` directory, you can
+access various included dependencies from the package itself.
+
+Running `require( 'uswds' )` will include the contents of the `components.js`
+file in your project. This file does not export currently export anything so it
+doesn't need to be assigned to a variable. This library depends on `jQuery` and
+`$` to be on the `window` object before it is required. So please be sure that
+you include the jQuery dependency from the `uswds` package before `components.js`
+is loaded via the `require()` statement.
+
+```html
+<script src="./node_modules/uswds/assets/js/vendor/jquery-1.11.3.min.js"></script>
+<!-- Loading the components.js file directly from the package -->
+<script src="./node_modules/uswds/assets/js/components.js"></script>
+<!-- Or loading the components.js file via `require()` within your project's npm-asset-pipeline -->
+<script src="path/to/project/all.js"></script>
+```
 
 ## Licenses and attribution
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,8 @@ npm install --save uswds
 This will add the Draft Web Design Standards as a dependency for your project and save
 it to your `package.json` file. The package will be installed in `node_modules`
 under `uswds`. The CSS file(s) are generated on the `npm-prepublish` hook and can
-found in the following directory: `./node_modules/uswds/assets/css`.
-
-An `npm` task called `build-sass` is supplied, though you are not required to
-use it, that will compile the Sass to a CSS file named `uswds.css` (in
-`node_modules/uswds/assets/css/uswds.css`).
+found in the following directory `./node_modules/uswds/assets/css` once the
+package is installed.
 
 Note: You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.
 This error is related to a dependency found in `node-sass`.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ contents of the `web-design-standards` project under `node_modules/uswds` within
 the `project-using-npm`. For more information on `npm-link`, you can read about
 it in the [`npm-link` documentation](https://docs.npmjs.com/cli/link).
 
+##### Using `uswds` with `npm`
+
+With the `uswds` package installed in your `node_modules` directory, you can
+access various included dependencies from the package itself.
+
+Running `require( 'uswds' )` will include the contents of the `components.js`
+file in your project. This file does not export currently export anything so it
+doesn't need to be assigned to a variable. This library depends on `jQuery` and
+`$` to be on the `window` object before it is required. So please be sure that
+you include the jQuery dependency from the `uswds` package before `components.js`
+is loaded via the `require()` statement.
+
+```html
+<script src="./node_modules/uswds/assets/js/vendor/jquery-1.11.3.min.js"></script>
+<!-- Loading the components.js file directly from the package -->
+<script src="./node_modules/uswds/assets/js/components.js"></script>
+<!-- Or loading the components.js file via `require()` within your project's npm-asset-pipeline -->
+<script src="path/to/project/all.js"></script>
+```
+
 ## Setup for your local environment
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -42,21 +42,51 @@ Refer to these files by adding a `<link>` and a `<script>` element into your HTM
 
 ### Install with NPM
 
-If you have `node` installed on your machine, you can use `npm` to install the Web Design Standards. In your `package.json` list the following under `dependencies`:
+If you have `node` installed on your machine, you can use `npm` to install the
+Web Design Standards.
 
-```json
-  "uswds": "git@github.com:18F/web-design-standards.git#v0.8.3"
+```shell
+cd path/to/project-using-npm
+npm install --save uswds
 ```
 
-On subsequent runs of `npm install`, the package will be installed in `node_modules` under `uswds`. The CSS will be *not* compiled after it is installed. Instead, you are able to compile it however it fits into your project.
+This will add the Web Design Standards as a dependency for your project and save
+it to your `package.json` file. The package will be installed in `node_modules`
+under `uswds`. The CSS file(s) are generated on the `npm-prepublish` hook and can
+found in the following directory: `./node_modules/uswds/assets/css`.
 
-An `npm` task called `build-sass` is supplied, though you are not required to use it, that will compile the Sass to a CSS file named `uswds.css` (in `node_modules/uswds/assets/css/uswds.css`).
-
-If you simply want to compile the Sass you could do something like:
-
-`cd node_modules/uswds && npm run build-sass`
+An `npm` task called `build-sass` is supplied, though you are not required to
+use it, that will compile the Sass to a CSS file named `uswds.css` (in
+`node_modules/uswds/assets/css/uswds.css`).
 
 Note: You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.
+This error is related to a dependency found in `node-sass`.
+
+#### Install with `npm-link`
+
+If you have a clone of this repository locally and would like to use it on
+another project without using the published version, you can use `npm link`.
+
+**Please note** that this use case is primarily useful if you're developing on the
+Web Design Standards locally and would like to see those changes in another
+project that is using them. Using `npm link` _should not be done_ if you are using
+a release version of the Web Design Standards. Please follow the `npm install`
+instructions above if you are using a release version.
+
+The following commands will link your local `web-design-standards` project to
+another project.
+
+```
+cd path/to/web-design-standards # note: your paths will differ
+npm link
+cd path/to/another/project-using-npm # note: this project name is reused below
+npm link uswds
+```
+
+The `node_modules` directory in your project will contain a symbolic link of the
+contents of the `web-design-standards` project under `node_modules/uswds` within
+the `project-using-npm`. For more information on `npm-link`, you can read about
+it in the [`npm-link` documentation](https://docs.npmjs.com/cli/link).
 
 ## Setup for your local environment
 

--- a/README.md
+++ b/README.md
@@ -62,52 +62,6 @@ use it, that will compile the Sass to a CSS file named `uswds.css` (in
 Note: You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.
 This error is related to a dependency found in `node-sass`.
 
-#### Install with `npm-link`
-
-If you have a clone of this repository locally and would like to use it on
-another project without using the published version, you can use `npm link`.
-
-**Please note** that this use case is primarily useful if you're developing on the
-Web Design Standards locally and would like to see those changes in another
-project that is using them. Using `npm link` _should not be done_ if you are using
-a release version of the Web Design Standards. Please follow the `npm install`
-instructions above if you are using a release version.
-
-The following commands will link your local `web-design-standards` project to
-another project.
-
-```
-cd path/to/web-design-standards # note: your paths will differ
-npm link
-cd path/to/another/project-using-npm # note: this project name is reused below
-npm link uswds
-```
-
-The `node_modules` directory in your project will contain a symbolic link of the
-contents of the `web-design-standards` project under `node_modules/uswds` within
-the `project-using-npm`. For more information on `npm-link`, you can read about
-it in the [`npm-link` documentation](https://docs.npmjs.com/cli/link).
-
-##### Using `uswds` with `npm`
-
-With the `uswds` package installed in your `node_modules` directory, you can
-access various included dependencies from the package itself.
-
-Running `require( 'uswds' )` will include the contents of the `components.js`
-file in your project. This file does not export currently export anything so it
-doesn't need to be assigned to a variable. This library depends on `jQuery` and
-`$` to be on the `window` object before it is required. So please be sure that
-you include the jQuery dependency from the `uswds` package before `components.js`
-is loaded via the `require()` statement.
-
-```html
-<script src="./node_modules/uswds/assets/js/vendor/jquery-1.11.3.min.js"></script>
-<!-- Loading the components.js file directly from the package -->
-<script src="./node_modules/uswds/assets/js/components.js"></script>
-<!-- Or loading the components.js file via `require()` within your project's npm-asset-pipeline -->
-<script src="path/to/project/all.js"></script>
-```
-
 ## Setup for your local environment
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -52,9 +52,15 @@ npm install --save uswds
 
 This will add the Draft Web Design Standards as a dependency for your project and save
 it to your `package.json` file. The package will be installed in `node_modules`
-under `uswds`. The CSS file(s) are generated on the `npm-prepublish` hook and can
-found in the following directory `./node_modules/uswds/assets/css` once the
-package is installed.
+under `uswds`.
+
+Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
+
+```
+<link rel="stylesheet" href="./node_modules/uswds/assets/css/uswds.css">
+<link rel="stylesheet" href="./node_modules/uswds/assets/css/google-fonts.css">
+<script src="./node_modules/uswds/assets/js/components.js"></script>
+```
 
 Note: You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.
 This error is related to a dependency found in `node-sass`.

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Refer to these files by adding a `<link>` and a `<script>` element into your HTM
 ### Install with NPM
 
 If you have `node` installed on your machine, you can use `npm` to install the
-Web Design Standards.
+Draft Web Design Standards.
 
 ```shell
 cd path/to/project-using-npm
 npm install --save uswds
 ```
 
-This will add the Web Design Standards as a dependency for your project and save
+This will add the Draft Web Design Standards as a dependency for your project and save
 it to your `package.json` file. The package will be installed in `node_modules`
 under `uswds`. The CSS file(s) are generated on the `npm-prepublish` hook and can
 found in the following directory: `./node_modules/uswds/assets/css`.

--- a/README.md
+++ b/README.md
@@ -50,17 +50,35 @@ cd path/to/project-using-npm
 npm install --save uswds
 ```
 
-This will add the Draft Web Design Standards as a dependency for your project and save
-it to your `package.json` file. The package will be installed in `node_modules`
+This will add the Draft Web Design Standards as a dependency for your project and
+save it to your `package.json` file. The package will be installed in `node_modules`
 under `uswds`.
 
-Refer to these files by adding a `<link>` and a `<script>` element into your HTML pages:
+Refer to these files by adding a `<link>` and a `<script>` element into your
+HTML pages:
 
+If your project _does not_ already include jQuery please use the version of
+jQuery that is included in the package.
+
+```html
+<!-- CSS Includes -->
+<link rel="stylesheet" href="./node_modules/uswds/assets/css/google-fonts.css">
+<link rel="stylesheet" href="./node_modules/uswds/assets/css/uswds.css">
+
+<!-- JavaScript Includes -->
+<script src="./node_modules/uswds/assets/js/vendor/jquery-1.11.3.min.js"></script>
+<script src="./node_modules/uswds/assets/js/components.js"></script>
 ```
+
+If your project already includes jQuery via a script tag, feel free to use that
+version of jQuery.
+
+```html
+<!-- CSS Includes -->
 <link rel="stylesheet" href="./node_modules/uswds/assets/css/uswds.css">
 <link rel="stylesheet" href="./node_modules/uswds/assets/css/google-fonts.css">
-<!-- Include jQuery from the `uswds` project before `components.js` -->
-<script src="./node_modules/uswds/assets/js/vendor/jquery-1.11.3.min.js"></script>
+
+<!-- JavaScript Includes -->
 <script src="./node_modules/uswds/assets/js/components.js"></script>
 ```
 
@@ -74,8 +92,8 @@ Running `require( 'uswds' )` will include the contents of the `components.js`
 file in your project. This file does not export currently export anything so it
 doesn't need to be assigned to a variable. This library depends on `jQuery` and
 `$` to be on the `window` object before it is required. So please be sure that
-you include the jQuery dependency from the `uswds` package before `components.js`
-is loaded via the `require()` statement.
+you include the jQuery dependency on your HTML page or via `npm` and set it to
+the `window` object as `jQuery` and `$`.
 
 ```js
 window.$ = window.jQuery = require( 'jquery' );
@@ -88,6 +106,19 @@ your main Sass file like so:
 
 ```scss
 @import './node_modules/uswds/assets/_scss/all.scss';
+```
+
+Your HTML file may be structured like this:
+
+```html
+<!-- CSS Includes -->
+<link rel="stylesheet" href="./node_modules/uswds/assets/css/google-fonts.css">
+
+<!-- Your compiled CSS, which imports the Draft Web Design Standards -->
+<link rel="stylesheet" href="./path/to/assets/style.css">
+
+<!-- Your compiled JavaScript, which creates jQuery on the `window` object. -->
+<script src="./path/to/assets/start-app.js"></script>
 ```
 
 Note: You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,35 @@ Refer to these files by adding a `<link>` and a `<script>` element into your HTM
 ```
 <link rel="stylesheet" href="./node_modules/uswds/assets/css/uswds.css">
 <link rel="stylesheet" href="./node_modules/uswds/assets/css/google-fonts.css">
+<!-- Include jQuery from the `uswds` project before `components.js` -->
+<script src="./node_modules/uswds/assets/js/vendor/jquery-1.11.3.min.js"></script>
 <script src="./node_modules/uswds/assets/js/components.js"></script>
+```
+
+#### Using `uswds` with an `npm`-based asset pipeline
+
+With the `uswds` package installed in your `node_modules` directory, you can
+access various included dependencies from the package itself. These dependencies
+include both JavaScript and Sass files.
+
+Running `require( 'uswds' )` will include the contents of the `components.js`
+file in your project. This file does not export currently export anything so it
+doesn't need to be assigned to a variable. This library depends on `jQuery` and
+`$` to be on the `window` object before it is required. So please be sure that
+you include the jQuery dependency from the `uswds` package before `components.js`
+is loaded via the `require()` statement.
+
+```js
+window.$ = window.jQuery = require( 'jquery' );
+require( 'uswds' );
+// ...
+```
+
+To use the styles from the Draft Web Design Standards you can import it into
+your main Sass file like so:
+
+```scss
+@import './node_modules/uswds/assets/_scss/all.scss';
 ```
 
 Note: You might get an [`npm` warning related to `lodash`](https://github.com/18F/web-design-standards/pull/902#issuecomment-161076213), but you can generally ignore it.

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "prepublish": "npm run build-sass"
   },
   "assets": "assets/",
-  "style": "assets/css/uswds.css",
-  "css": "assets/css/uswds.css",
-  "scss": "assets/_scss/all.scss",
+  "style": "assets/_scss/all.scss",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/18F/web-design-standards.git"


### PR DESCRIPTION
This series of patches updates the documentation around installing the `uswds` package via NPM. It include instructions about how to use the package _in it's current state_ with an `npm`-based asset pipeline and how to also use the package with static HTML files. There are instructions and caveats pointed out around dependencies.

This change does not need to be merged / released on to `18f-pages` / production because it doesn't affect the website. It must be merged onto `18f-pages-staging` as that is the default branch for the project. The documentation that user's will see when they navigate to our repository via `npmjs.org` will need to match what gets published to the `npm` registry.

The version number for the package will also need to be updated. I would consider this a patch version update because the are no changes to the actual code but rather the documentation. The minor version update should happen when the updates concerning splitting the repository and dependency management / documentation is merged in the project.

> https://trello.com/c/4MWOWON6/30-as-a-master-builder-i-want-to-be-able-to-install-the-web-design-standards-easily-into-my-project