### PR TITLE
[Website]: Move title line instruction inside comment

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,8 @@
-<!-- Please feel free to remove whatever sections/lines in this aren't relevant. -->
+<!-- Please feel free to remove whatever sections/lines in this aren't relevant.
 
-## Title Line Template: [Website or UI component]: [Brief description]
-<!-- Use the title line as the title of your pull request, then delete these lines. 
+Use the title line as the title of your pull request, then delete these lines. 
+
+## Title line template: [Website or UI component]: [Brief description]
 
 Website: Issues that impact standards.usa.gov look, feel or functionality.
 UI component: Issues that impact the look, feel, or functionality of the standards themselves.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
 <!-- Please feel free to remove whatever sections/lines in this aren't relevant. 
-Before submitting a pull request, please be sure to read our guidelines [here](https://github.com/18F/web-design-standards/blob/18f-pages-staging/CONTRIBUTING.md#submitting-a-pull-request).-->
+Before submitting a pull request, please be sure to read our guidelines [here](https://github.com/18F/web-design-standards/blob/18f-pages-staging/CONTRIBUTING.md#submitting-a-pull-request).
 
 ## Title Line Template: [Website] - [UI component]: [Brief statement describing what this pull request solves.]
-<!-- Use the title line as the title of your pull request, then delete these lines.
+
+Use the title line as the title of your pull request, then delete these lines.
 
 Website: Issues that impact standards.usa.gov look, feel or functionality.
 UI component: Issues that impact the look, feel or functionality of the standards themselves.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 <!-- Please feel free to remove whatever sections/lines in this aren't relevant. 
-Before submitting a pull request, please be sure to read our guidelines [here](https://github.com/18F/web-design-standards/blob/18f-pages-staging/CONTRIBUTING.md#submitting-a-pull-request).
 
 ## Title Line Template: [Website] - [UI component]: [Brief statement describing what this pull request solves.]
 


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren't relevant. 
Before submitting a pull request, please be sure to read our guidelines [here](https://github.com/18F/web-design-standards/blob/18f-pages-staging/CONTRIBUTING.md#submitting-a-pull-request).-->

<!-- Use the title line as the title of your pull request, then delete these lines.

Website: Issues that impact standards.usa.gov look, feel or functionality.
UI component: Issues that impact the look, feel or functionality of the standards themselves.

-->

## Description

- Moves title line instruction inside comment so users don't have to manually remove it.
- Removes note to read CONTRIBUTING bc you get it for free already via GitHub automatically. If it's important that we have this, then I'd move it to a checklist at the end that says "I have read the CONTRIBUTING doc."

<img width="790" alt="screen shot 2016-05-16 at 1 10 15 pm" src="https://cloud.githubusercontent.com/assets/5249443/15302430/ca3e9718-1b67-11e6-9835-e5b27981aaac.png">

cc: @rogeruiz 