### PR TITLE
Remove image type from buttons

### DIFF
--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -11,8 +11,7 @@ $button-stroke: inset 0 0 0 2px;
 button,
 [type="button"],
 [type="submit"],
-[type="reset"],
-[type="image"] {
+[type="reset"] {
   appearance: none;
   background-color: $color-primary;
   border: 0;


### PR DESCRIPTION
- This is not a valid type attribute for button
- Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button