### PR TITLE
Remove duplicate clearfix mixin

### DIFF
--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -5,17 +5,6 @@
   }
 }
 
-// Clearfix helper
-@mixin clearfix() {
-  &:after {
-    content: ".";
-    display: block;
-    height: 0;
-    clear: both;
-    visibility: hidden;
-  }
-}
-
 // Screen reader only helper
 .usa-sr-only {
   position: absolute;


### PR DESCRIPTION
Bourbon already includes [a `clearfix` mixin](http://bourbon.io/docs/#clearfix) and this is a duplicate. Since these two mixins share the same name, it was confusing which one is actually being used (the latest imported one).

I recommend we remove this duplicate `clearfix` mixin and Bourbon’s will fill its place.

If this `clearfix` mixin being declared is solving a specific problem that Bourbon’s `clearfix` does not (browser support, maybe?), we should namespace this project one so to not having a name conflict.