### PR TITLE
[Form controls]: Fix date input error state

### DIFF
--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -278,20 +278,20 @@ lead: Form controls allow users to enter information into a page.
 
   <fieldset>
     <legend>Date of birth</legend>
-    <span class="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
+    <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
 
     <div class="usa-date-of-birth">
-      <div class="usa-datefield usa-form-group usa-form-group-month">
+      <div class="usa-form-group usa-form-group-month">
         <label for="date_of_birth_1">Month</label>
-        <input aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
       </div>
-      <div class="usa-datefield usa-form-group usa-form-group-day">
+      <div class="usa-form-group usa-form-group-day">
         <label for="date_of_birth_2">Day</label>
-        <input aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
       </div>
-      <div class="usa-datefield usa-form-group usa-form-group-year">
+      <div class="usa-form-group usa-form-group-year">
         <label for="date_of_birth_3">Year</label>
-        <input aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
       </div>
     </div>
   </fieldset>

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -77,6 +77,12 @@ select {
   label {
     margin-top: 0;
   }
+
+  .usa-datefield {
+    input {
+      width: inherit;
+    }
+  }
 }
 
 .usa-input-error-label {

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -88,8 +88,6 @@ select {
   }
 }
 
-
-
 .usa-input-error-label {
   display: block;
   font-size: $base-font-size;

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -78,12 +78,17 @@ select {
     margin-top: 0;
   }
 
-  .usa-datefield {
-    input {
-      width: inherit;
-    }
+  .usa-input-inline {
+    border: $input-border-width solid $color-gray;
+    width: inherit;
+  }
+
+  .usa-input-inline-error {
+    border: 3px solid $color-secondary-dark;
   }
 }
+
+
 
 .usa-input-error-label {
   display: block;


### PR DESCRIPTION
## Description

Fixes date input error state. Allows you to wrap date form in a div with `usa-input-error` to get an error state.

#### This is what it looks like:

<img width="331" alt="screen shot 2016-06-10 at 2 51 43 pm" src="https://cloud.githubusercontent.com/assets/5249443/15979852/907b6908-2f1b-11e6-9731-bdf4e7641a39.png">

cc: @ericadeahl for design review.

Fixes: #1094.