### PR TITLE
Add scss-lint

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,145 @@
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+  BorderZero:
+    enabled: false
+    convention: zero
+  ColorKeyword:
+    enabled: true
+    severity: warning
+  ColorVariable:
+    enabled: true
+  Comment:
+    enabled: true
+  DebugStatement:
+    enabled: true
+  DeclarationOrder:
+    enabled: false
+  DuplicateProperty:
+    enabled: true
+  ElsePlacement:
+    enabled: true
+    style: same_line
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+  EmptyRule:
+    enabled: true
+  FinalNewline:
+    enabled: true
+    present: true
+  HexLength:
+    enabled: false
+    style: short
+  HexNotation:
+    enabled: true
+    style: lowercase
+  HexValidation:
+    enabled: true
+  IdSelector:
+    enabled: true
+  ImportantRule:
+    enabled: true
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space
+    width: 2
+  LeadingZero:
+    enabled: false
+    style: include_zero
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+  NestingDepth:
+    enabled: true
+    max_depth: 4
+    severity: warning
+  PlaceholderInExtend:
+    enabled: false
+  PropertyCount:
+    enabled: true
+    include_nested: false
+    max_properties: 10
+  PropertySortOrder:
+    enabled: false
+    ignore_unspecified: false
+    severity: warning
+    separate_groups: false
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+    severity: warning
+  SelectorDepth:
+    enabled: true
+    max_depth: 2
+    severity: warning
+  SelectorFormat:
+    enabled: false # strict_BEM doesn't seem to be supported by Hound
+    convention: strict_BEM
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2]
+    severity: warning
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+  SingleLinePerSelector:
+    enabled: true
+  SpaceAfterComma:
+    enabled: true
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space
+  SpaceAfterPropertyName:
+    enabled: true
+  SpaceBeforeBrace:
+    enabled: true
+    style: space
+    allow_single_line_padding: false
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+  StringQuotes:
+    enabled: true
+    style: single_quotes
+  TrailingSemicolon:
+    enabled: true
+  TrailingZero:
+    enabled: false
+  UnnecessaryMantissa:
+    enabled: true
+  UnnecessaryParentReference:
+    enabled: true
+  UrlFormat:
+    enabled: true
+  UrlQuotes:
+    enabled: true
+  VariableForProperty:
+    enabled: false
+    properties: []
+  VendorPrefixes:
+    enabled: true
+    identifier_list: bourbon
+    include: []
+    exclude: []
+  ZeroUnit:
+    enabled: true
+    severity: warning
+  Compass::PropertyWithMixin:
+    enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,3 +1,6 @@
+scss_files: 'assets/_scss/**/*.scss'
+exclude: 'assets/_scss/lib/**'
+
 linters:
   BangFormat:
     enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'rouge', '1.9'
 gem 'redcarpet'
 
 gem 'go_script'
+
+gem 'scss_lint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
+    rake (10.5.0)
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -62,6 +63,9 @@ GEM
     rouge (1.9.0)
     safe_yaml (1.0.4)
     sass (3.4.16)
+    scss_lint (0.44.0)
+      rake (~> 10.0)
+      sass (~> 3.4.15)
     timers (4.0.1)
       hitimes
     toml (0.1.2)
@@ -77,6 +81,7 @@ DEPENDENCIES
   json
   redcarpet
   rouge (= 1.9)
+  scss_lint
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ and view the draft web design standards locally.
 
 Questions or need help with setup? Did you run into any weird errors while following these instructions? Feel free to open an issue here: [https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
 
+### Linting
+
+```shell
+$ scss-lint
+```
+
+By default this will run scss-lint on `assets/_scss` (except `lib/`) and return all warnings or errors. Errors must be fixed before code can be committed, but ideally try to fix warnings as well.
+
+You can also run scss-lint on other files:
+
+```shell
+$ scss-lint assets/css/styleguide.scss
+```
+
+Note, however, that scss-lint is not compatible with Jekyll's front matter, so you'll need to remove the following code (temporarily) before running scss-lint on files that contain it:
+
+```ruby
+---
+---
+```
+
 ## Contributing to the code base
 
 See [CONTRIBUTING](CONTRIBUTING.md).

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -57,7 +57,7 @@ $color-gold-light:           #f9c642; //  lighten($color-gold, 20%)
 $color-gold-lighter:         #fad980; //  lighten($color-gold, 60%)
 $color-gold-lightest:        #fff1d2; //  lighten($color-gold, 83%)
 
-$color-green:                #2e8540;  
+$color-green:                #2e8540;
 $color-green-light:          #4aa564; // lighten($color-green, 20%)
 $color-green-lighter:        #94bfa2; // lighten($color-green, 60%)
 $color-green-lightest:       #e7f4e4; // lighten($color-green, 60%)

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -40,6 +40,7 @@ $color-secondary-lightest:   #f9dede; // lighten($color-secondary, 90%)
 
 $color-white:                #ffffff;
 $color-base:                 #212121;
+$color-black:                #000000;
 
 $color-gray-dark:            #323a45;
 $color-gray:                 #5b616b; // lighten($color-gray-dark, 20%)

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -160,7 +160,7 @@ $site-top:           124px;
     @include position(fixed, 0 auto 0 0);
     @include size($sliding-panel-width 100%);
     @include transform(translateX(- $sliding-panel-width));
-    background: #fff;
+    background: $color-white;
     -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     z-index: 999999;
@@ -176,7 +176,7 @@ $site-top:           124px;
 .overlay {
   @include position(fixed, 0 0 0 0);
   @include transition;
-  background: #000;
+  background: $color-black;
   opacity: 0;
   visibility: hidden;
   z-index: 9999;
@@ -322,13 +322,13 @@ $site-top:           124px;
 
 .preview {
   @include clearfix();
-  background-color: #fff;
+  background-color: $color-white;
   margin: {
     top: 2em;
     bottom: 2em;
   }
   padding: 1em $site-margins;
-  border: 1px solid #eeeeee;
+  border: 1px solid $color-gray-warm-light;
 
   .is-peripheral {
     opacity: .2;
@@ -470,7 +470,7 @@ $site-top:           124px;
 
     > * {
       background: $color-grid-light;
-      color: #000;
+      color: $color-black;
     }
 
     h3 {
@@ -504,7 +504,7 @@ h3 + .button_wrapper {
 }
 
 .button_wrapper-dark {
-  background: #323a45
+  background: $color-gray-dark;
 }
 
 .usa-heading {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -22,7 +22,7 @@ $site-top:           124px;
   top: 0;
   width: 100%;
   z-index: 1;
-  
+
   a {
     border-bottom: none;
   }
@@ -35,15 +35,17 @@ $site-top:           124px;
         top: 2.7rem;
       }
     }
+
     margin-top: 4px;
 
     .logo {
       @include media($medium-screen + $width-nav-sidebar) {
         padding-left: $site-margins;
-        text-align: left; 
+        text-align: left;
         padding-top: 0;
         width: auto;
       }
+
       float: left;
       text-align: center;
       padding-top: 1.3rem;
@@ -65,6 +67,7 @@ $site-top:           124px;
         font-size: $h3-font-size;
         margin-top: .9rem;
       }
+
       margin: 0;
       font-size: $h5-font-size;
     }
@@ -74,12 +77,13 @@ $site-top:           124px;
         display: block;
         padding-right: $site-margins;
       }
+
       float: right;
       display: none;
       margin-top: -5px;
-      
-      li { 
-        display: inline; 
+
+      li {
+        display: inline;
         font-family: $font-sans;
 
         &:last-child .usa-button {
@@ -96,21 +100,25 @@ $site-top:           124px;
     font-size: $base-font-size / 1.25;
     border-bottom: 1px solid #616161;
     font-weight: 100;
-    .us-official { 
+
+    .us-official {
       margin: 0;
     }
+
     .stage {
       a { text-decoration: underline; }
       float: none;
       display: block;
       padding-top: 5px;
     }
+
     @include media($medium-screen + $width-nav-sidebar) {
-      .us-official { 
-        margin-left: 177px; 
+      .us-official {
+        margin-left: 177px;
       }
-      .stage { 
-        float: right; 
+
+      .stage {
+        float: right;
         padding: 0;
       }
     }
@@ -122,6 +130,7 @@ $site-top:           124px;
   @include media($medium-screen + $width-nav-sidebar) {
     display: none;
   }
+
   display: inline;
   float: left;
   margin-top: -4px;
@@ -138,7 +147,7 @@ $site-top:           124px;
     color: $color-white;
     background-color: $color-primary-darker;
   }
-  
+
   &:visited {
     color: $color-white;
   }
@@ -156,6 +165,7 @@ $site-top:           124px;
     overflow-y: auto;
     z-index: 999999;
     display: block;
+
     &.is-visible {
       @include transition(all 0.25s linear);
       @include transform(translateX(0));
@@ -191,7 +201,7 @@ $site-top:           124px;
   overflow: auto;
   display: none;
   z-index: -1;
-  
+
   .lt-ie9 & {
     width: 25%;
   }
@@ -207,7 +217,7 @@ $site-top:           124px;
 
 .visual-style .sidenav .visual-style-sublist {
   display: block;
-  
+
   ul {
     display: block;
   }
@@ -223,7 +233,7 @@ $site-top:           124px;
 
 .footers .sidenav .footers-sublist {
   display: block;
-} 
+}
 
 // Main Content --------- //
 
@@ -231,6 +241,7 @@ $site-top:           124px;
   @include media($medium-screen) {
     top: $site-top;
   }
+
   position: absolute;
   top: 4rem;
   bottom: 0;
@@ -238,8 +249,6 @@ $site-top:           124px;
   width: 100%;
   padding: {
     bottom: 0;
-//    left: 2em;
-//    right: 2em;
     top: 1em;
   }
   z-index: -1;
@@ -268,10 +277,12 @@ $site-top:           124px;
 
   > h1 {
     margin-top: 3.4rem;
+
     &:not(:first-child) {
       margin-top: 1.5em;
     }
   }
+
   @media (min-width: $medium-screen + $width-nav-sidebar) {
     padding: {
       left: 3em;
@@ -289,13 +300,15 @@ $site-top:           124px;
     top: 3rem;
   }
 
-// This is a styleguide-only rule and is not needed in the main library code for 
-// the footer component which uses different styles
-// TODO investigate why it's not needed in the main library CSS
-  p, a {
+  // This is a styleguide-only rule and is not needed in the main library code for
+  // the footer component which uses different styles
+  // TODO investigate why it's not needed in the main library CSS
+  p,
+  a {
     @include media($medium-screen) {
       margin-bottom: 0;
     }
+
     color: $color-white;
     font-size: $h5-font-size;
     margin: {
@@ -316,6 +329,7 @@ $site-top:           124px;
   }
   padding: 1em $site-margins;
   border: 1px solid #eeeeee;
+
   .is-peripheral {
     opacity: .2;
   }
@@ -334,18 +348,17 @@ $site-top:           124px;
 
 .code-snippets {
 
-  .code-snippet-button:after {
-    content: "\25be  hide code";
+  .code-snippet-button::after {
+    content: '\25be  hide code';
   }
 
   &.hidden {
-
     table {
       display: none;
     }
-    
-    .code-snippet-button:after {
-      content: "\25b8  show code";
+
+    .code-snippet-button::after {
+      content: '\25b8  show code';
     }
   }
 
@@ -379,7 +392,8 @@ $site-top:           124px;
       text-align: left;
     }
 
-    pre, code {
+    pre,
+    code {
       direction: ltr;
       text-align: left;
       white-space: pre;
@@ -508,6 +522,7 @@ h3 + .button_wrapper {
   @include media($medium-screen) {
     margin: 0;
   }
+
   margin: {
     bottom: 1em;
     top: 0;
@@ -536,7 +551,7 @@ h3 + .button_wrapper {
   }
 
   p {
-    font-family:  monospace, monospace;
+    font-family: monospace, monospace;
   }
 }
 
@@ -544,6 +559,7 @@ h3 + .button_wrapper {
   @include media($medium-screen) {
     margin-bottom: 8rem;
   }
+
   margin-bottom: 0;
 
   .usa-color-square {
@@ -563,6 +579,7 @@ h3 + .button_wrapper {
     @include media($medium-screen) {
       margin-right: 2.35765%;
     }
+
     margin-right: 0;
   }
 
@@ -836,7 +853,13 @@ h6.usa-heading-alt {
 }
 
 .usa-typography-example-font {
-  h1, h2, h3, h4, h5, h6, .usa-font-example p {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .usa-font-example p {
     margin: 0;
   }
 }
@@ -873,20 +896,33 @@ code[class*="language-"], pre[class*="language-"] {
   color: $color-base;
 }
 
-.token.property, .token.tag, .token.boolean, .token.number, .token.constant, .token.symbol, .token.deleted {
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
   color: $color-primary-alt-darkest;
 }
 
-.token.selector, .token.attr-name, .token.string, .token.char, .token.builtin, .token.inserted {
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
   color: $color-secondary;
 }
 
-.token.atrule, .token.attr-value, .token.keyword {
+.token.atrule,
+.token.attr-value,
+.token.keyword {
   color: $color-green;
 }
 
 .token.punctuation {
-    color: $color-primary-alt-darkest;
+  color: $color-primary-alt-darkest;
 }
 
 .usa-code-sample .usa-accordion-content {
@@ -936,6 +972,7 @@ code[class*="language-"], pre[class*="language-"] {
     font-size: 140px;
     line-height: 1.05;
   }
+
   .text-tiny {
     font-size: 15px;
   }
@@ -946,6 +983,7 @@ code[class*="language-"], pre[class*="language-"] {
     font-size: 120px;
     line-height: 1.275;
   }
+
   .text-tiny {
     font-size: 13px;
   }
@@ -968,10 +1006,10 @@ $font-light: 300;
 
   .usa-font-lead {
     font-weight: $font-light;
-  }
-  
-  .usa-font-lead.usa-font-lead-alt {
-    @include font-lead-alt();
+
+    .usa-font-lead-alt {
+      @include font-lead-alt();
+    }
   }
 
   &.serif-body {
@@ -984,20 +1022,25 @@ $font-light: 300;
 
       .usa-font-lead {
         font-size: $h3-font-size;
-      }
-    
-      .usa-font-lead.usa-font-lead-alt {
-        @include font-lead-alt();
+
+        .usa-font-lead-alt {
+          @include font-lead-alt();
+        }
       }
     }
   }
 }
 
 .sans-style {
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-family: $font-sans;
   }
-  
+
   h1 {
     font-size: rem(44px);
   }
@@ -1051,7 +1094,7 @@ $font-light: 300;
         font-size: rem(22px);
         font-weight: $font-light;
         line-height: $base-line-height;
-      }      
+      }
     }
   }
 }
@@ -1066,7 +1109,7 @@ $font-light: 300;
   margin-bottom: 6rem;
 }
 
-// This adds styleguide-only right and left margins for our disclaimer 
+// This adds styleguide-only right and left margins for our disclaimer
 // Since the layout we use is not in a grid
 .usa-disclaimer-stage {
   padding-right: $site-margins;
@@ -1076,5 +1119,6 @@ $font-light: 300;
   @include media($medium-screen) {
     padding-left: $site-margins;
   }
+
   padding-left: 2rem;
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -93,37 +93,6 @@ $site-top:           124px;
     }
   }
 
-  .disclaimer {
-    padding: .5rem 2rem;
-    color: white;
-    text-align: center;
-    font-size: $base-font-size / 1.25;
-    border-bottom: 1px solid #616161;
-    font-weight: 100;
-
-    .us-official {
-      margin: 0;
-    }
-
-    .stage {
-      a { text-decoration: underline; }
-      float: none;
-      display: block;
-      padding-top: 5px;
-    }
-
-    @include media($medium-screen + $width-nav-sidebar) {
-      .us-official {
-        margin-left: 177px;
-      }
-
-      .stage {
-        float: right;
-        padding: 0;
-      }
-    }
-  }
-
 }
 
 .menu-btn {
@@ -342,85 +311,6 @@ $site-top:           124px;
     bottom: 2em;
   }
   padding: 0;
-}
-
-// Code Sample Boxes --------- //
-
-.code-snippets {
-
-  .code-snippet-button::after {
-    content: '\25be  hide code';
-  }
-
-  &.hidden {
-    table {
-      display: none;
-    }
-
-    .code-snippet-button::after {
-      content: '\25b8  show code';
-    }
-  }
-
-  table {
-
-    table-layout: fixed;
-    width: 100%;
-    padding: 3em 0 0 0;
-
-    td {
-      background-color: #f5f5f5;
-      border: 1px solid #e0e0e0;
-      position: relative;
-      vertical-align: top;
-
-      .code-copy-button {
-        border-radius: 0;
-        position: absolute;
-        margin: 0;
-        right: 0;
-        top: 0;
-
-        &:hover {
-          background-color: $color-base;
-        }
-      }
-    }
-
-    th {
-      border: none;
-      text-align: left;
-    }
-
-    pre,
-    code {
-      direction: ltr;
-      text-align: left;
-      white-space: pre;
-      word-spacing: normal;
-      word-break: normal;
-    }
-
-    pre {
-      padding: 0 1em 1em 1em;
-    }
-
-    code {
-      font-size: $base-font-size / 1.5;
-      line-height: 1.4em;
-      word-wrap: break-word;
-
-      &.language-html {
-        max-width: 25em;
-      }
-    }
-  }
-}
-
-// Download Code Boxes --------- //
-
-.download-code {
-  padding-top: 3em;
 }
 
 // Search bar grid --------- //

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -221,12 +221,14 @@ $site-top:           124px;
     top: 1em;
   }
   z-index: -1;
+
   .lt-ie9 & {
     width: 75%;
   }
 
   @include media($medium-screen + $width-nav-sidebar) {
     width: calc(100% - #{$width-nav-sidebar});
+
     .lt-ie9 & {
       width: 75%;
     }
@@ -302,6 +304,14 @@ $site-top:           124px;
   .is-peripheral {
     opacity: .2;
   }
+
+  .usa-background-dark {
+    display: inline-block;
+    padding: {
+      left: 1em;
+      right: 1em;
+    }
+  }
 }
 
 .preview-no_border {
@@ -374,18 +384,18 @@ $site-top:           124px;
 }
 
 h3 + .button_wrapper {
-  margin-top: -.5em
+  margin-top: -.5em;
 }
 
 .button_wrapper {
   clear: both;
   display: table;
   margin-left: -1rem;
-  padding: 0rem 1rem;
+  padding: 0 1rem;
 
-  &:after {
-    content:"\A";
-    white-space:pre;
+  &::after {
+    content: '\A';
+    white-space: pre;
   }
 
   button:last-child {
@@ -417,6 +427,8 @@ h3 + .button_wrapper {
     bottom: 1em;
     top: 0;
   }
+
+  font-size: 1.2rem;
 }
 
 .usa-color-row {
@@ -433,11 +445,11 @@ h3 + .button_wrapper {
   .color-small {
     float: left;
     width: 50%;
+    margin-right: 0;
 
     @include media($medium-screen) {
       width: 17%;
     }
-    margin-right: 0;
   }
 
   p {
@@ -491,10 +503,6 @@ h3 + .button_wrapper {
   }
 }
 
-.usa-color-name {
-  font-size: 1.2rem;
-}
-
 .usa-color-text {
   font-weight: $font-bold;
   margin-bottom: .4rem;
@@ -528,14 +536,6 @@ h3 + .button_wrapper {
 
 .usa-color-base {
   background-color: $color-base;
-}
-
-.usa-color-gray-dark {
-  background-color: $color-gray-dark;
-}
-
-.usa-color-gray-light {
-  background-color: $color-gray-light;
 }
 
 .usa-color-white {
@@ -705,10 +705,6 @@ h3 + .button_wrapper {
   color: $color-gray-dark;
 }
 
-.usa-color-text-gray-dark {
-  color: $color-gray-dark;
-}
-
 .usa-color-text-gray {
   color: $color-gray;
 }
@@ -738,9 +734,11 @@ h3 + .button_wrapper {
   padding-bottom: .8rem;
 }
 
+// scss-lint:disable QualifyingElement
 h6.usa-heading-alt {
   margin-top: 4rem;
 }
+// scss-lint:enable QualifyingElement
 
 .usa-typography-example-font {
   h1,
@@ -778,11 +776,14 @@ h6.usa-heading-alt {
   font-size: 1.2rem;
 }
 
-:not(pre) > code[class*="language-"], pre[class*="language-"] {
-    background: none;
+// scss-lint:disable QualifyingElement
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background: none;
 }
 
-code[class*="language-"], pre[class*="language-"] {
+code[class*="language-"],
+pre[class*="language-"] {
   color: $color-base;
 }
 
@@ -822,16 +823,7 @@ code[class*="language-"], pre[class*="language-"] {
 .usa-code-sample pre[class*="language-"] {
   margin-top: 0;
 }
-
-.preview {
-  .usa-background-dark {
-    display: inline-block;
-    padding: {
-      left: 1em;
-      right: 1em;
-    }
-  }
-}
+// scss-lint:enable QualifyingElement
 
 .alignment-example {
   border-left: 2px solid $color-primary-darker;


### PR DESCRIPTION
@maya @mbland 

## Things
- [x] Add scss-lint to Gemfile
- [x] Add 18F's `.scss-lint.yml` config file
- [x] Fix a bunch of linter errors in `styleguide.scss`
- [x] Add `$color-black`

## Issues
- There are still a number of SelectorDepth and NestingDepth linter warnings in `styleguide.scss`. This would require refactoring a bunch of the code to be less nested
- I haven't cleaned up other scss files yet
- scss-lint doesn't play nicely with Jekyll front matter. In order to run `scss-lint`, you need to remove the `--- ---` from the top of the scss file. See the issue here: https://github.com/jekyll/jekyll/issues/3408

## Notes
- Update your Bundler version :)