### PR TITLE
Prefer dashes over underscore in CSS class names

### DIFF
--- a/docs/_components/footers.md
+++ b/docs/_components/footers.md
@@ -54,8 +54,8 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
           </ul>
         </nav>
 
-        <div class="usa-sign_up-block usa-width-one-third">
-          <h3 class="usa-sign_up-header">Sign up</h3>
+        <div class="usa-sign-up-block usa-width-one-third">
+          <h3 class="usa-sign-up-header">Sign up</h3>
 
           <label class="" for="email" id="">Your email address</label>
           <input id="email" name="email" type="email">
@@ -65,7 +65,7 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
       </div>
     </div>
 
-    <div class="usa-footer-secondary_section usa-footer-big-secondary-section">
+    <div class="usa-footer-secondary-section usa-footer-big-secondary-section">
       <div class="usa-grid">
         <div class="usa-footer-logo usa-width-one-half">
           <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
@@ -120,13 +120,13 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
             </li>
             <li class="usa-width-one-sixth usa-footer-primary-content">
               <a class="usa-footer-primary-link" href="#">Primary link</a>
-            </li>                    
+            </li>
           </ul>
         </nav>
       </div>
     </div>
 
-    <div class="usa-footer-secondary_section">
+    <div class="usa-footer-secondary-section">
       <div class="usa-grid">
         <div class="usa-footer-logo usa-width-one-half">
           <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
@@ -182,17 +182,17 @@ lead: Footers serve site visitors who arrive at the bottom of a page without fin
           </ul>
         </nav>
         <div class="usa-width-one-third">
-          <div class="usa-footer-primary-content usa-footer-contact_info">
+          <div class="usa-footer-primary-content usa-footer-contact-info">
             <p>(800) CALL-GOVT</p>
           </div>
-          <div class="usa-footer-primary-content usa-footer-contact_info">
+          <div class="usa-footer-primary-content usa-footer-contact-info">
             <a href="mailto:info@agency.gov">info@agency.gov</a>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="usa-footer-secondary_section">
+    <div class="usa-footer-secondary-section">
       <div class="usa-grid">
         <div class="usa-footer-logo">
           <img class="usa-footer-slim-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -95,7 +95,7 @@
     }
   }
 
-  .usa-footer-contact_info {
+  .usa-footer-contact-info {
     > * {
       @include media($medium-screen) {
         margin: 0;
@@ -136,7 +136,7 @@ li.usa-footer-primary-content {
 }
 // scss-lint:enable QualifyingElement
 
-.usa-sign_up-block {
+.usa-sign-up-block {
   padding-bottom: 2rem;
   padding-left: 2.5rem;
   padding-right: 2.5rem;
@@ -161,7 +161,7 @@ li.usa-footer-primary-content {
   }
 }
 
-.usa-footer-secondary_section {
+.usa-footer-secondary-section {
   background-color: $color-gray-lighter;
   padding-bottom: 3rem;
   padding-top: 3rem;
@@ -263,7 +263,7 @@ li.usa-footer-primary-content {
   padding: 2rem 0;
 }
 
-.usa-sign_up-header {
+.usa-sign-up-header {
   @include media($medium-screen) {
     margin: 0;
     padding: 2rem 0;
@@ -301,7 +301,7 @@ li.usa-footer-primary-content {
   }
 }
 
-.usa-social_link {
+.usa-social-link {
   // Height of icon within hit area.
   $background-height: 3rem;
 
@@ -336,25 +336,25 @@ li.usa-footer-primary-content {
 }
 
 .usa-link-facebook {
-  @extend .usa-social_link;
+  @extend .usa-social-link;
   background-image: url("../img/social-icons/png/facebook25.png");
   background-image: url("../img/social-icons/svg/facebook25.svg");
 }
 
 .usa-link-twitter {
-  @extend .usa-social_link;
+  @extend .usa-social-link;
   background-image: url("../img/social-icons/png/twitter16.png");
   background-image: url("../img/social-icons/svg/twitter16.svg");
 }
 
 .usa-link-youtube {
-  @extend .usa-social_link;
+  @extend .usa-social-link;
   background-image: url("../img/social-icons/png/youtube15.png");
   background-image: url("../img/social-icons/svg/youtube15.svg");
 }
 
 .usa-link-rss {
-  @extend .usa-social_link;
+  @extend .usa-social-link;
   background-image: url("../img/social-icons/png/rss25.png");
   background-image: url("../img/social-icons/svg/rss25.svg");
 }


### PR DESCRIPTION
* Noticed one of these when using the standards because my CSS linter
  rules want all class names to have dashes, which is typical
* Consistency is easier, anyway!