### PR TITLE
Add autoprefixer to `gulp` asset pipeline

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var dutil = require('./doc-util');
 var sass = require('gulp-sass');
+var autoprefixer = require('gulp-autoprefixer');
 var sourcemaps = require('gulp-sourcemaps');
 var rename = require('gulp-rename');
 var linter = require('gulp-scss-lint');
@@ -10,6 +11,13 @@ var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
 
 var entryFileFilter = filter('all.scss', { restore: true });
 var normalizeCssFilter = filter('normalize.css', { restore: true });
+var supportedBrowsers = [
+  '> 1%',
+  'Last 2 versions',
+  'IE 11',
+  'IE 10',
+  'IE 9',
+];
 
 gulp.task('scss-lint', function (done) {
 
@@ -54,6 +62,12 @@ gulp.task(task, [ 'scss-lint' ], function (done) {
       sass({ outputStyle: 'expanded' })
         .on('error', sass.logError)
     )
+    .pipe(
+      autoprefixer({
+        browsers: supportedBrowsers,
+        cascade: false,
+      })
+    )
     .pipe(rename({ basename: dutil.pkg.name }))
     .pipe(gulp.dest('dist/css'));
 
@@ -62,6 +76,12 @@ gulp.task(task, [ 'scss-lint' ], function (done) {
       .pipe(
         sass({ outputStyle: 'compressed' })
           .on('error', sass.logError)
+      )
+      .pipe(
+        autoprefixer({
+          browsers: supportedBrowsers,
+          cascade: false,
+        })
       )
       .pipe(rename({
         basename: dutil.pkg.name,

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -143,24 +143,25 @@ $site-top:           124px;
 
     @include position(fixed, 0 auto 0 0);
     @include size($sliding-panel-width 100%);
-    @include transform(translateX(- $sliding-panel-width));
     background: #fff;
     -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     z-index: 999999;
     display: block;
+    transform: translateX(- $sliding-panel-width);
+
     &.is-visible {
-      @include transition(all 0.25s linear);
-      @include transform(translateX(0));
+      transform: translateX(0);
+      transition: all 0.25s linear;
     }
   }
 }
 
 .overlay {
   @include position(fixed, 0);
-  @include transition;
   background: #000;
   opacity: 0;
+  transition: all 0.25s linear;
   visibility: hidden;
   z-index: 9999;
 

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -143,25 +143,24 @@ $site-top:           124px;
 
     @include position(fixed, 0 auto 0 0);
     @include size($sliding-panel-width 100%);
+    @include transform(translateX(- $sliding-panel-width));
     background: #fff;
     -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     z-index: 999999;
     display: block;
-    transform: translateX(- $sliding-panel-width);
-
     &.is-visible {
-      transform: translateX(0);
-      transition: all 0.25s linear;
+      @include transition(all 0.25s linear);
+      @include transform(translateX(0));
     }
   }
 }
 
 .overlay {
   @include position(fixed, 0);
+  @include transition;
   background: #000;
   opacity: 0;
-  transition: all 0.25s linear;
   visibility: hidden;
   z-index: 9999;
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "browserify": "^13.0.0",
     "del": "^2.2.0",
     "gulp": "^3.9.0",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-cached": "^1.1.0",
     "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.6.0",

--- a/src/stylesheets/components/_skipnav.scss
+++ b/src/stylesheets/components/_skipnav.scss
@@ -1,19 +1,19 @@
 .skipnav {
-  @include transition(all .2s ease-in-out);
   background: transparent;
   color: $color-base;
   left: 0;
   padding: 1rem 1.5rem;
   position: absolute;
   top: -4.2rem;
+  transition: all 0.2s ease-in-out;
   z-index: 100;
-  
+
   &:focus {
-    @include transition(all .2s ease-in-out);
     background: $color-white;
     left: 0;
     outline: 0;
     position: absolute;
     top: 0;
+    transition: all 0.2s ease-in-out;
   }
 }


### PR DESCRIPTION
## Description

Leveraging the great work that @tysongach added in #1046, this patch series adds `gulp-autoprefixer` along with the commits in the previous PR. #1046 will be closed and superseded by this PR.

## Additional information

* Not all Bourbon mixins were removed.
    * The mixins found in `docs/doc_assets/css/**/*.scss` remain even though Bourbon 5.0 doesn't have those mixins. The reason is [outlined in this commit](https://github.com/18F/web-design-standards/commit/9debfe2985624ba005386a026a357b19d78fc9df).
