### PR TITLE
Remove unbind code because overriding default behavior is only useful…

### DIFF
--- a/src/js/start.js
+++ b/src/js/start.js
@@ -58,18 +58,14 @@ $(function () {
 
       $('.usa-footer-big nav ul').addClass('hidden');
 
-      $('.usa-footer-big nav .usa-footer-primary-link').unbind('click');
-
       $('.usa-footer-big nav .usa-footer-primary-link').bind('click', function () {
         $(this).parent().removeClass('hidden')
         .siblings().addClass('hidden');
       });
     } else {
-
       $('.usa-footer-big nav ul').removeClass('hidden');
-
-      $('.usa-footer-big nav .usa-footer-primary-link').unbind('click');
     }
+
   };
 
   footerAccordion();


### PR DESCRIPTION
## Description

Resolve "Return to top" link in footers Issue #990. There is code that unbinds the standard click event for primary links. This is only useful for the sample code page, and does not make sense for distributable code. I removed it because it is a feature that causes a bigger problem than it solves.

## Additional information

* Even though click event overrides have been removed, the "Return to Top" link still doesn't seem to work as expected. There might be other code that is overriding default click behavior.

