### PR TITLE
[Buttons] Fix disabled button

### DIFF
--- a/docs/_elements/buttons.md
+++ b/docs/_elements/buttons.md
@@ -53,7 +53,7 @@ lead: Use buttons to signal actions.
 
   <h6>Disabled Button</h6>
   <div class="button_wrapper">
-    <button class="usa-button-disabled">Default</button>
+    <button class="usa-button-disabled" disabled>Default</button>
   </div>
 
   <h6>Big Button</h6>

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -156,7 +156,6 @@ button,
 .usa-button-disabled {
   background-color: $color-gray-lighter;
   color: $color-gray-dark;
-  cursor: default;
   pointer-events: none;
 
   &:hover,

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -157,6 +157,7 @@ button,
   background-color: $color-gray-lighter;
   color: $color-gray-dark;
   cursor: default;
+  pointer-events: none;
 
   &:hover,
   &.usa-button-hover,


### PR DESCRIPTION
## Description

Ensures disabled button is not clickable by adding a disabled attribute and adding `pointer-events: none` to the `usa-button-disabled` class.

Fixes: #493.