### PR TITLE
[UI Component]: Fix aria hidden (simple)

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -89,4 +89,9 @@ $accordion-border: 3px solid $color-gray-lightest;
   > *:last-child {
     margin-bottom: 0;
   }
+
+  &[aria-hidden=true] {
+    visibility: hidden;
+    height: 0;
+  }
 }

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -82,16 +82,15 @@ $accordion-border: 3px solid $color-gray-lightest;
   overflow: auto;
   padding: 3rem;
 
+  &[aria-hidden=true] {
+    display: none;
+  }
+  
   > *:first-child {
     margin-top: 0;
   }
 
   > *:last-child {
     margin-bottom: 0;
-  }
-
-  &[aria-hidden=true] {
-    visibility: hidden;
-    height: 0;
   }
 }

--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -21,7 +21,3 @@ body {
     filter: none !important;
   }
 }
-
-[aria-hidden=true] {
-  display: none !important;
-}


### PR DESCRIPTION
## Description

Removes `display: none` from `aria-hidden="true"` and moves that to `usa-accordion`.

Fixes: #1120.