### PR TITLE
[ Website ]: Deployment Remove path from manifest & add to cf push

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,19 +30,19 @@ deployment:
     branch: [master]
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-production
-      - cf push
+      - cf push -p _site
   staging:
     branch: [staging]
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-staging
-      - cf push -f config/cf/manifest-staging.yml
+      - cf push -f config/cf/manifest-staging.yml -p _site
   release:
     branch: [release]
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-release
-      - cf push -f config/cf/manifest-release.yml
+      - cf push -f config/cf/manifest-release.yml -p _site
   user-testing:
     branch: [user-testing]
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-user-testing
-      - cf push -f config/cf/manifest-user-testing.yml
+      - cf push -f config/cf/manifest-user-testing.yml -p _site

--- a/config/cf/manifest-release.yml
+++ b/config/cf/manifest-release.yml
@@ -1,4 +1,4 @@
-# Manifest file for automated deployments to our release environment 
+# Manifest file for automated deployments to our release environment
 # Main manifest.yml can be found in the root level directory.
 ---
 inherit: ../../manifest.yml

--- a/config/cf/manifest-staging.yml
+++ b/config/cf/manifest-staging.yml
@@ -1,4 +1,4 @@
-# Manifest file for automated deployments to our staging environment. 
+# Manifest file for automated deployments to our staging environment.
 # Main manifest.yml can be found in the root level directory.
 ---
 inherit: ../../manifest.yml

--- a/config/cf/manifest-user-testing.yml
+++ b/config/cf/manifest-user-testing.yml
@@ -1,4 +1,4 @@
-# Manifest file for automated deployments to our user testing environment 
+# Manifest file for automated deployments to our user testing environment
 # Main manifest.yml can be found in the root level directory.
 ---
 inherit: ../../manifest.yml

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,5 @@ memory: 64MB
 applications:
 - name: wds-microsite
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
-  path: _site
   env:
     FORCE_HTTPS: true


### PR DESCRIPTION
This patch adds the path parameter for the application to the `cf push`
command because the `path: _site` property in the main manifest was not
properly resolving since the folders moved into `config/cf`.