### PR TITLE
Searchbar text

### DIFF
--- a/docs/_components/search-bar.md
+++ b/docs/_components/search-bar.md
@@ -27,7 +27,7 @@ lead: A block that allows users to search for specific content if they know what
 
   <div class="usa-grid">
     <div class="usa-width-one-half">
-      <form class="usa-search">
+      <form class="usa-search usa-search-medium">
         <div role="search">
           <label class="usa-sr-only" for="search-field">Search medium</label>
           <input id="search-field" type="search" name="search">

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -76,6 +76,17 @@ $usa-btn-big-width:     11.6rem;
     }
   }
 
+&.usa-search-medium {
+    @include media($small-screen) {
+
+      [type="search"],
+      .usa-search-input {
+        font-size: 1.5rem;
+      }
+    }
+  }
+
+
   &.usa-search-small {
     @include media($small-screen) {
       $width: $usa-btn-small-width;
@@ -83,7 +94,10 @@ $usa-btn-big-width:     11.6rem;
       [type="search"],
       .usa-search-input {
         width: calc(100% - #{$width});
+        font-size: 1.5rem;
       }
+
+
 
       [type="submit"],
       .usa-search-submit {


### PR DESCRIPTION
## Description

Resized the search bar text for small and medium search bars from 1.7rem to 1.5rem

## Additional information

* In search-bar.md HTML file: Added new class to medium search bar form tag: usa-search-medium
* In _search.scss Stylesheet: Added text-size properties on .usa-search-medium and .usa-search-small inputs. Set properties to 1.5rem. 
* Final product:

<img width="462" alt="screen shot 2016-06-17 at 3 04 59 pm" src="https://cloud.githubusercontent.com/assets/8316393/16163081/eaad6148-349c-11e6-98c9-9da5e65df91e.png">



* Orignally looked like this: 

![searchbox_og](https://cloud.githubusercontent.com/assets/8316393/16163449/e7174a7e-349e-11e6-98e0-eaceb6a821e8.png)