### PR TITLE
[Website]: Remove button from "Getting Started"

### DIFF
--- a/docs/pages/getting-started.html
+++ b/docs/pages/getting-started.html
@@ -42,7 +42,7 @@ lead: The Draft U.S. Web Design Standards are designed to set a new bar for simp
     </code> 
     in the site root.
   </li>
-  <li><strong>Sass</strong> styles are located in: <code>src/stylesheets/ (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is located in the <a class="usa-button" href="{{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip">downloadable zip file </a>.</li>
+  <li><strong>Sass</strong> styles are located in: <code>src/stylesheets/ (/core, /elements, /components)</code>. <strong>Compiled CSS</strong> is located in the <a href="{{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip">downloadable zip file </a>.</li>
   <li><strong>JS</strong> is located in: <code>src/js/components (accordion.js, toggle-field-mark.js, toggle-form-input.js, validator.js)</code>.</li>
   <li><strong>Fonts</strong> are located in: <code>src/fonts</code>.</li>
   <li><strong>Images</strong> and icons are located in: <code>src/img</code>.</li>


### PR DESCRIPTION
## Description

Removes button class from "Getting Started" link: https://standards.usa.gov/getting-started/

Before:

<img width="565" alt="screen shot 2016-06-13 at 5 32 30 pm" src="https://cloud.githubusercontent.com/assets/5249443/16027698/f5a0050a-318c-11e6-9f78-976282ed1aa7.png">

After:

<img width="566" alt="screen shot 2016-06-13 at 5 33 36 pm" src="https://cloud.githubusercontent.com/assets/5249443/16027703/f98fa67a-318c-11e6-8fa9-555cd279afec.png">
