### PR TITLE
Screener/CircleCI integration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  hosts:
+    ci.server: 127.0.0.1
   node:
     version: 5.1.0
 
@@ -9,6 +11,11 @@ dependencies:
     - sudo dpkg -i debs/temp.deb
     - cf -v
     - bundle install
+    - wget https://s3-us-west-2.amazonaws.com/screener-files/ci/v2/screener-ci.zip
+    - unzip screener-ci.zip
+    # Install Screener Tunnel Client
+    - wget https://s3-us-west-2.amazonaws.com/screener-files/screener-tunnel/screener-tunnel-client-linux-amd64.zip
+    - unzip screener-tunnel-client-linux-amd64.zip
   cache_directories:
     - debs
 
@@ -21,6 +28,14 @@ test:
     - npm test # Run the package and docs test suite
     - npm run build:package # Run the release process
     - npm run build:website # Build Jekyll based docs website
+    - jekyll serve -w:
+       background: true
+    # start tunnel
+    - ./screener-tunnel-client -apikey="$SCREENER_API_KEY" -host="ci.server:4000":
+        background: true
+    - sleep 20
+    # run tests
+    - ./screener-ci.sh $SCREENER_API_KEY $SCREENER_GROUP_ID $CIRCLE_BUILD_NUM
   post:
     - ls -agolf dist/ # Ensure that build:package worked
     - ls -agolf _site/ # Ensure that build:website worked


### PR DESCRIPTION

## Screener Integration

This PR affects the test builds of the repository. During a build, it connects the CI server to Screener's (https://screener.io) cloud server and checks for visual regressions in the page's layout. These tests are defined via Screener's interface and must be manually configured. Some basic checks have been put in place for purposes of testing these changes, they can be found in the `uswds` project under the name `styleguide-ci`.

## Description

* Amends circle.yml file to install screener's tunnel and shell scripts

## Additional information

The changes made to the circle.yml file are pretty basic, there are probably optimizations that can be made. Currently, running these regression tests appears to add about 5 minutes to the build; this represents a significant increase in running time.
