### PR TITLE
Update gem asset pipeline

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -4,6 +4,7 @@ var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var rename = require('gulp-rename');
 var linter = require('gulp-scss-lint');
+var merge = require('merge-stream');
 var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
 
 var options = {

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -45,7 +45,7 @@ gulp.task(task, [ 'scss-lint' ], function (done) {
 
   if (cFlags.gem) {
     dutil.logMessage(task, 'Creating gem directories');
-    stream.pipe(gulp.dest('dist-gem/assets/css'))
+    compiledStream.pipe(gulp.dest('dist-gem/assets/css'))
       .pipe(gulp.dest('dist-gem/app/assets/stylesheets'));
     dutil.logMessage(task, 'Creating gem src directories');
     var srcStream = gulp.src('src/stylesheets/**/*.scss')

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -31,19 +31,25 @@ gulp.task(task, [ 'scss-lint' ], function (done) {
 
   dutil.logMessage(task, 'Compiling Sass');
 
-  var stream = gulp.src('src/stylesheets/all.scss')
+  var compiledStream = gulp.src('src/stylesheets/all.scss')
     .pipe(sourcemaps.init())
     .pipe(sass(options).on('error', sass.logError))
     .pipe(sourcemaps.write())
     .pipe(rename({ basename: dutil.pkg.name }))
     .pipe(gulp.dest('dist/css'));
 
+  var streams = merge(compiledStream);
+
   if (cFlags.gem) {
     dutil.logMessage(task, 'Creating gem directories');
-    stream = stream.pipe(gulp.dest('dist-gem/assets/css'));
-    stream = stream.pipe(gulp.dest('dist-gem/app/assets/stylesheets'));
+    stream.pipe(gulp.dest('dist-gem/assets/css'))
+      .pipe(gulp.dest('dist-gem/app/assets/stylesheets'));
+    dutil.logMessage(task, 'Creating gem src directories');
+    var srcStream = gulp.src('src/stylesheets/**/*.scss')
+      .pipe(gulp.dest('dist-gem/assets/sass'));
+    streams.add(srcStream);
   }
 
-  return stream;
+  return streams;
 
 });

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -5,6 +5,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var rename = require('gulp-rename');
 var linter = require('gulp-scss-lint');
 var merge = require('merge-stream');
+var filter = require('gulp-filter');
 var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
 
 var options = {
@@ -12,6 +13,8 @@ var options = {
   outputStyle: cFlags.production ? 'compressed' : 'expanded',
 
 };
+
+var entryFile = filter('all.scss', { restore: true });
 
 gulp.task('scss-lint', function (done) {
 
@@ -46,6 +49,9 @@ gulp.task(task, [ 'scss-lint' ], function (done) {
       .pipe(gulp.dest('dist-gem/app/assets/stylesheets'));
     dutil.logMessage(task, 'Creating gem src directories');
     var srcStream = gulp.src('src/stylesheets/**/*.scss')
+      .pipe(entryFile)
+        .pipe(rename('us_web_design_standards.scss'))
+      .pipe(entryFile.restore)
       .pipe(gulp.dest('dist-gem/assets/sass'));
     streams.add(srcStream);
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-zip": "^3.1.0",
     "inquirer": "^0.11.4",
     "jquery": "^2.2.0",
+    "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
     "node-sass": "^3.4.2",
     "politespace": "^0.1.4",


### PR DESCRIPTION
@nickjs Mentioned in #985 that the CI was failing because the Gem is being used and currently doesn't contain the variables. There has been an ongoing discussion in the 18f/us_web_design_standards_gem#15 about whether or not to include the compiled / bundled files. This update to the Sass automation ensures that the Gem assets are generated using the correct names.