### PR TITLE
Updating copy around the repo with new workflow, refs #1163

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,7 +57,7 @@ The task above is an alias for running `gulp sass javascript images fonts` and
 is the task to build all assets. Building the package will generate a `/dist`
 directory with the contents of the ZIP archive made available to download.
 Building just the package is useful if you'd like to create your own
-distribution bundle for frameworks that aren't supported via npm. This files in
+distribution bundle for frameworks that aren't supported via npm. The files in
 `/dist` contain no documentation and are compiled and bundled CSS, JavaScript,
 fonts, and images files. The command is aliased by `npm run prepublish`.
 
@@ -81,60 +81,6 @@ the Draft U.S. Web Design Standards website locally (http://127.0.0.1:4000).
 This also sets up gulp and Jekyll to watch for file changes to the `/docs`
 and `/src` directories and rebuilds the website accordingly. The command is
 aliased by `npm start`
-
-### Committing files when updating the `/src` directory
-
-When you run `npm start` to preview the website locally, you generate many files
-that are tracked by Git. This leaves your working directory in a dirty state,
-and it can make knowing which files to include in your commit seem like a
-daunting task. The following steps will make it easier for you to commit changes
-while the team looks into different approaches for handling changes to the
-Standards website and the `uswds` package.
-
-If you made any changes to the `/src` directory, you have also made changes in
-the following directories:
-
-```
-docs/_scss/
-docs/assets/img/
-docs/assets/fonts/
-docs/assets/js/vendor/
-```
-
-This is due to how the Standards website consumes the `uswds` package.
-
-Changes may also appear in these directories and files, if you've made any
-changes to `/src`.
-
-```
-dist/css/
-dist/js/
-dist/fonts/
-dist/img/
-```
-
-These changes must be committed in order for our distribution directories and
-Standards website to remain in sync with the `uswds` package. Please keep
-changes in a directory within its own series of commits. The commit messages
-below offer a few examples.
-
-```sh
-git add src/ && \
-git commit -m "Update the src files"
-
-git add docs/ && \
-git commit -m "Update the Standards website"
-
-git add dist && \
-git commit -m "Update the dist directory"
-```
-
-Because this will produce three commits, the only commits that may be reviewed
-are the commits to the `/src` directory. This only applies to contributions that
-are made strictly to the `/src` directory. If any contributions are added to the
-Standards website, the `/docs` directory will also be reviewed. The contents of
-the `/dist` directory are generated automatically, so commits may not need a
-review.
 
 ## Licenses and attribution
 

--- a/.npmignore
+++ b/.npmignore
@@ -3,10 +3,6 @@
 docs/
 _site/
 
-# Gem releases
-#
-dist-gem/
-
 # Configuration and scripts
 #
 .ruby-version

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ First, download the Draft Web Design Standards assets:
 
 [https://github.com/18F/web-design-standards/releases/download/v0.9.2/uswds-0.9.2.zip](https://github.com/18F/web-design-standards/releases/download/v0.9.2/uswds-0.9.2.zip)
 
-Then, add the `dist` directory files into a relevant place in your code base — likely a directory where you keep third-party libraries:
+Then, add the following folders into a relevant place in your code base — likely a directory where you keep third-party libraries:
 
 ```
 uswds-0.9.2/
@@ -76,16 +76,16 @@ to your project's `package.json` as a dependency:
 npm install --save uswds
 ```
 
-The package will be installed in `node_modules/uswds`. You can use the files
-found in the `src/` directory.
+The package will be installed in `node_modules/uswds`. You can use the un-compiled files
+found in the `src/` or the compiled files in the `dist/` directory.
 
 ```
 node_modules/uswds/
 ├── dist/
 │   ├── css/
 │   ├── fonts/
-│   ├── img/
-│   ├── js/
+│   ├── img//
+│   ├── js
 └── src/
     ├── fonts/
     ├── img/
@@ -111,7 +111,7 @@ node_modules/uswds/dist/css/uswds.css
 
 If you’re using another framework or package manager that doesn’t support NPM, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions](#download). Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
 
-If you’re interested in maintaining a package that helps us distribute the Draft Web Design Standards, the project's build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](.github/CONTRIBUTING.md#building-the-project-locally-with--gulp-) to locally build distributions for your framework or package manager.
+If you’re interested in maintaining a package that helps us distribute the Draft U.S. Web Design Standards, the project's build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](.github/CONTRIBUTING.md#building-the-project-locally-with--gulp-) to locally build distributions for your framework or package manager.
 
 ## Need installation help?
 
@@ -131,7 +131,7 @@ If you have questions or concerns about our contributing workflow, please contac
 
 ## Reuse of open-source style guides
 
-Much of the guidance in the Draft Web Design Standards leans on open source designs, code, and patterns from other civic and government organizations, including:
+Much of the guidance in the Draft U.S. Web Design Standards leans on open source designs, code, and patterns from other civic and government organizations, including:
 
 * Consumer Financial Protection Bureau’s [Design Manual](https://cfpb.github.io/design-manual/)
 * U.S. Patent and Trademark Office’s [Design Patterns](http://uspto.github.io/designpatterns/)

--- a/docs/pages/getting-started.html
+++ b/docs/pages/getting-started.html
@@ -42,10 +42,10 @@ lead: The Draft U.S. Web Design Standards are designed to set a new bar for simp
     </code> 
     in the site root.
   </li>
-  <li><strong>Sass</strong> styles are located in: <code>dist/stylesheets/_scss (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is located in: <code>_site/assets/css/<wbr>styleguide.css</code>.</li>
-  <li><strong>JS</strong> is located in: <code>dist/js/components.js</code>.</li>
-  <li><strong>Fonts</strong> are located in: <code>dist/fonts</code>.</li>
-  <li><strong>Images</strong> and icons are located in: <code>dist/img</code>.</li>
+  <li><strong>Sass</strong> styles are located in: <code>src/stylesheets/ (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is located in the <a class="usa-button" href="{{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip">downloadable zip file </a>.</li>
+  <li><strong>JS</strong> is located in: <code>src/js/components (accordion.js, toggle-field-mark.js, toggle-form-input.js, validator.js)</code>.</li>
+  <li><strong>Fonts</strong> are located in: <code>src/fonts</code>.</li>
+  <li><strong>Images</strong> and icons are located in: <code>src/img</code>.</li>
 </ol>
 
 <h4>Browser support:</h4>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Maya Benari <maya.ben-ari@gsa.gov>",
     "Marco Segreto <marco.segreto@gsa.gov>",
     "Jeremia Kimelman <jeremia.kimelman@gsa.gov>",
-    "Roger Steve Ruiz <roger.ruiz@gsa.gov>"
+    "Roger Steve Ruiz <roger.ruiz@gsa.gov>",
+    "Julia Elman <julia.elman@gsa.gov>"
   ],
   "license": "SEE LICENSE in LICENSE.md",
   "bugs": {


### PR DESCRIPTION
## Description

Updating various places in the repo to reflect the new workflow due to the removal of the `dist/` directory in version control, refs #1164.

Also adds Julia Elman as one of the contributors in `package.json`.