### PR TITLE
Update CONTRIBUTING with copy from release notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
   - bundle
   - npm install
 
-script: gulp website:build
+script:
+  - npm run deploy
 
 notifications:
   email:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,9 @@ gulp website:build
 
 The task above builds the entire Draft U.S. Web Design Standards website locally.
 It can be useful when debugging for build errors or generating a deployable
-version of the Standards website. This will create a `/_site` directory which
-contains the Jekyll-built site. This is the same build step that occurs when the
-website is deployed.
+version of the Standards website. This creates a `/_site` directory that
+contains the Jekyll-built site. This is the same build step that we use to
+deploy the website.
 
 ```sh
 gulp website:serve
@@ -94,7 +94,7 @@ gulp website:serve
 
 The task above is similar to the previous `./go` serve command from earlier
 versions of the Standards. After running this command, you’ll be able to view
-the Draft U.S.  Web Design Standards website locally (http://127.0.0.1:4000).
+the Draft U.S. Web Design Standards website locally (http://127.0.0.1:4000).
 This also sets up gulp and Jekyll to watch for file changes to the `/docs`
 and `/src` directories and rebuilds the website accordingly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,32 +51,30 @@ Questions or need help with setup? Feel free to open an issue here [https://gith
 The Draft U.S. Web Design Standards `uswds` package (the ZIP download and the
 files needed to use the Standards on your project) and Standards website (our
 public site that displays examples of each component and the HTML code) are
-built using gulp automation. If you’d like to use to use gulp, first make sure
-you've installed it on your machine globally.
+built using gulp automation. To use gulp, first make sure you've installed it on
+your machine globally.
 
 ```sh
 npm install --global gulp-cli
 ```
 
-To start, you’ll need to run the following command to
-install some new dependencies:
+Then to start, run the following command to install any new dependencies:
 
 ```sh
 npm install
 ```
 
-To help you get started, here are a few of the common tasks that you may find
-useful in this new workflow:
+Here are a few of the common tasks:
 
 ```sh
 gulp build
 ```
 
 The task above is an alias for running `gulp sass javascript images fonts` and
-is the recommended task to build all assets. Building the package will generate
-a `/dist` directory with the contents of the ZIP archive made available to
-download. Building just the package is useful if you'd like to create your own
-distribution bundle for frameworks that aren't supported via npm.  This files in
+is the task to build all assets. Building the package will generate a `/dist`
+directory with the contents of the ZIP archive made available to download.
+Building just the package is useful if you'd like to create your own
+distribution bundle for frameworks that aren't supported via npm. This files in
 `/dist` contain no documentation and are compiled and bundled CSS, JavaScript,
 fonts, and images files.
 
@@ -85,10 +83,10 @@ gulp website:build
 ```
 
 The task above builds the entire Draft U.S. Web Design Standards website locally.
-It can be useful when debugging for build errors. Building the Draft U.S. Web
-Design Standards Website can be done via `gulp` with the following command. This
-will create a `/_site` directory which contains the Jekyll-built site. This is
-the same build step that occurs when the website is deployed.
+It can be useful when debugging for build errors or generating a deployable
+version of the Standards website. This will create a `/_site` directory which
+contains the Jekyll-built site. This is the same build step that occurs when the
+website is deployed.
 
 ```sh
 gulp website:serve
@@ -97,8 +95,8 @@ gulp website:serve
 The task above is similar to the previous `./go` serve command from earlier
 versions of the Standards. After running this command, you’ll be able to view
 the Draft U.S.  Web Design Standards website locally (http://127.0.0.1:4000).
-This will also setup gulp and Jekyll to watch for file changes to the `/docs`
-and `/src` directories and update the website accordingly.
+This also sets up gulp and Jekyll to watch for file changes to the `/docs`
+and `/src` directories and rebuilds the website accordingly.
 
 ## Licenses and attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ directory with the contents of the ZIP archive made available to download.
 Building just the package is useful if you'd like to create your own
 distribution bundle for frameworks that aren't supported via npm. This files in
 `/dist` contain no documentation and are compiled and bundled CSS, JavaScript,
-fonts, and images files.
+fonts, and images files. The command is aliased by `npm run prepublish`.
 
 ```sh
 gulp website:build
@@ -86,7 +86,7 @@ The task above builds the entire Draft U.S. Web Design Standards website locally
 It can be useful when debugging for build errors or generating a deployable
 version of the Standards website. This creates a `/_site` directory that
 contains the Jekyll-built site. This is the same build step that we use to
-deploy the website.
+deploy the website. The command is aliased by `npm run deploy`.
 
 ```sh
 gulp website:serve
@@ -96,7 +96,8 @@ The task above is similar to the previous `./go` serve command from earlier
 versions of the Standards. After running this command, you’ll be able to view
 the Draft U.S. Web Design Standards website locally (http://127.0.0.1:4000).
 This also sets up gulp and Jekyll to watch for file changes to the `/docs`
-and `/src` directories and rebuilds the website accordingly.
+and `/src` directories and rebuilds the website accordingly. The command is
+aliased by `npm start`
 
 ## Licenses and attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Here are a few guidelines to follow when submitting a pull request:
 1. Once you're ready to submit a pull request, push your branch up to the repo.
 1. Submit your pull request against the `18f-pages-staging` branch.
 
-Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
+Have questions or need help with setup? Open an issue here [https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
 
 ### Building the project locally with gulp
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,49 +46,59 @@ Here are a few guidelines to follow when submitting a pull request:
 
 Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
 
-### Building the project locally with Gulp
+### Building the project locally with gulp
 
-The Draft Web Design Standards `uswds` package and style guide website are built
-using Gulp automation. To use Gulp, please make sure you have it installed
-on your machine globally.
+The Draft U.S. Web Design Standards `uswds` package (the ZIP download and the
+files needed to use the Standards on your project) and Standards website (our
+public site that displays examples of each component and the HTML code) are
+built using gulp automation. If you’d like to use to use gulp, first make sure
+you've installed it on your machine globally.
 
 ```sh
 npm install --global gulp-cli
 ```
 
-Once you have Gulp installed globally, you can run the following command to
-see all the commands available to you.
+To start, you’ll need to run the following command to
+install some new dependencies:
 
 ```sh
-gulp
+npm install
 ```
 
-Building the package will generate a `dist/` directory with the contents of the
-ZIP archive made available to download. Building just the package is useful if
-you'd like to create your own distribution bundle for frameworks that aren't
-supported via `npm`.  This package contains no documentation and the compiled
-and bundled CSS, JavaScript, fonts, and images. To build the package locally,
-run the following command:
+To help you get started, here are a few of the common tasks that you may find
+useful in this new workflow:
 
-```
+```sh
 gulp build
 ```
 
-Building the Draft Web Design Standards Website can be done via `gulp` with the
-following command. This will create a `_site/` directory which contains the
-Jekyll-built site.
+The task above is an alias for running `gulp sass javascript images fonts` and
+is the recommended task to build all assets. Building the package will generate
+a `/dist` directory with the contents of the ZIP archive made available to
+download. Building just the package is useful if you'd like to create your own
+distribution bundle for frameworks that aren't supported via npm.  This files in
+`/dist` contain no documentation and are compiled and bundled CSS, JavaScript,
+fonts, and images files.
 
 ```sh
 gulp website:build
 ```
 
-Working on the Draft Web Design Standards site locally can be done via `gulp`
-with the following command. This will setup Gulp and Jekyll to watch for file
-changes to the `docs/` and `src/` directory and update the website accordingly.
+The task above builds the entire Draft U.S. Web Design Standards website locally.
+It can be useful when debugging for build errors. Building the Draft U.S. Web
+Design Standards Website can be done via `gulp` with the following command. This
+will create a `/_site` directory which contains the Jekyll-built site. This is
+the same build step that occurs when the website is deployed.
 
 ```sh
 gulp website:serve
 ```
+
+The task above is similar to the previous `./go` serve command from earlier
+versions of the Standards. After running this command, you’ll be able to view
+the Draft U.S.  Web Design Standards website locally (http://127.0.0.1:4000).
+This will also setup gulp and Jekyll to watch for file changes to the `/docs`
+and `/src` directories and update the website accordingly.
 
 ## Licenses and attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Then to start, run the following command to install any new dependencies:
 npm install
 ```
 
-Here are a few of the common tasks:
+The following examples detail a few tasks you'll encounter as you use gulp
 
 ```sh
 gulp build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Then to start, run the following command to install any new dependencies:
 npm install
 ```
 
-The following examples detail a few tasks you'll encounter as you use gulp
+The following examples detail a few tasks you'll encounter as you use gulp:
 
 ```sh
 gulp build

--- a/config/gulp/website.js
+++ b/config/gulp/website.js
@@ -129,7 +129,7 @@ gulp.task('copy-assets', [ 'build' ], function (done) {
 //
 gulp.task('bundle-gems', [ 'copy-assets' ], function (done) {
 
-  var bundle = spawn('bundle', [ 'update' ]);
+  var bundle = spawn('bundle');
 
   bundle.stdout.on('data', function (data) {
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "src/js/start.js",
   "scripts": {
-    "prepublish": "gulp build",
+    "prepublish": "bundle && gulp build",
     "start": "gulp website:serve",
     "build": "gulp release",
     "test": "gulp eslint scss-lint",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "gulp release",
     "test": "gulp eslint scss-lint",
     "preversion": "npm test",
-    "version": "npm run prepublish"
+    "version": "npm run prepublish",
+    "deploy": "gulp website:build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I ported over the `gulp workflow` section from the release notes into what was already in CONTRIBUTING. I updated the release notes [here](https://github.com/18F/web-design-standards/releases) with the a reference to this update.