### PR TITLE
[Slim footer]: Fix alignment

### DIFF
--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -193,28 +193,28 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
     </div>
     <div class="usa-footer-primary-section">
       <div class="usa-grid-full">
-        <nav class="usa-footer-nav usa-width-two-thirds">
+        <nav class="usa-footer-nav">
           <ul class="usa-unstyled-list">
-            <li class="usa-width-one-fourth usa-footer-primary-content">
+            <li class="usa-width-one-sixth usa-footer-primary-content">
               <a class="usa-footer-primary-link" href="#">Primary link</a>
             </li>
-            <li class="usa-width-one-fourth usa-footer-primary-content">
+            <li class="usa-width-one-sixth usa-footer-primary-content">
               <a class="usa-footer-primary-link" href="#">Primary link</a>
             </li>
-            <li class="usa-width-one-fourth usa-footer-primary-content">
+            <li class="usa-width-one-sixth usa-footer-primary-content">
               <a class="usa-footer-primary-link" href="#">Primary link</a>
             </li>
-            <li class="usa-width-one-fourth usa-footer-primary-content">
+            <li class="usa-width-one-sixth usa-footer-primary-content">
               <a class="usa-footer-primary-link" href="#">Primary link</a>
+            </li>
+            <li class="usa-width-one-sixth usa-footer-primary-content">
+              <p>(800) CALL-GOVT</p>
+            </li>
+            <li class="usa-width-one-sixth usa-footer-primary-content">
+              <a href="mailto:info@agency.gov">info@agency.gov</a>
             </li>
           </ul>
-        </nav>
-        <div class="usa-width-one-sixth usa-footer-primary-content">
-          <p>(800) CALL-GOVT</p>
-        </div>
-        <div class="usa-width-one-sixth usa-footer-primary-content">
-          <a href="mailto:info@agency.gov">info@agency.gov</a>
-        </div>          
+        </nav>         
       </div>
     </div>
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -74,10 +74,6 @@
 }
 
 .usa-footer-slim {
-  ul {
-    display: flex;
-  }
-
   li > * {
     @include padding (2rem null);
     margin: 0;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -74,20 +74,26 @@
 }
 
 .usa-footer-slim {
+  ul {
+    display: flex;
+  }
+
+  li > * {
+    @include padding (2rem null);
+    margin: 0;
+  }
+
   .usa-footer-nav a {
     display: block;
   }
 
   .usa-footer-primary-section {
-    padding-bottom: 2rem;
-
     @include media($medium-screen) {
       padding-bottom: 1rem;
       padding-top: 1rem;
 
       .usa-grid-full {
         align-items: center;
-        display: flex;
       }
     }
   }


### PR DESCRIPTION
## Description

This fixes an issue in IE 10 where things were incorrectly aligned. The problem stemmed from IE 10 not respecting flexbox the same way other browsers do, so I've removed flexbox. It also removes the nesting of grids inside of grids bc this was a bit overcomplicated. Instead it uses a single level of 1/6 width columns, which is more consistent with the medium footer.

One difference is this will collapse differently in medium / tablet browsers (3 columns instead of 4) and have a border around the fifth and sixth column text and links on mobile.

#### This is what it looks like on medium screens:

<img width="635" alt="screen shot 2016-06-10 at 10 33 59 pm" src="https://cloud.githubusercontent.com/assets/5249443/16015076/e488e276-3148-11e6-8e9a-a42dd302941b.png">

#### This is what it looks like on small screens:

<img width="318" alt="screen shot 2016-06-10 at 10 34 13 pm" src="https://cloud.githubusercontent.com/assets/5249443/16015078/e7da7d5e-3148-11e6-97d6-139f397f80a6.png">

cc: @ericadeahl @bradnunnally 

Fixes: #540