### PR TITLE
[Links]: Fix underline

### DIFF
--- a/docs/doc_assets/css/homepage.scss
+++ b/docs/doc_assets/css/homepage.scss
@@ -183,6 +183,20 @@ a {
   &:visited {
     color: $color-primary;
   }
+
+  &:hover {
+    color: $color-primary-darker;
+  }
+}
+
+.usa-img-secondary-link,
+.usa-example-link {
+  text-decoration: none;
+
+  &:hover {
+    color: $color-primary-darker;
+    text-decoration: underline;
+  }
 }
 
 .usa-standlast {

--- a/docs/doc_assets/css/homepage.scss
+++ b/docs/doc_assets/css/homepage.scss
@@ -179,23 +179,25 @@ a:hover {
 }
 
 a {
-  > h3,
   &:visited {
     color: $color-primary;
   }
 
-  &:hover {
-    color: $color-primary-darker;
+  &.usa-img-secondary-link {
+    text-decoration: none;
+
+    &:hover {
+      color: $color-primary-darker;
+      text-decoration: underline;
+    }
   }
-}
 
-.usa-img-secondary-link,
-.usa-example-link {
-  text-decoration: none;
+  &.usa-example-link {
+    text-decoration: none;
 
-  &:hover {
-    color: $color-primary-darker;
-    text-decoration: underline;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 
@@ -206,8 +208,9 @@ a {
 }
 
 .usa-example-heading {
-  font-weight: $font-normal;
   @include margin(0 null 1.6rem);
+  color: $color-primary;
+  font-weight: $font-normal;
 }
 
 .usa-section-examples {

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -50,7 +50,7 @@ title: Draft U.S. Web Design Standards
         <img src="{{ site.baseurl }}/assets/img/home/homepage_illustrations_ui_components_2x.png" alt="UI Components">
       </div>
       <h3>
-        <a href="{{ site.baseurl }}/getting-started">UI Components</a>
+        <a class="usa-img-secondary-link" href="{{ site.baseurl }}/getting-started">UI Components</a>
       </h3>
       <p>Common web interactions (buttons, forms, navigation, etc.) with reusable and downloadable code</p>
     </div>
@@ -59,7 +59,7 @@ title: Draft U.S. Web Design Standards
         <img src="{{ site.baseurl }}/assets/img/home/homepage_illustrations_visual_style_guide_2x.png" alt="Visual Style Guide">
       </div>
       <h3>
-        <a href="{{ site.baseurl }}/visual-style/">Visual Style Guide</a>
+        <a class="usa-img-secondary-link" href="{{ site.baseurl }}/visual-style/">Visual Style Guide</a>
       </h3>
       <p>508-compliant colors and typography designed to bring consistency to government web design</p>
     </div>

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -10,9 +10,14 @@
     margin-top: 0;
     padding-bottom: 2rem;
     padding-top: 2rem;
+    text-decoration: none;
 
     @include media($medium-screen) {
       border-top: none;
+    }
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 
@@ -113,7 +118,6 @@ li.usa-footer-primary-content {
 }
 // scss-lint:enable QualifyingElement
 
-
 .usa-sign_up-block {
   padding-bottom: 2rem;
   padding-left: 2.5rem;
@@ -158,6 +162,12 @@ li.usa-footer-primary-content {
 .usa-footer-contact-links {
   @include media($medium-screen) {
     text-align: right;
+  }
+}
+
+.usa-social-links {
+  a {
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
## Description

Removes underline from homepage "UI Components" and "Visual Style" links and footer primary links.

Fixes link issues noted here: https://github.com/18F/web-design-standards/pull/1215#issuecomment-225685069

#### This is what it looks like:

<img width="1066" alt="screen shot 2016-06-14 at 1 27 16 pm" src="https://cloud.githubusercontent.com/assets/5249443/16058570/f71127c8-3233-11e6-9f32-fdb36d183e9f.png">
<img width="859" alt="screen shot 2016-06-14 at 1 28 50 pm" src="https://cloud.githubusercontent.com/assets/5249443/16058571/f726265a-3233-11e6-9948-4b9771f338da.png">
<img width="852" alt="screen shot 2016-06-14 at 1 29 03 pm" src="https://cloud.githubusercontent.com/assets/5249443/16058572/f733484e-3233-11e6-8592-c20a3e1db41f.png">

