### PR TITLE
Create heading-margin-alt class to add margin-top to specified header…

### DIFF
--- a/docs/_components/form-templates.md
+++ b/docs/_components/form-templates.md
@@ -5,7 +5,7 @@ title: Form templates
 lead: Patterns for some of the most commonly used forms on government websites
 ---
 
-<h3 class="usa-heading">Accessibility</h3>
+<h3 class="usa-heading heading-margin-alt">Accessibility</h3>
 
 <p>As you customize these templates, make sure they continue to meet the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for all form controls</a> as well as the accessibility guidelines for each individual control.</p>
 <p>In addition, when creating forms with multiple controls or customizing these templates, be sure to:</p>

--- a/docs/_elements/form-controls.md
+++ b/docs/_elements/form-controls.md
@@ -5,7 +5,7 @@ title: Form controls
 lead: Form controls allow users to enter information into a page.
 ---
 
-<h3 class="usa-heading">Accessibility</h3>
+<h3 class="usa-heading heading-margin-alt">Accessibility</h3>
 
 <p>As you customize these templates, make sure they continue to meet the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for all form controls</a> as well as the accessibility guidelines for each individual control.</p>
 <p>In addition, when creating forms with multiple controls or customizing these templates, be sure to:</p>

--- a/docs/_visual/colors.md
+++ b/docs/_visual/colors.md
@@ -7,7 +7,7 @@ order: 02
 <p>A flexible, yet distinctly American palette designed to communicate warmth and trustworthiness while meeting the highest standards of 508 color contrast requirements.</p><a class="usa-button usa-button-primary-alt" href="https://github.com/18F/web-design-standards-assets/archive/master.zip">Download the design files</a>
 <p class="usa-text-small">Download a zip file with font files and color swatches.</p>
 
-<h3 class="usa-heading" id="palette">Palette</h3>
+<h3 class="usa-heading heading-margin-alt" id="palette">Palette</h3>
 
 <p>This palette is designed to support a range of distinct visual styles that continue to feel connected. The intent of the palette is to convey a warm and open American spirit, with bright saturated tints of blue and red, grounded in sophisticated deeper shades of cool blues and grays. These colors — combined with clear hierarchy, good information design, and ample white space — should leave users feeling welcomed and in good hands.</p>
 

--- a/docs/_visual/typography.md
+++ b/docs/_visual/typography.md
@@ -6,7 +6,7 @@ order: 01
 
 <p>U.S. government websites have common typographic needs: clear and consistent headings, highly legible body paragraphs, clear labels, and easy-to-use input fields. We recommend a font system that uses two open-source font families: Source Sans Pro and Merriweather, both of which are designed for legibility and can beautifully adapt to a variety of visual styles.</p>
 
-<h3 class="usa-heading" id="typefaces">Typefaces</h3>
+<h3 class="usa-heading heading-margin-alt" id="typefaces">Typefaces</h3>
 
 <h4 class="usa-heading-alt">Source Sans Pro</h4>
 
@@ -44,7 +44,7 @@ order: 01
   </div>
 </div>
 
-<h3 class="usa-heading" id="pairings">Pairings + Styles</h3>
+<h3 class="usa-heading heading-margin-alt" id="pairings">Pairings + Styles</h3>
 <p>To support both more contemporary and more traditional web design aesthetics, this font system offers recommended font pairings. Each pairing includes web hierarchy guidance on font family, weight, size, and spacing which express either more modern or more classical type design.</p>
 <p>Note: Some pairings require more font weights than others. While this allows more typographic expression, the use of more than four font weights will have a negative impact on page load performance. Find the balance that works for your product.</p>
 

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -32,7 +32,7 @@ $site-top:           124px;
     font-style: normal;
     font-weight: $font-bold;
     margin: 0;
-    
+
     @include media($medium-screen + $width-nav-sidebar) {
       display: block;
       font-size: $h3-font-size;
@@ -300,7 +300,7 @@ $site-top:           124px;
     font-size: $h5-font-size;
     @include margin(0 null 1.5rem);
   }
-  
+
   a {
     color: $color-gray-lighter;
 
@@ -1108,4 +1108,8 @@ $font-light: 300;
   [href^="https:"]:not([href*="standards.com"]) {
     @include external-link(external-link-alt, external-link-alt-hover);
   }
+}
+
+.heading-margin-alt {
+  margin-top: 3em;
 }

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -282,6 +282,10 @@ $site-top:           124px;
   }
 }
 
+.heading-margin-alt {
+  margin-top: 6rem;
+}
+
 // Footer --------------- //
 
 .usa-styleguide-footer {
@@ -1108,8 +1112,4 @@ $font-light: 300;
   [href^="https:"]:not([href*="standards.com"]) {
     @include external-link(external-link-alt, external-link-alt-hover);
   }
-}
-
-.heading-margin-alt {
-  margin-top: 3em;
 }


### PR DESCRIPTION
## Description

Issue #503 
Create and apply heading-margin-alt class to double space above the specified h3 headers below. So before they were 30px above the headers and now there is 60px.

**Typefaces**
<img width="1122" alt="1" src="https://cloud.githubusercontent.com/assets/12946576/16163621/eefb39f2-349f-11e6-962d-8803cb5eb3bd.png">

**Pairings + Styles**
<img width="1103" alt="2" src="https://cloud.githubusercontent.com/assets/12946576/16163623/eefd49c2-349f-11e6-9a3d-208cef75227f.png">

**Palette**
<img width="1114" alt="3" src="https://cloud.githubusercontent.com/assets/12946576/16163622/eefd0bba-349f-11e6-97e7-b94a910bae90.png">

**Form Controls/Accessibility**
<img width="1094" alt="4" src="https://cloud.githubusercontent.com/assets/12946576/16163624/eeffcc24-349f-11e6-9a77-a3a4c0d3113d.png">

**Form Templates/Accessibility**
<img width="1097" alt="5" src="https://cloud.githubusercontent.com/assets/12946576/16163625/ef00d826-349f-11e6-81a1-ddc75123bfa7.png">

… Apply class to appropriate h3s.