### PR TITLE
USWDS - Form: add padding-right so text doesnt overlap dropdown chevron

### DIFF
--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -28,6 +28,10 @@ form {
   @include media($medium-screen) {
     max-width: $usa-form-width;
   }
+
+  select {
+    padding-right: 2em;
+  }
 }
 
 .usa-form-note {


### PR DESCRIPTION
## Description
Fixes this issue where long text options in forms overlaps the dropdown chevrons. 
https://github.com/18F/web-design-standards/issues/1039

## Additional information
none.

