### PR TITLE
update button wrapper scss for standards website

### DIFF
--- a/docs/assets/css/styleguide.scss
+++ b/docs/assets/css/styleguide.scss
@@ -431,13 +431,12 @@ h3 + .button_wrapper {
 
 .button_wrapper {
   clear: both;
-  display: table;
+  display: block;
   margin-left: -1rem;
   padding: 0rem 1rem;
 
-  &:after {
-    content:"\A";
-    white-space:pre;
+  @include media($small-screen) {
+    display: table;
   }
 
   button:last-child {


### PR DESCRIPTION
This is a fix for https://github.com/18F/web-design-standards/issues/463.

As discussed with @brendansudol, changing `display: table` to `display: block` fixes the issue for small screen sizes:

<img width="237" alt="draft_u_s__web_design_standards___buttons" src="https://cloud.githubusercontent.com/assets/2628718/14360181/0818e89a-fcaa-11e5-9d91-f2a15bf44515.png">

For larger screens, `display: table` is still needed or else this happens:

<img width="621" alt="draft_u_s__web_design_standards___buttons" src="https://cloud.githubusercontent.com/assets/2628718/14360073/6cd2457a-fca9-11e5-80d7-b96a35785ea5.png">

I also removed this code

```
&:after {
  content:"\A";
  white-space:pre;
}
```

because it was causing extra space with `display: block` in Chrome:

<img width="266" alt="draft_u_s__web_design_standards___buttons" src="https://cloud.githubusercontent.com/assets/2628718/14360136/bbcdc320-fca9-11e5-9937-6e7b53e51219.png">

but I'm not sure if doing that has unwanted side effects.

Tested in Safari 9.0.3, Chrome 49, Firefox 45.0.1.

I also have these other changed files, but I'm not sure which ones I need to include:

```
modified:   Gemfile.lock
modified:   dist/css/uswds.min.css.map
modified:   dist/js/uswds.js
modified:   dist/js/uswds.min.js
modified:   dist/js/uswds.min.js.map
modified:   docs/_scss/lib/_neat.scss
modified:   docs/assets/js/vendor/uswds.min.js
```

I think according to the contribution guidelines I should commit everything in `dist` and `docs`. (The `Gemfile.lock` got changed when I ran `./go update_gems`.) Just wanted to double check!