### PR TITLE
[Documentation] Add explanations of branches to the repo docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Here are a few guidelines to follow when submitting a pull request:
 1. Create a GitHub account or sign in to your existing account.
 1. Fork this repo into your GitHub account (or just clone it if you're an 18F team member). Read more about forking a repo here on GitHub:
 [https://help.github.com/articles/fork-a-repo/](https://help.github.com/articles/fork-a-repo/)
-1. Create a branch that lightly defines what you're working on (for example, add-styles).
+1. Create a branch from `staging` that lightly defines what you're working on (for example, add-styles).
 1. Ensure that your contribution works via `npm`, if applicable. See below under
    _Install the package locally via `npm-link`_.
 1. Once you're ready to submit a pull request, fill out the PULL REQUEST template provided.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ If you’re using another framework or package manager that doesn’t support NP
 
 If you’re interested in maintaining a package that helps us distribute the Draft U.S. Web Design Standards, the project's build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](CONTRIBUTING.md#building-the-project-locally-with--gulp-) to locally build distributions for your framework or package manager.
 
+## Our use of branches
+
+The `staging` branch is the bleeding edge of development. When developing, we create a feature branch from `staging`, do our work in that, then create a pull request which merges back to `staging`. New commits to `staging` are automatically deployed to [our staging site](https://standards-staging.usa.gov/).
+
+When cutting a [release](https://github.com/18F/web-design-standards/releases), we merge from `staging` to `master`. The `master` branch holds the latest production-ready release, as well as [the production website](https://standards.usa.gov/).
+
+The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release & development branches, back when the site was hosted on `pages.18f.gov`. Those branches still auto-deploy to 18F Pages, but will now only contain minimal redirects to the new site.
+
 ## Need installation help?
 
 Do you have questions or need help with setup? Did you run into any weird errors while following these instructions? Feel free to open an issue here:

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ If you’re interested in maintaining a package that helps us distribute the Dra
 
 The `staging` branch is the bleeding edge of development. When developing, we create a feature branch from `staging`, do our work in that branch, and then create a pull request that merges back into `staging`. New commits to `staging` are automatically deployed to [our staging site](https://standards-staging.usa.gov/).
 
-When cutting a [release](https://github.com/18F/web-design-standards/releases), we merge from `staging` to `master`. The `master` branch holds the latest production-ready release, as well as [the production website](https://standards.usa.gov/).
+The `master` branch always holds the latest production-ready release, as well as [the production website](https://standards.usa.gov/). When cutting a [release](https://github.com/18F/web-design-standards/releases), we create a release branch from `staging` named for the new version: for example, `0.9.2`. Once we've completed QA on that branch, we tag the release and merge it into the `master` branch.
 
-The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release and development branches, back when the site was hosted on `pages.18f.gov`. Those branches still autodeploy to 18F Pages, but will now only contain minimal redirects to the new site.
+The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release and development branches, back when the site was hosted on `pages.18f.gov`. Those branches still auto deploy to 18F Pages, but will now only contain minimal redirects to the new site.
 
 ## Need installation help?
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ If you’re interested in maintaining a package that helps us distribute the Dra
 
 ## Our use of branches
 
-The `staging` branch is the bleeding edge of development. When developing, we create a feature branch from `staging`, do our work in that, then create a pull request which merges back to `staging`. New commits to `staging` are automatically deployed to [our staging site](https://standards-staging.usa.gov/).
+The `staging` branch is the bleeding edge of development. When developing, we create a feature branch from `staging`, do our work in that branch, and then create a pull request that merges back into `staging`. New commits to `staging` are automatically deployed to [our staging site](https://standards-staging.usa.gov/).
 
 When cutting a [release](https://github.com/18F/web-design-standards/releases), we merge from `staging` to `master`. The `master` branch holds the latest production-ready release, as well as [the production website](https://standards.usa.gov/).
 
-The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release & development branches, back when the site was hosted on `pages.18f.gov`. Those branches still auto-deploy to 18F Pages, but will now only contain minimal redirects to the new site.
+The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release and development branches, back when the site was hosted on `pages.18f.gov`. Those branches still autodeploy to 18F Pages, but will now only contain minimal redirects to the new site.
 
 ## Need installation help?
 


### PR DESCRIPTION
## Description

Minimal explanations of what the `master`, `staging`, `18f-pages` & `18f-pages-staging` branches are for. Fixes #1189.
