### PR TITLE
usa-width-five-sixths @ medium breakpoint typo

### DIFF
--- a/src/stylesheets/core/_grid.scss
+++ b/src/stylesheets/core/_grid.scss
@@ -34,7 +34,7 @@
       }
     }
     .usa-width-five-sixths {
-      @include span-columns(5);
+      @include span-columns(4);
     }
     .usa-width-one-twelfth {
       @include span-columns(2);


### PR DESCRIPTION
@ medium breakboint the usa-width-five-sixths is set to the wrong number of columns. Documentation indicates it should be 4/6 not 5/6.