### PR TITLE
[Typography]: Remove inaccessible text links

### DIFF
--- a/docs/_visual/typography.md
+++ b/docs/_visual/typography.md
@@ -949,7 +949,6 @@ order: 01
 
 <div class="preview">
 
-  <a href="#">This is a link without surrounding text.</a>
   <p><a href="#">This</a> is a text link on a light background.</p>
 
   <p><a class="usa-color-text-visited" href="#">This</a> is a visited link.</p>

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -49,10 +49,10 @@ $site-top:           124px;
       // scss-lint:disable SelectorDepth, NestingDepth
       a {
         color: $color-gray;
+        text-decoration: none;
 
         &:hover {
           color: $color-gray-dark;
-          text-decoration: none;
         }
       }
     }

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -17,6 +17,7 @@
     font-family: $font-sans;
     line-height: 1;
     padding: 1rem 1rem 1rem 1.8rem;
+    text-decoration: none;
 
     &:hover {
       background-color: $color-gray-lightest;

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -15,12 +15,11 @@ p {
 
 a {
   color: $color-primary;
-  text-decoration: none;
+  text-decoration: underline;
 
   &:hover,
   &:active {
     color: $color-primary-darker;
-    text-decoration: underline;
   }
 
   &:visited {
@@ -128,13 +127,6 @@ dfn {
 
 .usa-content-list {
   max-width: $text-max-width;
-}
-
-p,
-.usa-content-list {
-  a {
-    text-decoration: underline;
-  }
 }
 
 .usa-sans {


### PR DESCRIPTION
## Description

Removes inaccessible text links. Removes the examples of them on the styleguide site. Manually removes some underline styles on styleguide components that should not have them.

## Additional information

This is what it looks like:

<img width="443" alt="screen shot 2016-05-31 at 4 35 29 pm" src="https://cloud.githubusercontent.com/assets/5249443/15693889/0ad247ce-274e-11e6-9b4a-fa725b90c9d6.png">

Resolves #812.