### PR TITLE
[ work in progress ] Add GITHUB_TEMPLATES

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+**Description**
+
+*Include a high-level description of the feature or error here including steps
+of how to recreate it if applicable. Include any benefits, challenges, or
+considerations. This can be short and sweet.*
+
+**Ask**
+
+*Describe the desired behavior and what would deem this issue, bug, or feature
+complete.*
+
+**To Do**
+- [ ] Steps
+- [ ] To
+- [ ] Complete/Fix
+
+**Additional Info**
+
+*Include any images, steps to recreate, notes, emojis, or whatever.*
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,22 +14,7 @@ If you have any questions or want to read more, check out the [18F Open Source P
 
 To help us get a better understanding of the issue you are submitting, please leverage the following outline (as used in the following [Girl Develop It issue template](https://github.com/girldevelopit/gdi-new-site/issues/83)):
 
-**Description**
-
-*Include a high-level description of the feature or error here including steps of how to recreate it if applicable. Include any benefits, challenges, or considerations. This can be short and sweet.*
-
-**Ask**
-
-*Describe the desired behavior and what would deem this issue, bug, or feature complete.*
-
-**To Do**
-- [ ] Steps
-- [ ] To
-- [ ] Complete/Fix
-
-**Additional Info**
-
-*Include any images, steps to recreate, notes, emojis, or whatever.*
+[View the `ISSUE_TEMPLATE.md` in this repository](.github/ISSUE_TEMPLATE.md)
 
 ### Submitting a pull request
 


### PR DESCRIPTION
Issue and Pull Request templates have landed on Github :tada:. This PR adds templates that can be used by Github when creating issues and pull-requests. Read the blog post linked below for more information. This is currently a work in progress as [I'm not sure we have a template to use around submitting Pull Requests](https://github.com/18F/web-design-standards/blob/18f-pages-staging/CONTRIBUTING.md#submitting-a-pull-request)

https://github.com/blog/2111-issue-and-pull-request-templates