### PR TITLE
[ work in progress ] Updating /docs with consistent naming conventions.

### DIFF
--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -112,7 +112,7 @@ lead: Form controls allow users to enter information into a page.
       <li>If the list of options is very short. Use radio buttons instead.</li>
       <li>If the list of options is very long. Let users type the same information into a text input that suggests possible options instead.</li>
       <li>If you need to allow users to select more than one option at once. Users often don’t understand how to select multiple items from dropdowns. Use checkboxes instead.</li>
-      <li>For site navigation (use the navigation components instead).</li>
+      <li>For site navigation (use the navigation UI Components instead).</li>
     </ul>
     <h5>Guidance</h5>
     <ul class="usa-content-list">

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -20,7 +20,7 @@
       </div>
       <ul class="usa-button-list usa-unstyled-list">
         <li>
-          <a class="usa-button" href="{{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button inside site');">Download code</a>
+          <a class="usa-button" href="{{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button inside site');">Download UI Components</a>
         </li>
         <li>
           <a class="usa-button usa-button-outline" href="{{ site.repos[0].url }}" onclick="ga('send', 'event', 'Viewed on Github', 'Clicked View on Github from inside site');">

--- a/docs/pages/all.html
+++ b/docs/pages/all.html
@@ -8,7 +8,7 @@ title: Draft U.S. Web Design Standards
 
 <p>Welcome to the alpha site for the Draft U.S. Web Design Standards project.</p>
 
-<p>This Draft Web Design Standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
+<p>The Draft U.S. Web Design Standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
 
 <p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="{{ site.repos[0].url }}/issues">{{ site.repos[0].url }}/issues</a>.</p>
 

--- a/docs/pages/getting-started.html
+++ b/docs/pages/getting-started.html
@@ -9,7 +9,7 @@ lead: The Draft U.S. Web Design Standards are designed to set a new bar for simp
 
 <h3 class="usa-heading">For developers</h3>
 
-<p>The UI components are built on a solid <strong>HTML</strong> foundation, progressively enhanced to provide core experiences across browsers. All users get critical information and experiences. New browsers get the prettiest experiences, while older browsers get less pretty, but usable ones. If JavaScript fails, users will still get a robust HTML foundation.</p>
+<p>The UI Components are built on a solid <strong>HTML</strong> foundation, progressively enhanced to provide core experiences across browsers. All users get critical information and experiences. New browsers get the prettiest experiences, while older browsers get less pretty, but usable ones. If JavaScript fails, users will still get a robust HTML foundation.</p>
 
 <h4>CSS architecture</h4>
 
@@ -33,7 +33,7 @@ lead: The Draft U.S. Web Design Standards are designed to set a new bar for simp
 
 <ol class="usa-content-list">
   <li>
-    <strong>HTML</strong> markup for the components are located in: 
+    <strong>HTML</strong> markup for the UI Components are located in: 
     <code>
       docs/_visual, 
       docs/_layout-system,  
@@ -60,8 +60,8 @@ lead: The Draft U.S. Web Design Standards are designed to set a new bar for simp
 <p>We fully expect many teams will need to customize this style guide, but we encourage you to incorporate as much consistency in look, feel and usability as possible.</p>
 <p>As a complement to this visual style guidance, we strongly recommend you use <a href="https://pages.18f.gov/content-guide/">18F’s Content Guide</a> when writing language for government services.</p>
 
-<h4>UI components and patterns</h4>
-<p>The site contains HTML mockups of common UI components designed to follow the Draft Web Design Standards' visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
+<h4>UI Components and patterns</h4>
+<p>The site contains HTML mockups of common UI Components designed to follow the Draft Web Design Standards' visual style guide. To view the specs of each design live on this website (padding, margins, stroke weight, line-height, etc.), use your browser’s developer tools.</p>
 <p>All of these designs are also available in a variety of design file formats for download:</p>
 <ul class="usa-content-list">
   <li><strong>Illustrator, EPS, Sketch, and OmniGraffle</strong> art files of each component and pattern on this site are available at: <a href="{{ site.repos[1].url }}">{{ site.repos[1].url }}</a></li>

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -25,11 +25,11 @@ title: Draft U.S. Web Design Standards
       </nav>
       <div class="usa-banner-content" id="main-content">
         <h1><span class="usa-label">Draft</span>U.S. Web Design Standards</h1>
-        <h2 class="usa-font-lead">Open source UI components and visual style guide to create consistency and beautiful user experiences across U.S. federal government websites</h2>
+        <h2 class="usa-font-lead">Open source UI Components and visual style guide to create consistency and beautiful user experiences across U.S. federal government websites</h2>
       </div>
         <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/getting-started" onclick="ga('send', 'event', 'Viewed the standards', 'Clicked View the Standards button in homepage splash');">View the standards</a>
         <div class="usa-button-block">
-          <a class="usa-button usa-button-big usa-button-outline-inverse" href="{{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button on homepage');">Download the components</a>
+          <a class="usa-button usa-button-big usa-button-outline-inverse" href="{{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip" onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button on homepage');">Download the UI Components</a>
           <p class="usa-text-small">Download a zip file with code and assets</p>
         </div>
     </div>
@@ -148,7 +148,7 @@ title: Draft U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro">
       <h2>Examples</h2>
-      <h3 class="usa-font-lead">A few samples of the draft web design standards at work:</h3>
+      <h3 class="usa-font-lead">A few samples of the Draft U.S. Web Design Standards at work:</h3>
     </div>
   </div>
   <div class="usa-grid">
@@ -181,7 +181,7 @@ title: Draft U.S. Web Design Standards
   <div class="usa-grid">
     <div class="usa-intro usa-standlast">
       <h2>Contribute</h2>
-      <p>The draft web design standards alpha was created during the summer of 2015 by designers and developers at the U.S. Digital Service and 18F. We will continue to maintain and update these resources as we learn what works best for the people we serve.</p>
+      <p>The Draft U.S. Web Design Standards alpha was created during the summer of 2015 by designers and developers at the U.S. Digital Service and 18F. We will continue to maintain and update these resources as we learn what works best for the people we serve.</p>
       <p>Help us make it better.</p>
     </div>
     <div class="usa-cta">


### PR DESCRIPTION
This pull request updates the Standards Website with the new naming conventions agreed upon by the team. 

> `UI Components` when talking about the standards themselves and `Standards Website` when referring to the standards.