### PR TITLE
Fix "Return to top" within footer examples

### DIFF
--- a/docs/doc_assets/js/styleguide.js
+++ b/docs/doc_assets/js/styleguide.js
@@ -7,7 +7,11 @@ $(function(){
   function handleDisabledLinks() {
     $(document).on('click', 'a[href="#"]', function (event) {
       // Stop default browser action which would likely return to the top of the page
-      event.preventDefault();
+      // unless it's an actual return-to-top link
+      var isReturnToTop = 'return to top' === $(event.target).text().toLowerCase();
+      if (! isReturnToTop) {
+        event.preventDefault();
+      }
     });
   }
   handleDisabledLinks()


### PR DESCRIPTION
## Description

The issue around the "Return to top" examples not working #990 mentions that the intended behavior of those examples are to have the page return to the top. Currently the documentation site has a `handleDisabledLinks` function which aggressively disables `<a>` with the `href="#"` attribute. This patch updates this function to not disable links for `return to top` links. This allows for the examples to work as expected.

This closes #990.