### PR TITLE
[Tables] Fix table background overlap

### DIFF
--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -4,7 +4,7 @@ table {
   min-width: 100%;
 
   thead {
-    tr {
+    th {
       background-color: $color-gray-lightest;
     }
   }
@@ -21,6 +21,7 @@ table {
 
   th,
   td {
+    background-color: $color-white;
     border: 1px solid $color-gray;
     padding: 1.5rem;
   }


### PR DESCRIPTION
## Description

Prevents page background from interfering with table background. 

## Additional information

This is what it looks like:

<img width="390" alt="screen shot 2016-05-31 at 12 25 17 pm" src="https://cloud.githubusercontent.com/assets/5249443/15687741/23f00782-272b-11e6-81b6-347f39094d38.png">

Fixes: #353.