### PR TITLE
[ Website ]: Remap routes on deployments

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,11 +35,13 @@ deployment:
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-production
       - cf zero-downtime-push wds-microsite -f manifest.yml -p _site
+      - cf map-route wds-microsite standards.usa.gov
   staging:
     branch: [staging]
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-staging
       - cf zero-downtime-push wds-microsite -f config/cf/manifest-staging.yml -p _site
+      - cf map-route wds-microsite standards-staging.usa.gov
   release:
     branch: [release]
     commands:


### PR DESCRIPTION
## Description
This patch adds a map-route command to remap the routes for
`standards[-staging].usa.gov` when deploying `master` and `staging`.
The explicit remapping needs to happen because the `cf-plugin`
`zero-downtime-push` doesn't support anything but a `manifest` and
`path` flag. Because all of our manifests inherit the production
manifest and we rely on the default mapping for our shard domain and
custom mapping for our private domain, we must run `map-route` manually
after a successful `zero-downtime-push`.