### PR TITLE
[Website]: Prevent example search bars from reloading page when clicked

### DIFF
--- a/docs/doc_assets/js/styleguide.js
+++ b/docs/doc_assets/js/styleguide.js
@@ -3,7 +3,7 @@ $(function(){
     $('.sidenav, .overlay').toggleClass('is-visible');
     e.preventDefault();
   });
-  
+
   function handleDisabledLinks() {
     $(document).on('click', 'a[href="#"]', function (event) {
       // Stop default browser action which would likely return to the top of the page
@@ -67,12 +67,12 @@ var calculateAnchorPosition = function (hash) {
   if (anchor.length === 0) {
     return topOffset;
   }
-  
+
   //start with the height of the header
   topOffset = $('.usa-site-header').first().outerHeight();
   //subtract the diffence in padding between nav top and anchor
   topOffset = topOffset - (anchorPadding - navPadding);
-  
+
   //anchor should now align with first item inside nav
   return anchor.offset().top - topOffset;
 }
@@ -113,7 +113,7 @@ $('.sidenav').on('click', 'a', function(e) {
   if (scrollTopPos === 0) {
     return true;
   }
-  
+
   e.preventDefault();
 
   /* Firefox needs html, others need body */
@@ -143,4 +143,8 @@ $('.sidenav').on('click', 'a', function(e) {
       }
     }
   });
+});
+
+$(".preview-search-bar .usa-search").submit(function(event){
+  event.preventDefault();
 });


### PR DESCRIPTION
## Description
Prevents default on objects with the class `.usa-search` which are inside of the `.preview-search-bar`. This prevents the example search bar forms from attempting to submit and reloading the page.

## Additional information

* Pull request also removes unnecessary whitespace on blank lines within the `styleguide.js` file.
* Resolves: #595 