### PR TITLE
[Website]: Fix open keyboard header bug in landscape mode on Android

### DIFF
--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -25,6 +25,14 @@ $font-monospace:       Consolas, Monaco, 'Andale Mono', monospace;
     position: relative;
   }
 
+  @media screen and (min-aspect-ratio: 13/9) {
+    position: absolute;
+  }
+
+  a {
+    border-bottom: none;
+  }
+
   em {
     display: block;
     font-family: $font-serif;

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -25,6 +25,7 @@ $font-monospace:       Consolas, Monaco, 'Andale Mono', monospace;
     position: relative;
   }
 
+  // Removes fixed header on Android in landscape with an open keyboard
   @media screen and (min-aspect-ratio: 13/9) {
     position: absolute;
   }


### PR DESCRIPTION
## Description

Fixes a bug that made it unable to scroll in landscape mode with an open keyboard on Android.

Note: this will need to be tested, I was unable to test it on a device. 

Aspect ratio from here: http://stackoverflow.com/questions/8883163/css-media-query-soft-keyboard-breaks-css-orientation-rules-alternative-solut

Fixes: #345