### PR TITLE
Fix American flag

### DIFF
--- a/config/gulp/doc-util.js
+++ b/config/gulp/doc-util.js
@@ -25,11 +25,11 @@ function drawFlag () {
   );
   gutil.log(
     gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
     gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
     gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),


### PR DESCRIPTION
Minor edit to the output of lines. Seems like `red` and `white` were swapped somewhere. This PR swaps them back.

Before
<img width="632" alt="screen shot 2016-03-09 at 7 05 23 am" src="https://cloud.githubusercontent.com/assets/706004/13634786/de419e4a-e5c5-11e5-8246-68054189a120.png">

After
<img width="638" alt="screen shot 2016-03-09 at 7 10 10 am" src="https://cloud.githubusercontent.com/assets/706004/13634807/f8c98746-e5c5-11e5-8587-bb31d1cee45f.png">

:us: :rocket: 