### PR TITLE
Remove legacy google-fonts.css file

### DIFF
--- a/docs/_includes/head-home.html
+++ b/docs/_includes/head-home.html
@@ -32,7 +32,7 @@
 <!--[if lt IE 9]>
   <script src="{{ site.baseurl }}/assets/js/vendor/html5shiv.js"></script>
   <script src="{{ site.baseurl }}/assets/js/vendor/respond.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>  
+  <script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>
 <![endif]-->
 
 <!-- Favicons

--- a/docs/_includes/head-home.html
+++ b/docs/_includes/head-home.html
@@ -57,5 +57,4 @@
 
 <!-- CSS
 ================================================== -->
-  <link rel="stylesheet" href="{{ "/assets/css/google-fonts.css" | prepend: site.baseurl }}">
   <link rel="stylesheet" href="{{ "/assets/css/homepage.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
Remove legacy `google-fonts.css` file from `/docs`.

![screen shot 2016-03-18 at 12 31 11 pm](https://cloud.githubusercontent.com/assets/706004/13884704/91fe11d4-ed05-11e5-8792-b359f8ca195f.png)
