### PR TITLE
[Website] Stop copying of vendor libs around

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -33,24 +33,6 @@ gulp.task('scss-lint', function (done) {
 
 });
 
-gulp.task('copy-vendor-sass', function (done) {
-
-  dutil.logMessage('copy-vendor-sass', 'Compiling vendor CSS');
-
-  var stream = gulp.src([
-    './node_modules/normalize.css/normalize.css',
-    './node_modules/bourbon/app/assets/stylesheets/**/*.scss',
-    './node_modules/bourbon-neat/app/assets/stylesheets/**/*.scss',
-  ])
-    .pipe(normalizeCssFilter)
-      .pipe(rename('_normalize.scss'))
-    .pipe(normalizeCssFilter.restore)
-    .on('error', function (error) { console.log(error); })
-    .pipe(gulp.dest('src/stylesheets/lib'));
-
-  return stream;
-});
-
 gulp.task(task, [ 'scss-lint' ], function (done) {
 
   dutil.logMessage(task, 'Compiling Sass');

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bourbon-neat": "^1.7.3",
     "cross-spawn": "^2.1.5",
     "jquery": "^2.2.0",
-    "normalize.css": "^3.0.3",
+    "normalize-scss": "^4.2.1",
     "politespace": "^0.1.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "src/js/start.js",
   "scripts": {
-    "prepublish": "bundle && && gulp build",
+    "prepublish": "bundle && gulp build",
     "start": "gulp website:serve",
     "build": " gulp release",
     "test": "gulp eslint scss-lint test",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "src/js/start.js",
   "scripts": {
-    "prepublish": "bundle && gulp copy-vendor-sass && gulp build",
-    "prestart": "gulp copy-vendor-sass",
+    "prepublish": "bundle && && gulp build",
     "start": "gulp website:serve",
-    "build": "gulp copy-vendor-sass && gulp release",
+    "build": " gulp release",
     "test": "gulp eslint scss-lint test",
     "preversion": "npm test",
     "version": "npm run prepublish",
-    "deploy": "gulp copy-vendor-sass && gulp website:build"
+    "deploy": "gulp website:build"
   },
   "repository": {
     "type": "git",

--- a/src/stylesheets/all.scss
+++ b/src/stylesheets/all.scss
@@ -1,8 +1,8 @@
 // Vendor -------------- //
 
-@import 'lib/bourbon';
-@import 'lib/neat';
-@import 'lib/normalize';
+@import '../../node_modules/bourbon/app/assets/stylesheets/bourbon';
+@import '../../node_modules/bourbon-neat/app/assets/stylesheets/neat';
+@import '../../node_modules/normalize-scss/sass/_normalize';
 
 
 // Core -------------- //


### PR DESCRIPTION
## Description
Removes the build step of copying the CSS vendor libs to the src/stylesheets folder by using a full path to them to node_modules.

## Additional information
So node-sass can import .css files but ruby sass cannot, so I want
to ditch the annoying normalize lib for the scss version.

I'm using the straight node_module paths, which isn't the perfect
solution. Something better but would be much more complicated to
get working on sites that use the standard is to set the includePath
in the sass build path. I'm hesitant to do this now because node-sass
and ruby-sass use these differently so I'm not sure how we'll use them
both.

### Benefits
- A user can install with npm directly from the github repo, `@import` the src files into their project and everything will work
- There's no non-source code in `src`.

### Negatives
- If bourbon, neat or normalize changes where the main scss files are, then the imports will break

TODO
- Remove unnecessary build steps.