### PR TITLE
[Radio buttons and checkboxes] Fix IE9 - IE11 alignment issue

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -179,6 +179,7 @@ input[type="radio"] + label::before {
   line-height: 1.8rem;
   margin-right: 0.6em;
   text-indent: 0.15em;
+  vertical-align: middle\0; // Target IE 11 and below
   width: 1.8rem;
 }
 

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -179,7 +179,7 @@ input[type="radio"] + label::before {
   line-height: 1.8rem;
   margin-right: 0.6em;
   text-indent: 0.15em;
-  vertical-align: middle\0; // Target IE 11 and below
+  vertical-align: middle\0; // Target IE 11 and below to vertically center inputs
   width: 1.8rem;
 }
 


### PR DESCRIPTION
## Description

Fixes bug (#1299) where radio buttons and checkboxes were not aligned in IE9 - IE11. 

## Additional information

#### This is what it looks like:

<img width="409" alt="screen shot 2016-07-03 at 11 27 49 am" src="https://cloud.githubusercontent.com/assets/5249443/16600574/9430cb42-42bc-11e6-97be-001cb6b0ae02.png">

<img width="430" alt="screen shot 2016-07-03 at 11 28 04 am" src="https://cloud.githubusercontent.com/assets/5249443/16600580/98c65bae-42bc-11e6-9145-64145e4070f7.png">

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.

Fixes: #1299.