### PR TITLE
[UI component]: Footer h4 semantics

### DIFF
--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -17,28 +17,28 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
       <div class="usa-grid-full">
         <nav class="usa-footer-nav usa-width-two-thirds">
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <h4 class="usa-footer-primary-link">Topic</h4>
+            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <h4 class="usa-footer-primary-link">Topic</h4>
+            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <h4 class="usa-footer-primary-link">Topic</h4>
+            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <h4 class="usa-footer-primary-link">Topic</h4>
+            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>

--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -17,28 +17,36 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
       <div class="usa-grid-full">
         <nav class="usa-footer-nav usa-width-two-thirds">
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
+            <li class="usa-footer-primary-link">
+              <h4>Topic</h4>
+            </li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
+            <li class="usa-footer-primary-link">
+              <h4>Topic</h4>
+            </li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
+            <li class="usa-footer-primary-link">
+              <h4>Topic</h4>
+            </li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
           </ul>
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link"><h4>Topic</h4></li>
+            <li class="usa-footer-primary-link">
+              <h4>Topic</h4>
+            </li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>
             <li><a href="#">Secondary link</a></li>

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -203,7 +203,7 @@ li.usa-footer-primary-content {
     }
 
     h4 {
-      margin: 0;
+      margin-top: 0;
     }
 
     &.hidden {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -200,10 +200,10 @@ li.usa-footer-primary-content {
         padding-bottom: 0;
         padding-left: 0;
       }
-    }
 
-    h4 {
-      @include margin(0 null);
+      > * {
+        @include margin(0 null);
+      }
     }
 
     &.hidden {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -203,7 +203,7 @@ li.usa-footer-primary-content {
     }
 
     h4 {
-      margin-top: 0;
+      margin: 0;
     }
 
     &.hidden {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -196,6 +196,7 @@ li.usa-footer-primary-content {
 
       @include media($medium-screen) {
         background: none;
+        margin-bottom: .8rem;
         padding-bottom: 0;
         padding-left: 0;
       }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -191,6 +191,7 @@ li.usa-footer-primary-content {
       background-position: 1.5rem center;
       background-repeat: no-repeat;
       background-size: 1.3rem;
+      margin: 0;
       padding-left: 3.5rem;
 
       @include media($medium-screen) {
@@ -201,25 +202,25 @@ li.usa-footer-primary-content {
     }
 
     h4 {
-      margin-top: 0;
+      margin: 0;
     }
 
     &.hidden {
       padding-bottom: 0;
 
+      li { display: none; }
+
       .usa-footer-primary-link { 
         background-image: url('../img/arrow-right.png');
         background-image: url('../img/arrow-right.svg');
         cursor: pointer;
-        margin: 0;
+        display: block;
 
         @include media($medium-screen) {
           background: none;
           padding-left: 0;
-        }        
+        }
       }
-        
-      li { display: none; }
     }
   }
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -200,6 +200,10 @@ li.usa-footer-primary-content {
       }
     }
 
+    h4 {
+      margin-top: 0;
+    }
+
     &.hidden {
       padding-bottom: 0;
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -191,7 +191,7 @@ li.usa-footer-primary-content {
       background-position: 1.5rem center;
       background-repeat: no-repeat;
       background-size: 1.3rem;
-      margin: 0;
+      margin-left: 0;
       padding-left: 3.5rem;
 
       @include media($medium-screen) {
@@ -203,7 +203,7 @@ li.usa-footer-primary-content {
     }
 
     h4 {
-      margin: 0;
+      @include margin(0 null);
     }
 
     &.hidden {


### PR DESCRIPTION
## Description

This PR contains the work done by @madmanlear on #1150 rebased onto `18f-pages-staging` with the correct number of file changes. This PR removes the `dist/` and `docs/` directory commits that were necessary when the original commits were made.

### Additional Information

@madmanlear, feel free to review the commits here and branch off this branch to offer any new additional changes as needed. Or you can follow the instructions on #1150 around rebasing and removing the `dist/` and `docs/` directories.

Original comment from @madmanlear

> Link lists in the big footer included an h4 as a direct child of a ul, and this is not allowed.

> - Wrapped footer h4 in li to comply with semantics
> - Updated styles to suit

> Resolves issue #794