### PR TITLE
[Medium footer]: Fix inconsistent text line breaks in IE 11

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -68,7 +68,6 @@
   .usa-footer-nav ul {
     @include media($medium-screen) {
       align-items: center;
-      display: flex;
     }
   }
 }


### PR DESCRIPTION
## Description

This fixes medium footer inconsistent text line breaks in IE 11. Removes the flexbox rule.

This is what it looks like:

<img width="553" alt="screen shot 2016-06-10 at 9 29 12 pm" src="https://cloud.githubusercontent.com/assets/5249443/16015347/18e1bc72-314a-11e6-80fa-6655b43e6e68.png">

Fixes: #460.
