### PR TITLE
[Form controls]: Fix input width in error state

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -71,7 +71,7 @@ select {
   textarea,
   select {
     border: 3px solid $color-secondary-dark;
-    width: calc(100% + 1.5rem);
+    width: calc(100% + 1.9rem); // 1.5rem left padding + 4px border from input error spacing
   }
 
   label {


### PR DESCRIPTION
## Description

Fixes input width in error state where the input was 4px too short bc it didn't account for the 4px border (on mobile).

Before:

<img width="510" alt="screen shot 2016-06-10 at 2 39 25 pm" src="https://cloud.githubusercontent.com/assets/5249443/15979955/547e465e-2f1c-11e6-85fc-0518b9aa01c6.png">

After:

<img width="528" alt="screen shot 2016-06-10 at 2 39 41 pm" src="https://cloud.githubusercontent.com/assets/5249443/15979982/855dfddc-2f1c-11e6-955e-b17018e88545.png">


