### PR TITLE
Remove unneeded code from footer

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -55,12 +55,6 @@
   }
 }
 
-.width-one-sixth {
-  @include media($medium) {
-    @include span-columns(2);
-  }  
-}
-
 .usa-footer-medium {
   .usa-footer-primary-section {
     padding: 0;


### PR DESCRIPTION
This removes unneeded code from the footer in `assets/_scss/components/_footer.scss`. 

This is instead of: https://github.com/18F/web-design-standards/pull/958