### PR TITLE
Revert accidental apostrophe change from #1273

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ The task above builds the entire Draft U.S. Web Design Standards website locally
 It can be useful when debugging for build errors or generating a deployable
 version of the Standards website. This creates a `/_site` directory that
 contains the Jekyll-built site. This is the same build step that we use to
-deploy the website. The command is aliased by `npm run deploy'.
+deploy the website. The command is aliased by `npm run deploy`.
 
 ```sh
 gulp website:serve


### PR DESCRIPTION
## Documentation: Revert accidental apostrophe change from #1273

## Description
Following up on @maya's [observation](https://github.com/18F/web-design-standards/pull/1273/files#r67582877) about a change that snuck into #1273, this PR reverts that ' to a ` so markdown will work as intended.