### PR TITLE
[Forms]: Add documentation for screen reader support

### DIFF
--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -21,7 +21,14 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <h4>Supporting screen readers</h4>
 
-<p>content goes here</p>
+<p><b>Note: </b>These code examples have been designed to support a wide range of screen readers, but that does not guarantee it will work with all versions.</p>
+
+<h5>Known issues</h5>
+<ul>
+  <li>Voiceover on iOS currently does not support fieldset and legend for forms. This can be addressed by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
+  
+  <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields including, labels, legned, and hint text</li>
+</ul>
 
 <h2 class="usa-heading" id="name-form">Name form</h2>
 <p class="usa-font-lead">A standard template for collecting a person’s full name</p>

--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -19,6 +19,10 @@ lead: Patterns for some of the most commonly used forms on government websites
   <li>Keep your form blocks in a vertical pattern. It's an ideal approach for accessibility, due to limited vision that makes it hard to scan from right to left.</li>
 </ul>
 
+<h4>Supporting screen readers</h4>
+
+<p>content goes here</p>
+
 <h2 class="usa-heading" id="name-form">Name form</h2>
 <p class="usa-font-lead">A standard template for collecting a person’s full name</p>
 

--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -25,9 +25,9 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <h5>Known issues</h5>
 
-<ul>
-  <li>Voiceover on iOS currently does not support fieldset and legend for forms. You can address this by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-  <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields, including, labels, legned, and hint text</li>
+<ul class="usa-content-list">
+  <li>Voiceover on iOS currently does not support fieldset and legend for forms. You can address this by using <code>aria-labeledby="for-attribute-of-label id-of-legend id-of-additional-info"</code> on each input in the fieldset. Using <code>aria-labeledby</code> will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
+  <li>Voiceover on OSX currently does not support <code>aria-describedby</code>. Use <code>aria-labeledby</code> instead, and include all related fields, including, labels, legned, and hint text</li>
 </ul>
 
 <h2 class="usa-heading" id="name-form">Name form</h2>

--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -21,12 +21,12 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <h4>Supporting screen readers</h4>
 
-<p><b>Note: </b>These code examples have been designed to support a wide range of screen readers, but that does not guarantee it will work with all versions.</p>
+<p><b>Note:</b> These code examples have been designed to support a wide range of screen readers, but that does not guarantee it will work with all versions.</p>
 
 <h5>Known issues</h5>
+
 <ul>
   <li>Voiceover on iOS currently does not support fieldset and legend for forms. This can be addressed by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-  
   <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields including, labels, legned, and hint text</li>
 </ul>
 

--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -26,8 +26,8 @@ lead: Patterns for some of the most commonly used forms on government websites
 <h5>Known issues</h5>
 
 <ul class="usa-content-list">
-  <li>Voiceover on iOS currently does not support fieldset and legend for forms. You can address this by using <code>aria-labeledby="for-attribute-of-label id-of-legend id-of-additional-info"</code> on each input in the fieldset. Using <code>aria-labeledby</code> will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-  <li>Voiceover on OSX currently does not support <code>aria-describedby</code>. Use <code>aria-labeledby</code> instead, and include all related fields, including, labels, legned, and hint text</li>
+  <li>VoiceOver on iOS currently does not support fieldset and legend for forms. You can address this by using <code>aria-labeledby="for-attribute-of-label id-of-legend id-of-additional-info"</code> on each input in the fieldset. Using <code>aria-labeledby</code> will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
+  <li>VoiceOver on OS X currently does not support <code>aria-describedby</code>. Use <code>aria-labeledby</code> instead, and include all related fields, including, labels, legend, and hint text</li>
 </ul>
 
 <h2 class="usa-heading" id="name-form">Name form</h2>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -25,9 +25,9 @@ lead: Form controls allow users to enter information into a page.
 
 <h5>Known issues</h5>
 
-<ul>
-  <li>Voiceover on iOS currently does not support fieldset and legend for forms. You can address this by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-  <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields, including, labels, legned, and hint text</li>
+<ul class="usa-content-list">
+  <li>Voiceover on iOS currently does not support fieldset and legend for forms. You can address this by using <code>aria-labeledby="for-attribute-of-label id-of-legend id-of-additional-info"</code> on each input in the fieldset. Using <code>aria-labeledby</code> will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
+  <li>Voiceover on OSX currently does not support <code>aria-describedby</code>. Use <code>aria-labeledby</code> instead, and include all related fields, including, labels, legned, and hint text</li>
 </ul>
 
 <p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines in the “Form Templates” section</a>.</p>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -18,12 +18,12 @@ lead: Form controls allow users to enter information into a page.
 
 <h4>Supporting screen readers</h4>
 
-<p><b>Note: </b>These code examples have been designed to support a wide range of screen readers, but that does not guarantee it will work with all versions.</p>
+<p><b>Note:</b> These code examples have been designed to support a wide range of screen readers, but that does not guarantee it will work with all versions.</p>
 
 <h5>Known issues</h5>
+
 <ul>
   <li>Voiceover on iOS currently does not support fieldset and legend for forms. This can be addressed by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-  
   <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields including, labels, legned, and hint text</li>
 </ul>
 

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -7,24 +7,27 @@ lead: Form controls allow users to enter information into a page.
 
 <h3 class="usa-heading">Accessibility</h3>
 
-<p>As you customize form controls from this library, be sure they continue to meet the following accessibility requirements:</p>
+<p>As you customize these templates, make sure they continue to meet the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for all form controls</a> as well as the accessibility guidelines for each individual control.</p>
+<p>In addition, when creating forms with multiple controls or customizing these templates, be sure to:</p>
 
 <ul class="usa-content-list">
-  <li>All form control tags should have an associated label. The labels for attribute value should match the related input <code>id</code> attribute and should also be unique to the entire page. For example, the input with <code>id=<wbr>"favorite-national-park"</code> will always have a label with <code>for=<wbr>"favorite-national-park"</code>. This way screen readers are able to perceive the relevant content.</li>
-  <li>Any additional information — such as required, optional, or example text — should be wrapped within the label tags. For example: <code>&lt;label for=<wbr>"name"&gt;Favorite Pie &lt;span&gt;Optional&lt;/span&gt;&lt;/label&gt;</code>. This way screen readers know what additional information is related to each field.</li>
-  <li>Do not replace <code>&lt;input&gt;</code> tag-based form controls with styled <code>&lt;div&gt;</code> tags, or use JavaScript to create 'fake' form controls. Screen readers have a difficult time reading form controls that are not written in semantic HTML.</li>
-  <li>If you adjust the color scheme of the buttons, ensure a minimum contrast ratio of 4.5:1 (for small text, 3:1 for large) for the default, hover, focus, and selected states of the button. The disabled state may have less contrast to indicate that it is inactive.</li>
+  <li>Display form controls in the same order in HTML as they appear on screen. Do not use CSS to rearrange the form controls. Screen readers narrate forms in the order they appear in the HTML.</li>
+  <li>Visually align validation messages with the input fields, so people using screen magnifiers can read them quickly.</li>
+  <li>Group each set of thematically related controls in a fieldset element. Use the legend element to offer a label within each one. The fieldset and legend elements make it easier for screen reader users to navigate the form.</li>
+  <li>Use a single legend for fieldset (this is required). One example of a common use of fieldset and legend is a question with radio button options for answers. The question text and radio buttons are wrapped in a fieldset, with the question itself being inside the legend tag.</li>
+  <li>Embed multiple fieldsets and legends for more complex forms.</li>
+  <li>Keep your form blocks in a vertical pattern. This approach is ideal, from an accessibility standpoint, because of limited vision that makes it hard to scan from right to left.</li>
 </ul>
 
 <h4>Supporting screen readers</h4>
 
-<p><b>Note:</b> These code examples have been designed to support a wide range of screen readers, but that does not guarantee it will work with all versions.</p>
+<p><b>Note:</b> These code examples have been designed to support a range of screen readers. That said, they may not work with all versions.</p>
 
 <h5>Known issues</h5>
 
 <ul>
-  <li>Voiceover on iOS currently does not support fieldset and legend for forms. This can be addressed by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-  <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields including, labels, legned, and hint text</li>
+  <li>Voiceover on iOS currently does not support fieldset and legend for forms. You can address this by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
+  <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields, including, labels, legned, and hint text</li>
 </ul>
 
 <p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines in the “Form Templates” section</a>.</p>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -26,8 +26,8 @@ lead: Form controls allow users to enter information into a page.
 <h5>Known issues</h5>
 
 <ul class="usa-content-list">
-  <li>Voiceover on iOS currently does not support fieldset and legend for forms. You can address this by using <code>aria-labeledby="for-attribute-of-label id-of-legend id-of-additional-info"</code> on each input in the fieldset. Using <code>aria-labeledby</code> will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-  <li>Voiceover on OSX currently does not support <code>aria-describedby</code>. Use <code>aria-labeledby</code> instead, and include all related fields, including, labels, legned, and hint text</li>
+  <li>VoiceOver on iOS currently does not support fieldset and legend for forms. You can address this by using <code>aria-labeledby="for-attribute-of-label id-of-legend id-of-additional-info"</code> on each input in the fieldset. Using <code>aria-labeledby</code> will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
+  <li>VoiceOver on OS X currently does not support <code>aria-describedby</code>. Use <code>aria-labeledby</code> instead, and include all related fields, including, labels, legend, and hint text</li>
 </ul>
 
 <p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines in the “Form Templates” section</a>.</p>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -18,7 +18,14 @@ lead: Form controls allow users to enter information into a page.
 
 <h4>Supporting screen readers</h4>
 
-<p>content goes here</p>
+<p><b>Note: </b>These code examples have been designed to support a wide range of screen readers, but that does not guarantee it will work with all versions.</p>
+
+<h5>Known issues</h5>
+<ul>
+  <li>Voiceover on iOS currently does not support fieldset and legend for forms. This can be addressed by using `aria-labeledby='for-attribute-of-label id-of-legend id-of-additional-info'` on each input in the fieldset. Using `aria-labeledby` will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
+  
+  <li>Voiceover on OSX currently does not support `aria-describedby`. Use `aria-labeledby` instead, and include all related fields including, labels, legned, and hint text</li>
+</ul>
 
 <p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines in the “Form Templates” section</a>.</p>
 

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -16,6 +16,10 @@ lead: Form controls allow users to enter information into a page.
   <li>If you adjust the color scheme of the buttons, ensure a minimum contrast ratio of 4.5:1 (for small text, 3:1 for large) for the default, hover, focus, and selected states of the button. The disabled state may have less contrast to indicate that it is inactive.</li>
 </ul>
 
+<h4>Supporting screen readers</h4>
+
+<p>content goes here</p>
+
 <p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines in the “Form Templates” section</a>.</p>
 
 <h2 class="usa-heading" id="text-inputs">Text input</h2>


### PR DESCRIPTION
## Description

This adds a new section for supporting screen readers for special circumstances (i.e. iOS and OS X behavior) in the thematic forms accessibility documentation in Form controls and Form templates pages. 

Replaces code changes in #1220.

- [x] @nickbristow will write the content.
- [x] Content review by @kategarklavs 

Resolves #792.