### PR TITLE
Fix broken links & typos in README & CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We're so glad you're thinking about contributing to an 18F open source project! 
 
 One of our goals is to ensure a welcoming environment for all contibutors to our projects. Our staff follows the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md), and all contributors should do the same.
 
-We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), [README](README.md) and its [Workflow](https://github.com/18F/web-design-standards/wiki/Workflow) process.
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](../LICENSE.md), [README](../README.md) and its [Workflow](https://github.com/18F/web-design-standards/wiki/Workflow) process.
 
 If you have any questions or want to read more, check out the [18F Open Source Policy GitHub repository]( https://github.com/18f/open-source-policy), or just [shoot us an email](mailto:18f@gsa.gov).
 
@@ -133,7 +133,7 @@ Because this will produce three commits, the only commits that may be reviewed
 are the commits to the `/src` directory. This only applies to contributions that
 are made strictly to the `/src` directory. If any contributions are added to the
 Standards website, the `/docs` directory will also be reviewed. The contents of
-the `/dist` directory is generated automatically, so commits may not need a
+the `/dist` directory are generated automatically, so commits may not need a
 review.
 
 ## Licenses and attribution

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The files `docs/assets/js/vendor/prism.js` and `assets-styleguide/css/prism.css`
 
 ### The rest of this project is in the public domain
 
-The rest of this project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
+The rest of this project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](.github/CONTRIBUTING.md):
 
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >


### PR DESCRIPTION
Fixes a couple of doc links between the top-level dir and the `.github` dir.