### PR TITLE
Update documentation file tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ uswds-0.9.0/
   │   ├── uswds.min.css
   │   └── uswds.css
   ├── img/
-  │   ├── social-icons/
-  │   ├── favicons/
-  │   ├── alerts/
   └── fonts/
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,17 +80,17 @@ The package will be installed in `node_modules/uswds`. You can use the files
 found in the `src/` directory.
 
 ```
-- node_modules/uswds/
-  - dist/
-    - css/
-    - fonts/
-    - img/
-    - js/
-  - src/
-    - fonts/
-    - img/
-    - js/
-    - stylesheets/
+node_modules/uswds/
+  ├── dist/
+  │   ├── css/
+  │   ├── fonts/
+  │   ├── img/
+  │   ├── js/
+  ├── src/
+  │   ├── fonts/
+  │   ├── img/
+  │   ├── js/
+  │   ├── stylesheets/
 ```
 
 `require('uswds')` will load all of the Draft U.S. Web Design Standard's JavaScript onto the page. The `uswds` module itself does not export anything.

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ node_modules/uswds/
 │   ├── fonts/
 │   ├── img/
 │   ├── js/
-├── src/
-│   ├── fonts/
-│   ├── img/
-│   ├── js/
-│   ├── stylesheets/
+└── src/
+    ├── fonts/
+    ├── img/
+    ├── js/
+    └── stylesheets/
 ```
 
 `require('uswds')` will load all of the Draft U.S. Web Design Standard's JavaScript onto the page. The `uswds` module itself does not export anything.

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Then, add the `dist` directory files into a relevant place in your code base —
 
 ```
 uswds-0.9.0/
-  ├── js/
-  │   ├── uswds.min.js.map
-  │   ├── uswds.min.js
-  │   └── uswds.js
-  ├── css/
-  │   ├── uswds.min.css.map
-  │   ├── uswds.min.css
-  │   └── uswds.css
-  ├── img/
-  └── fonts/
+├── js/
+│   ├── uswds.min.js.map
+│   ├── uswds.min.js
+│   └── uswds.js
+├── css/
+│   ├── uswds.min.css.map
+│   ├── uswds.min.css
+│   └── uswds.css
+├── img/
+└── fonts/
 ```
 
 Refer to these files by adding the following `<link>` and `<script>` elements
@@ -81,16 +81,16 @@ found in the `src/` directory.
 
 ```
 node_modules/uswds/
-  ├── dist/
-  │   ├── css/
-  │   ├── fonts/
-  │   ├── img/
-  │   ├── js/
-  ├── src/
-  │   ├── fonts/
-  │   ├── img/
-  │   ├── js/
-  │   ├── stylesheets/
+├── dist/
+│   ├── css/
+│   ├── fonts/
+│   ├── img/
+│   ├── js/
+├── src/
+│   ├── fonts/
+│   ├── img/
+│   ├── js/
+│   ├── stylesheets/
 ```
 
 `require('uswds')` will load all of the Draft U.S. Web Design Standard's JavaScript onto the page. The `uswds` module itself does not export anything.


### PR DESCRIPTION
This updates the file tree for consistent formatting and removes the folders under `uswds-0.9.0/img`.