### PR TITLE
[Forms] Fix label and fieldset for iOS/OS X Voiceover

### DIFF
--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -131,23 +131,23 @@ lead: Form controls allow users to enter information into a page.
 
   <fieldset class="usa-fieldset-inputs usa-sans">
 
-    <legend class="usa-sr-only">Historical figures 1</legend>
+    <legend class="usa-sr-only" id="historical-figures-1">Historical figures 1</legend>
 
     <ul class="usa-unstyled-list">
       <li>
-        <input id="apple-pie" type="checkbox" name="pies" value="apple-pie" checked />
+        <input id="apple-pie" type="checkbox" name="pies" value="apple-pie" checked aria-describedby="historical-figures-1">
         <label for="apple-pie">Sojourner Truth</label>
       </li>
       <li>
-        <input id="key-lime-pie" type="checkbox" name="pies" value="key-lime-pie">
+        <input id="key-lime-pie" type="checkbox" name="pies" value="key-lime-pie" aria-describedby="historical-figures-1">
         <label for="key-lime-pie">Frederick Douglass</label>
       </li>
       <li>
-        <input id="peach-pie" type="checkbox" name="pies" value="peach-pie">
+        <input id="peach-pie" type="checkbox" name="pies" value="peach-pie" aria-describedby="historical-figures-1">
         <label for="peach-pie">Booker T. Washington</label>
       </li>
       <li>
-        <input id="disabled" type="checkbox" name="pies" disabled />
+        <input id="disabled" type="checkbox" name="pies" disabled  aria-describedby="historical-figures-1">
         <label for="disabled">George Washington Carver</label>
       </li>
     </ul>
@@ -200,19 +200,19 @@ lead: Form controls allow users to enter information into a page.
 
   <fieldset class="usa-fieldset-inputs usa-sans">
 
-    <legend class="usa-sr-only">Historical figures 2</legend>
+    <legend class="usa-sr-only" id="historical-figures-2">Historical figures 2</legend>
 
     <ul class="usa-unstyled-list">
       <li>
-        <input id="pea-soup" type="radio" checked name="soup" value="pea">
+        <input id="pea-soup" type="radio" checked name="soup" value="pea" aria-describedby="historical-figures-2">
         <label for="pea-soup">Elizabeth Cady Stanton</label>
       </li>
       <li>
-        <input id="chicken-noodle" type="radio" name="soup" value="chicken-noodle">
+        <input id="chicken-noodle" type="radio" name="soup" value="chicken-noodle" aria-describedby="historical-figures-2">
         <label for="chicken-noodle">Susan B. Anthony</label>
       </li>
       <li>
-        <input id="tomato" type="radio" name="soup" value="tomato">
+        <input id="tomato" type="radio" name="soup" value="tomato" aria-describedby="historical-figures-2">
         <label for="tomato">Harriet Tubman</label>
       </li>
     </ul>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -269,15 +269,15 @@ lead: Form controls allow users to enter information into a page.
     <div class="usa-date-of-birth">
       <div class="usa-datefield usa-form-group usa-form-group-month">
         <label for="date_of_birth_1">Month</label>
-        <input class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="" aria-labeledby="memorable-date date_of_birth_1" aria-describedby="dobHint">
+        <input class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="" aria-labeledby="memorable-date dobHint date_of_birth_1">
       </div>
       <div class="usa-datefield usa-form-group usa-form-group-day">
         <label for="date_of_birth_2">Day</label>
-        <input class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="" aria-labeledby="memorable-date date_of_birth_2" aria-describedby="dobHint">
+        <input class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="" aria-labeledby="memorable-date dobHint date_of_birth_2">
       </div>
       <div class="usa-datefield usa-form-group usa-form-group-year">
         <label for="date_of_birth_3">Year</label>
-        <input class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="" aria-labeledby="memorable-date date_of_birth_3" aria-describedby="dobHint">
+        <input class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="" aria-labeledby="memorable-date dobHint date_of_birth_3">
       </div>
     </div>
   </fieldset>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -269,15 +269,15 @@ lead: Form controls allow users to enter information into a page.
     <div class="usa-date-of-birth">
       <div class="usa-datefield usa-form-group usa-form-group-month">
         <label for="date_of_birth_1">Month</label>
-        <input class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="" aria-labeledby="memorable-date dobHint date_of_birth_1">
+        <input class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="" aria-labeledby="date_of_birth_1 memorable-date dobHint">
       </div>
       <div class="usa-datefield usa-form-group usa-form-group-day">
         <label for="date_of_birth_2">Day</label>
-        <input class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="" aria-labeledby="memorable-date dobHint date_of_birth_2">
+        <input class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="" aria-labeledby="date_of_birth_2 memorable-date dobHint">
       </div>
       <div class="usa-datefield usa-form-group usa-form-group-year">
         <label for="date_of_birth_3">Year</label>
-        <input class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="" aria-labeledby="memorable-date dobHint date_of_birth_3">
+        <input class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="" aria-labeledby="date_of_birth_3 memorable-date dobHint">
       </div>
     </div>
   </fieldset>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -263,21 +263,21 @@ lead: Form controls allow users to enter information into a page.
 <div class="preview">
 
   <fieldset>
-    <legend>Date of birth</legend>
+    <legend id="memorable-date">Date of birth</legend>
     <span class="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
 
     <div class="usa-date-of-birth">
       <div class="usa-datefield usa-form-group usa-form-group-month">
         <label for="date_of_birth_1">Month</label>
-        <input aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
+        <input class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="" aria-labeledby="memorable-date date_of_birth_1" aria-describedby="dobHint">
       </div>
       <div class="usa-datefield usa-form-group usa-form-group-day">
         <label for="date_of_birth_2">Day</label>
-        <input aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
+        <input class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="" aria-labeledby="memorable-date date_of_birth_2" aria-describedby="dobHint">
       </div>
       <div class="usa-datefield usa-form-group usa-form-group-year">
         <label for="date_of_birth_3">Year</label>
-        <input aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
+        <input class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="" aria-labeledby="memorable-date date_of_birth_3" aria-describedby="dobHint">
       </div>
     </div>
   </fieldset>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -135,20 +135,20 @@ lead: Form controls allow users to enter information into a page.
 
     <ul class="usa-unstyled-list">
       <li>
-        <input id="apple-pie" type="checkbox" name="pies" value="apple-pie" checked aria-describedby="historical-figures-1">
-        <label for="apple-pie">Sojourner Truth</label>
+        <input id="truth" type="checkbox" name="historical-figures-1" value="truth" checked aria-labeledby="truth historical-figures-1">
+        <label for="truth">Sojourner Truth</label>
       </li>
       <li>
-        <input id="key-lime-pie" type="checkbox" name="pies" value="key-lime-pie" aria-describedby="historical-figures-1">
-        <label for="key-lime-pie">Frederick Douglass</label>
+        <input id="douglass" type="checkbox" name="historical-figures-1" value="douglass" aria-labeledby="douglass historical-figures-1">
+        <label for="douglass">Frederick Douglass</label>
       </li>
       <li>
-        <input id="peach-pie" type="checkbox" name="pies" value="peach-pie" aria-describedby="historical-figures-1">
-        <label for="peach-pie">Booker T. Washington</label>
+        <input id="washington" type="checkbox" name="historical-figures-1" value="washington" aria-labeledby="washington historical-figures-1">
+        <label for="washington">Booker T. Washington</label>
       </li>
       <li>
-        <input id="disabled" type="checkbox" name="pies" disabled  aria-describedby="historical-figures-1">
-        <label for="disabled">George Washington Carver</label>
+        <input id="carver" type="checkbox" name="historical-figures-1" disabled  aria-labeledby="carver historical-figures-1">
+        <label for="carver">George Washington Carver</label>
       </li>
     </ul>
 
@@ -204,16 +204,16 @@ lead: Form controls allow users to enter information into a page.
 
     <ul class="usa-unstyled-list">
       <li>
-        <input id="pea-soup" type="radio" checked name="soup" value="pea" aria-describedby="historical-figures-2">
-        <label for="pea-soup">Elizabeth Cady Stanton</label>
+        <input id="stanton" type="radio" checked name="historical-figures-2" value="stanton" aria-labeledby="stanton historical-figures-2">
+        <label for="stanton">Elizabeth Cady Stanton</label>
       </li>
       <li>
-        <input id="chicken-noodle" type="radio" name="soup" value="chicken-noodle" aria-describedby="historical-figures-2">
-        <label for="chicken-noodle">Susan B. Anthony</label>
+        <input id="anthony" type="radio" name="historical-figures-2" value="anthony" aria-labeledby="stanton historical-figures-2">
+        <label for="anthony">Susan B. Anthony</label>
       </li>
       <li>
-        <input id="tomato" type="radio" name="soup" value="tomato" aria-describedby="historical-figures-2">
-        <label for="tomato">Harriet Tubman</label>
+        <input id="tubman" type="radio" name="historical-figures-2" value="tubman" aria-labeledby="tubman historical-figures-2">
+        <label for="tubman">Harriet Tubman</label>
       </li>
     </ul>
 


### PR DESCRIPTION
## Description

Fieldset and legend are not supported by VoiceOver on iOS and OS X, so this changes our code so it will work. This is not the ideal way but necessary to make Apple work, bugs have been reported about this issue Apple already.

This also fixes some of our labels that were still reading different pies instead of historical figures.

cc: @nickbristow 

Fixes: #792.