### PR TITLE
[Forms]: Remove max-width on form element, move to class

### DIFF
--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -35,7 +35,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form>
+  <form class="usa-form">
     <fieldset>
       <legend>Name</legend>
       <label for="title">Title</label>
@@ -205,7 +205,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form>
+  <form class="usa-form">
     <fieldset>
       <legend class="usa-drop_text">Sign in</legend>
       <span>or <a href="#">create an account</a></span>
@@ -268,7 +268,7 @@ lead: Patterns for some of the most commonly used forms on government websites
 
 <div class="preview">
 
-  <form>
+  <form class="usa-form">
     <fieldset>
       <legend class="usa-drop_text">Reset password</legend>
       <span class="usa-serif">Please enter your new password</span>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -93,7 +93,7 @@ lead: Form controls allow users to enter information into a page.
 <p class="usa-font-lead">A dropdown allows users to select one option from a list.</p>
 
 <div class="preview">
-<form>
+<form class="usa-form">
   <label for="options">Dropdown label</label>
   <select name="options" id="options">
     <option value="value1">Option A</option>

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -1,5 +1,3 @@
-$usa-form-width: 32rem;
-
 form {
   a {
     border-bottom: 0;
@@ -26,7 +24,7 @@ form {
 
 .usa-form {
   @include media($medium-screen) {
-    max-width: $usa-form-width;
+    max-width: 32rem;
   }
 }
 
@@ -120,10 +118,6 @@ input.usa-input-medium {
   select {
     margin-bottom: 3rem;
   }
-}
-
-.usa-form-width {
-  max-width: $usa-form-width;
 }
 
 .usa-additional_text {

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -1,3 +1,5 @@
+$usa-form-width: 32rem;
+
 form {
   a {
     border-bottom: 0;
@@ -24,7 +26,7 @@ form {
 
 .usa-form {
   @include media($medium-screen) {
-    max-width: 32rem;
+    max-width: $usa-form-width;
   }
 }
 

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -1,10 +1,6 @@
 $usa-form-width: 32rem;
 
 form {
-  @include media($medium-screen) {
-    max-width: $usa-form-width;
-  }
-
   a {
     border-bottom: 0;
   }
@@ -25,6 +21,12 @@ form {
   input[name="password"],
   input[name="confirmPassword"] {
     margin-bottom: 1.1rem;
+  }
+}
+
+.usa-form {
+  @include media($medium-screen) {
+    max-width: $usa-form-width;
   }
 }
 


### PR DESCRIPTION
## Description

Removes max-width on form element and moves it to `usa-form` class.

**Note**: Inputs still have a max-width of 46rem / 460px.

This also removes a class which was not in use in the site: `usa-form-width`. I was thinking about removing the width variable (bc it doesn't change) but decided to keep it in case people want to change the default form width.

Resolves: #327

cc @msecret 