### PR TITLE
Fix sass-watch bug

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -1,5 +1,4 @@
 var gulp = require('gulp');
-var gutil = require('gulp-util');
 var dutil = require('./doc-util');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -1,4 +1,5 @@
 var gulp = require('gulp');
+var gutil = require('gulp-util');
 var dutil = require('./doc-util');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
@@ -48,23 +49,45 @@ gulp.task(task, [ 'scss-lint', 'copy-vendor-sass' ], function (done) {
   var entryFile = 'src/stylesheets/all.scss';
 
   var defaultStream = gulp.src(entryFile)
-    .pipe(sass({ outputStyle: 'expanded' }).on('error', sass.logError))
+    .pipe(
+      sass({ outputStyle: 'expanded' })
+        .on('error', function (error) {
+          console.log(error);
+          gutil.log(
+            gutil.colors.yellow(task),
+            gutil.colors.red('error'),
+            '\n',
+            error.messageformatted
+          );
+          this.emit('end');
+        })
+    )
     .pipe(rename({
       basename: dutil.pkg.name,
     }))
     .pipe(gulp.dest('dist/css'));
 
-  var minifiedStream = gulp.src(entryFile)
-    .pipe(sourcemaps.init({ loadMaps: true }))
-      .pipe(sass({ outputStyle: 'compressed' }).on('error', sass.logError))
-      .pipe(rename({
-        basename: dutil.pkg.name,
-        suffix: '.min',
-      }))
-    .pipe(sourcemaps.write('.', { addComment: false }))
-    .pipe(gulp.dest('dist/css'));
+  //var minifiedStream = gulp.src(entryFile)
+    //.pipe(sourcemaps.init({ loadMaps: true }))
+      //.pipe(sass({ outputStyle: 'compressed' }))
+      //.on('error', function (error) {
+        //gutil.log(
+          //gutil.colors.yellow(task),
+          //gutil.colors.red('error'),
+          //'\n',
+          //error.messageformatted
+        //);
 
-  var streams = merge(defaultStream, minifiedStream);
+        //this.emit('end');
+      //})
+      //.pipe(rename({
+        //basename: dutil.pkg.name,
+        //suffix: '.min',
+      //}))
+    //.pipe(sourcemaps.write('.', { addComment: false }))
+    //.pipe(gulp.dest('dist/css'));
+
+  var streams = merge(defaultStream/*, minifiedStream*/);
 
   return streams;
 

--- a/config/gulp/website.js
+++ b/config/gulp/website.js
@@ -55,10 +55,10 @@ gulp.task('copy-source-sass', function (done) {
 
   copySourceSass.on('close', function (code) { if (0 === code) {
     process.execSync(
-      'mv docs/_scss/all.scss ' +
+      'mv -fv docs/_scss/all.scss ' +
       'docs/_scss/_' + dutil.pkg.name + '.scss'
     );
-     done();
+    done();
   } });
 
 });
@@ -188,26 +188,15 @@ gulp.task(task, function (done) {
 // Wrapper task for `jekyll serve --watch` which runs after `gulp bundle-gems` to make sure
 // the gems are properly bundled.
 //
-gulp.task('sass-watch', function (done) {
-  gulp.watch([
-    'src/stylesheets/**/*.scss',
-    '!src/stylesheets/lib/**/*',
-  ], function (event) {
-    console.log('FILES CHANGES', event);
-    runSequence(
-      'sass',
-      'clean-source-sass',
-      'copy-source-sass'
-    );
-  });
-});
 gulp.task(taskServe, [ 'bundle-gems' ], function (done) {
 
   gulp.watch([
-    'src/stylesheets/**/*.scss',
+    'src/stylesheets/components/**/*.scss',
+    'src/stylesheets/elements/**/*.scss',
+    'src/stylesheets/core/**/*.scss',
+    'src/stylesheets/all.scss',
     '!src/stylesheets/lib/**/*',
   ], function (event) {
-    console.log('FILES CHANGES', event);
     runSequence(
       'sass',
       'clean-source-sass',

--- a/config/gulp/website.js
+++ b/config/gulp/website.js
@@ -188,16 +188,36 @@ gulp.task(task, function (done) {
 // Wrapper task for `jekyll serve --watch` which runs after `gulp bundle-gems` to make sure
 // the gems are properly bundled.
 //
-gulp.task(taskServe, [ 'bundle-gems' ], function (done) {
-
-  gulp.watch('src/stylesheets/**/*.scss', function (event) {
+gulp.task('sass-watch', function (done) {
+  gulp.watch([
+    'src/stylesheets/**/*.scss',
+    '!src/stylesheets/lib/**/*',
+  ], function (event) {
+    console.log('FILES CHANGES', event);
     runSequence(
       'sass',
       'clean-source-sass',
       'copy-source-sass'
     );
   });
-  gulp.watch('src/js/**/*.js', function (event) {
+});
+gulp.task(taskServe, [ 'bundle-gems' ], function (done) {
+
+  gulp.watch([
+    'src/stylesheets/**/*.scss',
+    '!src/stylesheets/lib/**/*',
+  ], function (event) {
+    console.log('FILES CHANGES', event);
+    runSequence(
+      'sass',
+      'clean-source-sass',
+      'copy-source-sass'
+    );
+  });
+  gulp.watch([
+    'src/js/**/*.js',
+    '!src/js/vendor/**/*',
+  ], function (event) {
     runSequence(
       'javascript',
       'clean-bundled-javascript',

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "src/js/start.js",
   "scripts": {
-    "prepublish": "bundle && gulp build",
+    "prepublish": "bundle && gulp copy-vendor-sass && gulp build",
+    "prestart": "gulp copy-vendor-sass",
     "start": "gulp website:serve",
-    "build": "gulp release",
+    "build": "gulp copy-vendor-sass && gulp release",
     "test": "gulp eslint scss-lint",
     "preversion": "npm test",
     "version": "npm run prepublish",
-    "deploy": "gulp website:build"
+    "deploy": "gulp copy-vendor-sass && gulp website:build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The original watch tasks around `sass` were too greedy when watching for file changes and would recursively watch themselves for ever. This PR fixes this problem so that `npm start` can successfully watch for subsequent changes to the source directories.