### PR TITLE
Fixes issue #1120 by removing display: none from aria-hidden, doesn't…

### DIFF
--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -19,7 +19,3 @@ body {
     filter: none !important;
   }
 }
-
-[aria-hidden=true] {
-  display: none !important;
-}


### PR DESCRIPTION
… impact anything but accordion component which should be addressed separately (see https://github.com/18F/web-design-standards/issues/1121, https://github.com/18F/web-design-standards/issues/1122, et al).

Regardless of how the accordion issue is solved, it is not appropriate for aria-hidden=true to have additional rules; instead, a class with display: none should be used where needed.

Thanks!