### PR TITLE
[Slim footer]: Fix alignment // take 2

### DIFF
--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -9,7 +9,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
 
   <h6 class="usa-heading-alt" id="big-footer">Big footer</h6>
 
-  <footer class="usa-footer usa-footer-big usa-sans" role="contentinfo">
+  <footer class="usa-footer usa-footer-big" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
       <a href="#">Return to top</a>
     </div>
@@ -112,7 +112,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
 
   <h6 class="usa-heading-alt" id="medium-footer">Medium footer</h6>
 
-  <footer class="usa-footer usa-footer-medium usa-sans" role="contentinfo">
+  <footer class="usa-footer usa-footer-medium" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
       <a href="#">Return to top</a>
     </div>
@@ -187,7 +187,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
 
   <h6 class="usa-heading-alt" id="slim-footer">Slim footer</h6>
 
-  <footer class="usa-footer usa-footer-slim usa-sans" role="contentinfo">
+  <footer class="usa-footer usa-footer-slim" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
       <a href="#">Return to top</a>
     </div>

--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -209,12 +209,14 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
             </li>
           </ul>
         </nav>
-        <div class="usa-width-one-sixth usa-footer-primary-content">
-          <p>(800) CALL-GOVT</p>
+        <div class="usa-width-one-third">
+          <div class="usa-width-one-half usa-footer-primary-content">
+            <p>(800) CALL-GOVT</p>
+          </div>
+          <div class="usa-width-one-half usa-footer-primary-content">
+            <a href="mailto:info@agency.gov">info@agency.gov</a>
+          </div>
         </div>
-        <div class="usa-width-one-sixth usa-footer-primary-content">
-          <a href="mailto:info@agency.gov">info@agency.gov</a>
-        </div>          
       </div>
     </div>
 

--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -210,10 +210,10 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
           </ul>
         </nav>
         <div class="usa-width-one-third">
-          <div class="usa-width-one-half usa-footer-primary-content">
+          <div class="usa-footer-primary-content usa-footer-contact_info">
             <p>(800) CALL-GOVT</p>
           </div>
-          <div class="usa-width-one-half usa-footer-primary-content">
+          <div class="usa-footer-primary-content usa-footer-contact_info">
             <a href="mailto:info@agency.gov">info@agency.gov</a>
           </div>
         </div>

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -87,8 +87,27 @@
 
       .usa-grid-full {
         align-items: center;
-        display: flex;
       }
+    }
+  }
+
+  .usa-footer-contact_info {
+    > * {
+      @include media($medium-screen) {
+        margin: 0;
+      }
+    }
+
+    @include media($medium-screen) {
+      @include padding (2rem null);
+    }
+
+    @include media($medium-screen) {
+      width: 100%;
+    }
+
+    @include media($large-screen) {
+      @include span-columns(6);
     }
   }
 }


### PR DESCRIPTION
## Description

Supersedes #1255. Goes back to nested grid approach, but without flexbox. Moves contact links to the right side on medium screens.

Screenshots:

<img width="912" alt="screen shot 2016-06-13 at 5 11 42 pm" src="https://cloud.githubusercontent.com/assets/5249443/16027387/5579a772-318a-11e6-8dfc-d1bb0b0cf6b5.png">

<img width="602" alt="screen shot 2016-06-13 at 5 10 26 pm" src="https://cloud.githubusercontent.com/assets/5249443/16027388/594fb8a0-318a-11e6-9ed8-a8ce720ee927.png">

<img width="321" alt="screen shot 2016-06-13 at 5 10 35 pm" src="https://cloud.githubusercontent.com/assets/5249443/16027393/5d7f0fca-318a-11e6-835f-308bc8de1d88.png">

Fixes: #540

cc: @ericadeahl 