### PR TITLE
[UI components]: Fix scss-lint warnings

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -26,13 +26,14 @@ $accordion-border: 3px solid $color-gray-lightest;
     }
   }
 
-  button[aria-expanded=false] {
+  [aria-expanded=false] {
     background-image: url('../img/plus.png');
     background-image: url('../img/plus.svg');
     background-repeat: no-repeat;
     background-size: 1.3rem;
   }
 
+  // scss-lint:disable PropertyCount
   button {
     background-color: $color-gray-lightest;
     background-image: url('../img/minus.png');
@@ -66,6 +67,7 @@ $accordion-border: 3px solid $color-gray-lightest;
       margin: 0;
     }
   }
+  // scss-lint:enable PropertyCount
 }
 
 .usa-accordion-bordered {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -306,7 +306,7 @@ li.usa-footer-primary-content {
   $background-height: 3rem;
 
   // Link hit target is 44 x 44 pixels following Apple iOS Human Interface Guidelines.
-  $hit-area: 4.4rem; 
+  $hit-area: 4.4rem;
 
   background-position: center center;
   background-repeat: no-repeat;
@@ -337,24 +337,24 @@ li.usa-footer-primary-content {
 
 .usa-link-facebook {
   @extend .usa-social_link;
-  background-image: url("../img/social-icons/png/facebook25.png");
-  background-image: url("../img/social-icons/svg/facebook25.svg");
+  background-image: url('../img/social-icons/png/facebook25.png');
+  background-image: url('../img/social-icons/svg/facebook25.svg');
 }
 
 .usa-link-twitter {
   @extend .usa-social_link;
-  background-image: url("../img/social-icons/png/twitter16.png");
-  background-image: url("../img/social-icons/svg/twitter16.svg");
+  background-image: url('../img/social-icons/png/twitter16.png');
+  background-image: url('../img/social-icons/svg/twitter16.svg');
 }
 
 .usa-link-youtube {
   @extend .usa-social_link;
-  background-image: url("../img/social-icons/png/youtube15.png");
-  background-image: url("../img/social-icons/svg/youtube15.svg");
+  background-image: url('../img/social-icons/png/youtube15.png');
+  background-image: url('../img/social-icons/svg/youtube15.svg');
 }
 
 .usa-link-rss {
   @extend .usa-social_link;
-  background-image: url("../img/social-icons/png/rss25.png");
-  background-image: url("../img/social-icons/svg/rss25.svg");
+  background-image: url('../img/social-icons/png/rss25.png');
+  background-image: url('../img/social-icons/svg/rss25.svg');
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -302,32 +302,23 @@ li.usa-footer-primary-content {
 }
 
 .usa-social_link {
-  // Height of icon within hit area.
-  $background-height: 3rem;
-
-  // Link hit target is 44 x 44 pixels following Apple iOS Human Interface Guidelines.
-  $hit-area: 4.4rem;
-
+  $background-height: 3rem; // Height of icon within hit area.
+  $hit-area: 4.4rem; // Link hit target is 44 x 44 pixels following Apple iOS
+                     // Human Interface Guidelines.
+  @include margin(2.5rem 1rem 1.5rem 0);
   background-position: center center;
   background-repeat: no-repeat;
   background-size: auto $background-height;
   display: inline-block;
   height: $hit-area;
   left: -1.6rem; // relative left positioning
-  margin-bottom: 1.5rem;
-  margin-left: 0;
-  margin-right: 1rem; // spacing between link hit areas
-  margin-top: 2.5rem;
   position: relative;
   text-align: center;
   width: $hit-area;
 
   @include media($medium-screen) {
+    @include margin(0 0 0 1rem);
     left: 1.2rem;
-    margin-bottom: 0;
-    margin-left: 1rem;
-    margin-right: 0;
-    margin-top: 0;
   }
 
   span {

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -5,8 +5,8 @@ form {
     border-bottom: 0;
   }
 
-  button[type="submit"],
-  input[type="submit"] {
+  [type="submit"],
+  [type="submit"] {
     display: block;
     margin-bottom: 1.5em;
     margin-top: 2.5rem;
@@ -18,8 +18,8 @@ form {
     }
   }
 
-  input[name="password"],
-  input[name="confirmPassword"] {
+  [name="password"],
+  [name="confirmPassword"] {
     margin-bottom: 1.1rem;
   }
 }
@@ -53,15 +53,17 @@ fieldset {
   }
 }
 
-input.usa-input-tiny {
-  @include media($medium-screen) {
-    max-width: 6rem;
+input {
+  &.usa-input-tiny {
+    @include media($medium-screen) {
+      max-width: 6rem;
+    }
   }
-}
 
-input.usa-input-medium {
-  @include media($medium-screen) {
-    max-width: 12rem;
+  &.usa-input-medium {
+    @include media($medium-screen) {
+      max-width: 12rem;
+    }
   }
 }
 
@@ -126,16 +128,6 @@ input.usa-input-medium {
   float: right;
   font-style: italic;
   font-weight: normal;
-}
-
-.usa-input-buttons-inline {
-  button,
-  button[type="submit"],
-  input[type="submit"],
-  & > * {
-    display: inline;
-    margin-right: 1.5em;
-  }
 }
 
 // Reset password checklist

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -31,12 +31,9 @@
     }
 
     &.usa-current {
+      border-left: 4px solid $color-primary;
       color: $color-primary;
       font-weight: $font-bold;
-    }
-
-    &.usa-current {
-      border-left: 4px solid $color-primary;
       padding-left: 1.4rem;
     }
   }
@@ -54,21 +51,21 @@
   a {
     padding-left: 2.8rem;
     line-height: $heading-line-height;
-  }
 
-  a:hover,
-  a.usa-current {
-    border: none;
-    padding-left: 2.8rem;
+    &:hover,
+    &.usa-current {
+      border: none;
+      padding-left: 2.8rem;
+    }
   }
 
   .usa-sidenav-sub_list {
     a {
       padding-left: 3.8rem;
-    }
 
-    a:hover {
-      padding-left: 3.8rem;
+      &:hover {
+        padding-left: 3.8rem;
+      }
     }
   }
 }

--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -18,6 +18,7 @@ body {
 // Hack for clearfixes
 .lt-ie9 {
   * {
+    // scss-lint:disable ImportantRule
     filter: none !important;
   }
 }

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -71,6 +71,7 @@ $color-cool-blue-lightest:   #dce4ef; // lighten($color-cool-blue, 90%)
 $color-focus:                #3e94cf;
 $color-visited:              #4c2c92;
 
+$color-shadow:               rgba(#000, 0.3);
 
 // Mobile First Breakpoints
 $small-screen:      481px;
@@ -85,6 +86,6 @@ $site-margins:      3rem;
 $article-max-width: 600px;
 $input-max-width:   46rem;
 $border-radius:     rem(3px);
-$box-shadow:        0 0 2px rgba(#000, 0.3);
+$box-shadow:        0 0 2px $color-shadow;
 $focus-shadow:      0 0 3px $color-focus, 0 0 7px $color-focus;
 $grid-margins:      3rem;

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -4,6 +4,7 @@ $button-stroke: inset 0 0 0 2px;
 
 // Buttons
 
+// scss-lint:disable PropertyCount
 .usa-button,
 .usa-button-primary,
 .usa-button:visited,
@@ -13,6 +14,7 @@ button,
 [type="submit"],
 [type="reset"],
 [type="image"] {
+  @include margin(0.5em 0.5em 0.5em null);
   appearance: none;
   background-color: $color-primary;
   border: 0;
@@ -24,9 +26,6 @@ button,
   font-size: $base-font-size;
   font-weight: $font-bold;
   line-height: 1;
-  margin-bottom: 0.5em;
-  margin-right: 0.5em;
-  margin-top: 0.5em;
   outline: none;
   padding: 1rem 2rem;
   text-align: center;
@@ -151,6 +150,7 @@ button,
     padding: 1.5rem 3rem;
   }
 }
+// scss-lint:enable PropertyCount
 
 [type="submit"]:disabled,
 .usa-button-disabled {
@@ -162,7 +162,7 @@ button,
   &.usa-button-hover,
   &:active,
   &.usa-button-active,
-  &:focus  {
+  &:focus {
     background-color: $color-gray-lighter;
     border: 0;
     box-shadow: none;


### PR DESCRIPTION
## Description

Fixes remaining scss-lint warnings in `src/`. 

**_Note_**: Does not touch `styleguide.scss` lint warnings as will be addressed in the new site design PR #1274.

## Additional information

<img width="796" alt="screen shot 2016-06-24 at 5 12 35 pm" src="https://cloud.githubusercontent.com/assets/5249443/16353426/e2f48142-3a2e-11e6-851b-62010802f450.png">

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.

Fixes: #1190.