### PR TITLE
[Website]: Remove h1 from site header

### DIFF
--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -13,10 +13,10 @@
     <nav class="usa-site-navbar">
       <a class="menu-btn" href="#">Menu</a>
       <div class="logo" id="logo">
-        <h1>
+        <em>
           <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
           Draft U.S. Web Design Standards</a>
-        </h1>
+        </em>
       </div>
       <ul class="usa-button-list usa-unstyled-list">
         <li>

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -26,18 +26,18 @@ $site-top:           124px;
   }
 
   em {
-    @include media($medium-screen + $width-nav-sidebar) {
-      display: block;
-      font-size: $h3-font-size;
-      margin-top: .8rem;
-    }
-    
     display: block;
     font-family: $font-serif;
     font-size: $h5-font-size;
     font-style: normal;
     font-weight: $font-bold;
     margin: 0;
+    
+    @include media($medium-screen + $width-nav-sidebar) {
+      display: block;
+      font-size: $h3-font-size;
+      margin-top: .8rem;
+    }
   }
 
   .usa-site-navbar {

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -25,6 +25,18 @@ $site-top:           124px;
     border-bottom: none;
   }
 
+  em {
+    @include media($medium-screen + $width-nav-sidebar) {
+      display: block;
+      font-size: $h3-font-size;
+      font-weight: $font-bold;
+      margin-top: .8rem;
+    }
+
+    margin: 0;
+    font-size: $h5-font-size;
+  }
+
   .usa-site-navbar {
     @include media($medium-screen + $width-nav-sidebar) {
       @include margin(2.7rem 0 1rem);
@@ -55,17 +67,6 @@ $site-top:           124px;
           text-decoration: none;
         }
       }
-    }
-
-    h1 {
-      @include media($medium-screen + $width-nav-sidebar) {
-        display: block;
-        font-size: $h3-font-size;
-        margin-top: .9rem;
-      }
-
-      margin: 0;
-      font-size: $h5-font-size;
     }
 
     .usa-button-list {

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -29,12 +29,15 @@ $site-top:           124px;
     @include media($medium-screen + $width-nav-sidebar) {
       display: block;
       font-size: $h3-font-size;
-      font-weight: $font-bold;
       margin-top: .8rem;
     }
-
-    margin: 0;
+    
+    display: block;
+    font-family: $font-serif;
     font-size: $h5-font-size;
+    font-style: normal;
+    font-weight: $font-bold;
+    margin: 0;
   }
 
   .usa-site-navbar {


### PR DESCRIPTION
## Description

Removes `h1` from header navbar as `h1`s should be used only for the title of a page and duplicate h1's are an accessibility problem.