### PR TITLE
Update npm capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Refer to these files by adding a `<link>` and a `<script>` element into your HTM
 
 And that’s it — you should be set to use the Standards.
 
-## Using NPM
+## Using npm
 
 If you have `node` installed on your machine, you can use npm to install the Standards. Add `uswds` to your `package.json` as a dependency or a development dependency:
 
@@ -66,7 +66,7 @@ Because both the source and compiled/bundled CSS are available to you, you may i
 
 ## Using another framework or package manager
 
-If you’re using another framework or package manager that doesn’t support NPM, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions][link-to-downloads#above-section]. Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
+If you’re using another framework or package manager that doesn’t support npm, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions][link-to-downloads#above-section]. Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
 
 If you’re interested in maintaining a package that helps us distribute the Draft Web Design Standards, the project’s build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](link-to-contributing#gulp-section) to locally build distributions for your framework or package manager.
 


### PR DESCRIPTION
This updates npm capitalization to lowercase, which is the correct usage/spelling.