### PR TITLE
[Checkbox and radio inputs] Fix checkbox and radio inputs from not appearing selectable on iOS VoiceOver

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -139,7 +139,9 @@ legend {
 
 input[type="checkbox"],
 input[type="radio"] {
-  @include sr-only();
+  margin-left: -2rem;
+  opacity: 0;
+  position: absolute;
 
   .lt-ie9 & {
     border: 0;


### PR DESCRIPTION
## Description

Fixes custom checkboxes and radio element issue where they didn't appear on iOS VoiceOver.

Thanks @slowbot for the fix!

Fixes: #1182

cc: @nickbristow 