### PR TITLE
Update Travis to use old `./go` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 
 script:
   - npm run deploy
+  - ./go build
 
 notifications:
   email:


### PR DESCRIPTION
Update Travis to use old `./go build` deployment strategy.