### PR TITLE
Remove footer js and update footer list html

### DIFF
--- a/src/js/start.js
+++ b/src/js/start.js
@@ -56,29 +56,6 @@ $(function() {
     new Accordion($(this));
   });
 
-  var footerAccordion = function() {
-    if (window.innerWidth < 600) {
-
-      $('.usa-footer-big nav ul').addClass('hidden');
-
-      $('.usa-footer-big nav .usa-footer-primary-link').unbind('click');
-
-      $('.usa-footer-big nav .usa-footer-primary-link').bind('click', function() {
-        $(this).parent().removeClass('hidden')
-        .siblings().addClass('hidden');
-      });
-    } else {
-
-      $('.usa-footer-big nav ul').removeClass('hidden');
-
-      $('.usa-footer-big nav .usa-footer-primary-link').unbind('click');
-    }
-  };
-
-  footerAccordion();
-
-  $(window).resize(footerAccordion);
-
   // Fixing skip nav focus behavior in chrome
   $('.skipnav').click(function(){
     $('#main-content').attr('tabindex','0');

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -167,7 +167,7 @@ li.usa-footer-primary-content {
   }
 
   ul {
-    padding-bottom: 2.5rem;
+    padding-bottom: 0;
 
     @include media($medium-screen) {
       padding-bottom: 0;
@@ -182,40 +182,63 @@ li.usa-footer-primary-content {
     }
 
     li {
+      display: none;
       line-height: 2em;
-    }
 
-    .usa-footer-primary-link {
-      background-image: url('../img/arrow-down.png');
-      background-image: url('../img/arrow-down.svg');
-      background-position: 1.5rem center;
-      background-repeat: no-repeat;
-      background-size: 1.3rem;
-      padding-left: 3.5rem;
+      &:last-child {
+        padding-bottom: 2.5rem;
+      }
 
       @include media($medium-screen) {
-        background: none;
-        padding-bottom: 0;
-        padding-left: 0;
+        display: block;
+
+        &:last-child {
+          padding-bottom: 0;
+        }
       }
     }
 
-    &.hidden {
-      padding-bottom: 0;
+    li.usa-footer-primary-link {
+      margin: 0;
 
-      .usa-footer-primary-link { 
+      h4 {
         background-image: url('../img/arrow-right.png');
         background-image: url('../img/arrow-right.svg');
+        background-position: 1.5rem center;
+        background-repeat: no-repeat;
+        background-size: 1.3rem;
         cursor: pointer;
         margin: 0;
-
-        @include media($medium-screen) {
-          background: none;
-          padding-left: 0;
-        }        
+        padding-left: 3.5rem;
       }
-        
-      li { display: none; }
+
+      @include media($medium-screen) {
+        padding-bottom: 1rem;
+
+        h4 {
+          background: none;
+          cursor: auto;
+          padding-bottom: 0;
+          padding-left: 0;
+        }
+      }
+    }
+
+    &:hover {
+      li.usa-footer-primary-link {
+        h4 {
+          background-image: url('../img/arrow-down.png');
+          background-image: url('../img/arrow-down.svg');
+
+          @include media($medium-screen) {
+            background: none;
+          }
+        }
+      }
+
+      li {
+        display: block;
+      }
     }
   }
 }


### PR DESCRIPTION
The big footer (with collapsing navigation on small screens) had an unnecessary reliance on javascript. Further, link lists in this footer included an h4 as a direct child of a ul, and this is not allowed.

- Remove javascript requirement for big footer
- Relying instead on css, show all list items with the parent is hovered. This automatically defaults to being triggered on click on touch-only devices
- Wrapped footer h4 in li to comply with semantics