### PR TITLE
[Accordion]: Make content accessible without JavaScript

### DIFF
--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -16,7 +16,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
           aria-expanded="true" aria-controls="collapsible-0">
           First Amendment
         </button>
-        <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+        <div id="collapsible-0" class="usa-accordion-content">
           <p>
           Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
           </p>
@@ -24,10 +24,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-1">
+          aria-controls="collapsible-1">
           Second Amendment
         </button>
-        <div id="collapsible-1" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-1" class="usa-accordion-content">
           <p>
           A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
           </p>
@@ -35,10 +35,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-            aria-expanded="false" aria-controls="collapsible-2">
+            aria-controls="collapsible-2">
           Third Amendment
         </button>
-        <div id="collapsible-2" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-2" class="usa-accordion-content">
           <p>
           No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
           </p>
@@ -46,10 +46,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-3">
+          aria-controls="collapsible-3">
           Fourth Amendment
         </button>
-        <div id="collapsible-3" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-3" class="usa-accordion-content">
           <p>
           The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
           </p>
@@ -57,10 +57,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-4">
+          aria-controls="collapsible-4">
           Fifth Amendment
         </button>
-        <div id="collapsible-4" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-4" class="usa-accordion-content">
           <p>
           No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
           </p>
@@ -78,7 +78,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
           aria-expanded="true" aria-controls="collapsible-0">
           First Amendment
         </button>
-        <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+        <div id="collapsible-0" class="usa-accordion-content">
           <p>
           Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
           </p>
@@ -86,10 +86,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-1">
+          aria-controls="collapsible-1">
           Second Amendment
         </button>
-        <div id="collapsible-1" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-1" class="usa-accordion-content">
           <p>
           A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
           </p>
@@ -97,10 +97,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-2">
+          aria-controls="collapsible-2">
           Third Amendment
         </button>
-        <div id="collapsible-2" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-2" class="usa-accordion-content">
           <p>
           No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
           </p>
@@ -108,10 +108,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-3">
+          aria-controls="collapsible-3">
           Fourth Amendment
         </button>
-        <div id="collapsible-3" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-3" class="usa-accordion-content">
           <p>
           The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
           </p>
@@ -119,10 +119,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-4">
+          aria-controls="collapsible-4">
           Fifth Amendment
         </button>
-        <div id="collapsible-4" aria-hidden="true" class="usa-accordion-content">
+        <div id="collapsible-4" class="usa-accordion-content">
           <p>
           No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
           </p>
@@ -138,7 +138,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
     aria-expanded="true" aria-controls="collapsible-0">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="collapsible-0" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -75,10 +75,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
     <ul class="usa-unstyled-list">
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="true" aria-controls="amendment-1">
+          aria-expanded="true" aria-controls="amendment-b-1">
           First Amendment
         </button>
-        <div id="amendment-1" class="usa-accordion-content">
+        <div id="amendment-b-1" class="usa-accordion-content">
           <p>
           Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
           </p>
@@ -86,10 +86,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="amendment-2">
+          aria-controls="amendment-b-2">
           Second Amendment
         </button>
-        <div id="amendment-2" class="usa-accordion-content">
+        <div id="amendment-b-2" class="usa-accordion-content">
           <p>
           A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
           </p>
@@ -97,10 +97,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="amendment-3">
+          aria-controls="amendment-b-3">
           Third Amendment
         </button>
-        <div id="amendment-3" class="usa-accordion-content">
+        <div id="amendment-b-3" class="usa-accordion-content">
           <p>
           No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
           </p>
@@ -108,10 +108,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="amendment-4">
+          aria-controls="amendment-b-4">
           Fourth Amendment
         </button>
-        <div id="amendment-4" class="usa-accordion-content">
+        <div id="amendment-b-4" class="usa-accordion-content">
           <p>
           The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
           </p>
@@ -119,10 +119,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="amendment-5">
+          aria-controls="amendment-b-5">
           Fifth Amendment
         </button>
-        <div id="amendment-5" class="usa-accordion-content">
+        <div id="amendment-b-5" class="usa-accordion-content">
           <p>
           No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
           </p>

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -145,10 +145,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
         Code header areas in the accordion as <code>&lt;buttons&gt;</code> so that they are usable with both screen readers and the keyboard.
       </li>
       <li>
-        Buttons should  state whether they are expanded or not with the appropriate attribute: use either <code>aria-expanded=<wbr>’true’</code> or <code>aria-expanded=<wbr>’false’</code>.
+        Buttons should state whether they are expanded or not with the appropriate attribute: use either <code>aria-expanded=<wbr>"true"</code> or <code>aria-expanded=<wbr>"false"</code>.
       </li>
       <li>
-        Each button has a unique name <code>aria-controls=<wbr>’collapsible-#’</code> that associates the control to the appropriate region by referencing the controlled elements <code>id</code>.
+        Each button has a unique name <code>aria-controls=<wbr>"collapsible-#"</code> that associates the control to the appropriate region by referencing the controlled elements <code>id</code>.
       </li>
       <li>
         Each content area has an <code>aria-hidden</code> attribute set to either <code>true</code> or <code>false</code>. When <code>true</code>, the element (and all children) are neither visible or perceivable, and assistive technologies will skip this content.

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -145,13 +145,13 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
         Code header areas in the accordion as <code>&lt;buttons&gt;</code> so that they are usable with both screen readers and the keyboard.
       </li>
       <li>
-        Buttons should state whether they are expanded or not with the appropriate attribute: use either <code>aria-expanded=<wbr>"true"</code> or <code>aria-expanded=<wbr>"false"</code>.
+        Buttons should state if they are expanded with <code>aria-expanded=<wbr>"true"</code>. The <code>aria-expanded=<wbr>"false"</code> attributes will be added to other buttons when the accordion is initialized by the JavaScript.
       </li>
       <li>
-        Each button has a unique name <code>aria-controls=<wbr>"collapsible-#"</code> that associates the control to the appropriate region by referencing the controlled elements <code>id</code>.
+        Each button has a unique name <code>aria-controls=<wbr>"id"</code> that associates the control to the appropriate region by referencing the controlled element&rsquo;s <code>id</code>.
       </li>
       <li>
-        Each content area has an <code>aria-hidden</code> attribute set to either <code>true</code> or <code>false</code>. When <code>true</code>, the element (and all children) are neither visible or perceivable, and assistive technologies will skip this content.
+        Each content area will have its <code>aria-hidden</code> attribute set to either <code>true</code> or <code>false</code> by the component, depending on its corresponding button&rsquo;s <code>aria-expaded</code> attribute. To ensure that your content is accessible in the event that the JavaScript does not load or is disabled, you should not set <code>aria-hidden=<wbr>"true"</wbr></code> on any of your content areas.
       </li>
     </ul>
     <h4 class="usa-heading">Usability</h4>

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -13,10 +13,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
     <ul class="usa-unstyled-list">
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="true" aria-controls="collapsible-0">
+          aria-expanded="true" aria-controls="amendment-1">
           First Amendment
         </button>
-        <div id="collapsible-0" class="usa-accordion-content">
+        <div id="amendment-1" class="usa-accordion-content">
           <p>
           Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
           </p>
@@ -24,10 +24,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="collapsible-1">
+          aria-controls="amendment-2">
           Second Amendment
         </button>
-        <div id="collapsible-1" class="usa-accordion-content">
+        <div id="amendment-2" class="usa-accordion-content">
           <p>
           A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
           </p>
@@ -35,10 +35,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-            aria-controls="collapsible-2">
+            aria-controls="amendment-3">
           Third Amendment
         </button>
-        <div id="collapsible-2" class="usa-accordion-content">
+        <div id="amendment-3" class="usa-accordion-content">
           <p>
           No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
           </p>
@@ -46,10 +46,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="collapsible-3">
+          aria-controls="amendment-4">
           Fourth Amendment
         </button>
-        <div id="collapsible-3" class="usa-accordion-content">
+        <div id="amendment-4" class="usa-accordion-content">
           <p>
           The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
           </p>
@@ -57,10 +57,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="collapsible-4">
+          aria-controls="amendment-5">
           Fifth Amendment
         </button>
-        <div id="collapsible-4" class="usa-accordion-content">
+        <div id="amendment-5" class="usa-accordion-content">
           <p>
           No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
           </p>
@@ -75,10 +75,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
     <ul class="usa-unstyled-list">
       <li>
         <button class="usa-button-unstyled"
-          aria-expanded="true" aria-controls="collapsible-0">
+          aria-expanded="true" aria-controls="amendment-1">
           First Amendment
         </button>
-        <div id="collapsible-0" class="usa-accordion-content">
+        <div id="amendment-1" class="usa-accordion-content">
           <p>
           Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
           </p>
@@ -86,10 +86,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="collapsible-1">
+          aria-controls="amendment-2">
           Second Amendment
         </button>
-        <div id="collapsible-1" class="usa-accordion-content">
+        <div id="amendment-2" class="usa-accordion-content">
           <p>
           A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
           </p>
@@ -97,10 +97,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="collapsible-2">
+          aria-controls="amendment-3">
           Third Amendment
         </button>
-        <div id="collapsible-2" class="usa-accordion-content">
+        <div id="amendment-3" class="usa-accordion-content">
           <p>
           No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
           </p>
@@ -108,10 +108,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="collapsible-3">
+          aria-controls="amendment-4">
           Fourth Amendment
         </button>
-        <div id="collapsible-3" class="usa-accordion-content">
+        <div id="amendment-4" class="usa-accordion-content">
           <p>
           The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
           </p>
@@ -119,10 +119,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
       </li>
       <li>
         <button class="usa-button-unstyled"
-          aria-controls="collapsible-4">
+          aria-controls="amendment-5">
           Fifth Amendment
         </button>
-        <div id="collapsible-4" class="usa-accordion-content">
+        <div id="amendment-5" class="usa-accordion-content">
           <p>
           No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
           </p>
@@ -135,10 +135,10 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
 
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-    aria-expanded="true" aria-controls="collapsible-0">
+    aria-expanded="true" aria-controls="documentation">
     Documentation
   </button>
-  <div id="collapsible-0" class="usa-accordion-content">
+  <div id="documentation" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -151,7 +151,7 @@ lead: Accordions are a list of headers that can be clicked to hide or reveal add
         Each button has a unique name <code>aria-controls=<wbr>"id"</code> that associates the control to the appropriate region by referencing the controlled element&rsquo;s <code>id</code>.
       </li>
       <li>
-        Each content area will have its <code>aria-hidden</code> attribute set to either <code>true</code> or <code>false</code> by the component, depending on its corresponding button&rsquo;s <code>aria-expaded</code> attribute. To ensure that your content is accessible in the event that the JavaScript does not load or is disabled, you should not set <code>aria-hidden=<wbr>"true"</wbr></code> on any of your content areas.
+        Each content area will have its <code>aria-hidden</code> attribute set to either <code>true</code> or <code>false</code> by the component, depending on its corresponding button&rsquo;s <code>aria-expanded</code> attribute. To ensure that your content is accessible in the event that the JavaScript does not load or is disabled, you should not set <code>aria-hidden=<wbr>"true"</wbr></code> on any of your content areas.
       </li>
     </ul>
     <h4 class="usa-heading">Usability</h4>

--- a/docs/_elements/tables.md
+++ b/docs/_elements/tables.md
@@ -12,29 +12,29 @@ lead: Tables show tabular data in columns and rows.
   <table>
     <thead>
       <tr>
-        <th scope='col'>Document title</th>
-        <th scope='col'>Description</th>
-        <th scope='col'>Year</th>
+        <th scope="col">Document title</th>
+        <th scope="col">Description</th>
+        <th scope="col">Year</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th scope='row'>Declaration of Independence</th>
+        <th scope="row">Declaration of Independence</th>
         <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
         <td>1776</td>
       </tr>
       <tr>
-        <th scope='row'>Bill of Rights</th>
+        <th scope="row">Bill of Rights</th>
         <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
         <td>1791</td>
       </tr>
       <tr>
-        <th scope='row'>Declaration of Sentiments</th>
+        <th scope="row">Declaration of Sentiments</th>
         <td>A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
         <td>1848</td>
       </tr>
       <tr>
-        <th scope='row'>Emancipation Proclamation</th>
+        <th scope="row">Emancipation Proclamation</th>
         <td>An executive order granting freedom to slaves in designated southern states.</td>
         <td>1863</td>
       </tr>
@@ -46,29 +46,29 @@ lead: Tables show tabular data in columns and rows.
   <table class="usa-table-borderless">
     <thead>
       <tr>
-        <th scope='col'>Document Title</th>
-        <th scope='col'>Description</th>
-        <th scope='col'>Year</th>
+        <th scope="col">Document Title</th>
+        <th scope="col">Description</th>
+        <th scope="col">Year</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th scope='row'>Declaration of Independence</th>
+        <th scope="row">Declaration of Independence</th>
         <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
         <td>1776</td>
       </tr>
       <tr>
-        <th scope='row'>Bill of Rights</th>
+        <th scope="row">Bill of Rights</th>
         <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
         <td>1791</td>
       </tr>
       <tr>
-        <th scope='row'>Declaration of Sentiments</th>
+        <th scope="row">Declaration of Sentiments</th>
         <td>MadeA document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
         <td>1848</td>
       </tr>
       <tr>
-        <th scope='row'>Emancipation Proclamation</th>
+        <th scope="row">Emancipation Proclamation</th>
         <td>An executive order granting freedom to slaves in designated southern states.</td>
         <td>1863</td>
       </tr>      
@@ -85,7 +85,7 @@ lead: Tables show tabular data in columns and rows.
   <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
-      <li>Simple tables can have two levels of headers. Each header cell should have <code>scope=<wbr>'col'</code> or <code>scope=<wbr>'row'</code>.</li>
+      <li>Simple tables can have two levels of headers. Each header cell should have <code>scope=<wbr>"col"</code> or <code>scope=<wbr>"row"</code>.</li>
       <li>Complex tables are tables with more than two levels of headers. Each header should be given a unique <code>id</code> and each data cell should have a <code>headers</code> attribute with each related header cell’s <code>id</code> listed.</li>
       <li>When adding a title to a table, include it in a <code>&lt;caption&gt;</code> tag inside of the <code>&lt;table&gt;</code> element.</li>
     </ul>

--- a/docs/doc_assets/js/styleguide.js
+++ b/docs/doc_assets/js/styleguide.js
@@ -30,8 +30,8 @@ $(function(){
         '<div class="usa-accordion-bordered usa-code-sample">' +
           '<ul class="usa-unstyled-list">' +
             '<li>' +
-              '<button class="usa-button-unstyled" aria-expanded="false" aria-controls="collapsible-0">Code</button>' +
-              '<div id="collapsible-0" aria-hidden="true" class="usa-accordion-content">' +
+              '<button class="usa-button-unstyled" aria-controls="collapsible-0">Code</button>' +
+              '<div id="collapsible-0" class="usa-accordion-content">' +
                 '<pre><code class="language-markup"></code></pre>' +
               '</div>' +
             '</li>' +

--- a/docs/doc_assets/js/styleguide.js
+++ b/docs/doc_assets/js/styleguide.js
@@ -30,8 +30,8 @@ $(function(){
         '<div class="usa-accordion-bordered usa-code-sample">' +
           '<ul class="usa-unstyled-list">' +
             '<li>' +
-              '<button class="usa-button-unstyled" aria-controls="collapsible-0">Code</button>' +
-              '<div id="collapsible-0" class="usa-accordion-content">' +
+              '<button class="usa-button-unstyled" aria-controls="code">Code</button>' +
+              '<div id="code" class="usa-accordion-content">' +
                 '<pre><code class="language-markup"></code></pre>' +
               '</div>' +
             '</li>' +

--- a/spec/unit/accordion/accordion.spec.js
+++ b/spec/unit/accordion/accordion.spec.js
@@ -25,7 +25,7 @@ describe('Accordion component', function () {
     $el = accordion.$root;
     $button = $el.find('button');
     $content = $el.find('#' + $button.attr(CONTROLS));
-  });   
+  });
 
   afterEach(function () {
     document.body.textContent = '';

--- a/spec/unit/accordion/template.js
+++ b/spec/unit/accordion/template.js
@@ -1,6 +1,6 @@
 var template = [
   '<div class="usa-accordion">',
-  '<button class="usa-button-unstyled" aria-expanded="false" aria-controls="collapsible-0"></button>',
+  '<button class="usa-button-unstyled" aria-controls="collapsible-0"></button>',
   '<div id="collapsible-0" aria-hidden="true" class="usa-accordion-content"></div>',
   '</div>'
 ].join(',');

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -25,10 +25,9 @@ function Accordion ($el) {
 
   // find the first expanded button
   var $expanded = this.$('button[aria-expanded=true]');
+  this.hideAll();
   if ($expanded.length) {
     this.show($expanded);
-  } else {
-    this.hideAll();
   }
 }
 

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -11,12 +11,15 @@ var $ = require('jquery');
 function Accordion ($el) {
   var self = this;
   this.$root = $el;
+
+  // delegate click events on each <button>
   this.$root.on('click', 'button', function (ev) {
-    var expanded = JSON.parse($(this).attr('aria-expanded'));
+    var $button = $(this);
+    var expanded = $button.attr('aria-expanded') === 'true';
     ev.preventDefault();
     self.hideAll();
     if (!expanded) {
-      self.show($(this));
+      self.show($button);
     }
   });
 

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -19,6 +19,14 @@ function Accordion ($el) {
       self.show($(this));
     }
   });
+
+  // find the first expanded button
+  var $expanded = this.$('button[aria-expanded=true]');
+  if ($expanded.length) {
+    this.show($expanded);
+  } else {
+    this.hideAll();
+  }
 }
 
 Accordion.prototype.$ = function (selector) {

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -63,6 +63,7 @@ Accordion.prototype.show = function ($button) {
 
   $button.attr('aria-expanded', true);
   $content.attr('aria-hidden', false);
+  return this;
 };
 
 /**
@@ -73,6 +74,7 @@ Accordion.prototype.hideAll = function () {
   this.$('button').each(function () {
     self.hide($(this));
   });
+  return this;
 };
 
 module.exports = Accordion;

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -2,11 +2,11 @@
 var $ = require('jquery');
 
 /**
- * Accordion
+ * @class Accordion
  *
  * An accordion component.
  *
- * @param {jQuery} $el A jQuery html element to turn into an accordion.
+ * @param {jQuery} el A jQuery html element to turn into an accordion.
  */
 function Accordion ($el) {
   var self = this;
@@ -32,18 +32,31 @@ function Accordion ($el) {
   }
 }
 
+/**
+ * @param {String} selector
+ * @return {jQuery}
+ */
 Accordion.prototype.$ = function (selector) {
   return this.$root.find(selector);
 };
 
+/**
+ * @param {jQuery} button
+ * @return {Accordion}
+ */
 Accordion.prototype.hide = function ($button) {
   var selector = $button.attr('aria-controls'),
     $content = this.$('#' + selector);
-  
+
   $button.attr('aria-expanded', false);
   $content.attr('aria-hidden', true);
+  return this;
 };
 
+/**
+ * @param {jQuery} button
+ * @return {Accordion}
+ */
 Accordion.prototype.show = function ($button) {
   var selector = $button.attr('aria-controls'),
     $content = this.$('#' + selector);
@@ -52,6 +65,9 @@ Accordion.prototype.show = function ($button) {
   $content.attr('aria-hidden', false);
 };
 
+/**
+ * @return {Accordion}
+ */
 Accordion.prototype.hideAll = function () {
   var self = this;
   this.$('button').each(function () {


### PR DESCRIPTION
## Description

This PR updates the accordion component to update its buttons' and corresponding content elements' `aria-expanded` and `aria-hidden` attributes (respectively) when initialized. This means that we can strip all of the `aria-expanded="false"` and `aria-hidden="true"` attributes from the HTML, which makes the content accessible in the event that the JS isn't loaded (or until it is). Hopefully, this addresses #1122.

⚠️ Note that the biggest change here is not in the JS, but in the HTML: Users will be expected to update their HTML to remove `aria-expanded="false"` and `aria-hidden="true"` attributes from accordion panels that aren't expanded by default so that their content is accessible without JS.

## Additional information

* The accordion documentation (and all of the accordions in each component's documentation) markup now reflects the best practice of leaving `aria-expanded="false"` and `aria-hidden="true"` attributes out, so that the content is accessible without JavaScript.
* I've updated the accordion documentation to state that the `aria-expanded` and `aria-hidden` attributes are unnecessary now (except in the case of the content area that you wish to be expanded by default), but this could probably use some clarification and/or word-smithing from @kategarklavs.
* The demo HTML now uses the `amendment-n+1` naming convention instead of `collapsible-n`, so that it plays nicely with the the Code and Documentation accordion below. See: #1225
* I've added jsdoc comments to all of the Accordion methods, and updated some of the existing ones.
* The Accordion JS component also now returns `this` from its `show()`, `hide()`, and `hideAll()` methods, so its methods are chainable. I'm happy to back out of this change if it's not consistent with the rest of the library.
