### PR TITLE
[Website]: Add "Component maturity scale" and update "Product roadmap" pages

### DIFF
--- a/docs/_data/milestones.yml
+++ b/docs/_data/milestones.yml
@@ -1,0 +1,80 @@
+- title: Milestone 1
+  tasks:
+    - title: A public, up-to-date product road map.
+      status: done
+      url: https://github.com/18F/web-design-standards/milestone/18
+    - title: A public maintenance plan.
+      status: in progress
+      url: https://github.com/18F/web-design-standards/milestone/19
+    - title: A bare-bones HTML starter page, with CSS and JS pre-linked and necessary tags and classes.
+      status: in progress
+      url: https://github.com/18F/web-design-standards/milestone/15
+    - title: Defined processes for active and public implementer support.
+      status: in progress
+      url:
+    - title: Contribution guidelines for both designers and developers.
+      status: in progress
+      url:
+    - title: Form patterns that include recommendations for just-in-time instructions.
+      status:
+      url:
+    - title: UI components are comprised of clean, semantic code.
+      status: in progress
+      url: https://github.com/18F/web-design-standards/milestone/13
+    - title: Simple "Getting Started" process and instructions.
+      status: in progress
+      url: https://github.com/18F/web-design-standards/milestone/16
+    - title: A core set of common, usable web components.
+      status: in progress
+      url: https://github.com/18F/web-design-standards/milestone/14
+    - title: Ready to go HTML templates (and related design stencils) for common types of government site pages.
+      status:
+      url: https://github.com/18F/web-design-standards/milestone/17
+
+- title: Milestone 2
+  tasks:
+    - title: Form templates structured in short chunks.
+      status:
+      url:
+    - title: Language toggle and other web components related to multilingual sites.
+      status:
+      url:
+    - title: Case studies that illustrate how the Standards can be used.
+      status:
+      url:
+    - title: Boilerplate language to include in government contracts.
+      status:
+      url:
+    - title: The ability to quickly copy and paste code from the website.
+      status:
+      url:
+    - title: Concise, focused documentation that is easy to find but out of the way.
+      status:
+      url:
+    - title: Form patterns that allow for easy recovery of mistakes.
+      status:
+      url:
+    - title: Website chrome in Spanish.
+      status:
+      url:
+    - title: Easy ways to customize the Standards to fit an agency’s brand and needs.
+      status:
+      url:
+    - title: Design stencils and assets.
+      status:
+      url:
+
+- title: Milestone 3
+  tasks:
+    - title: Interaction patterns for save-as-you-go functionality
+      status:
+      url:
+    - title: Guidance on how to manage updates to the Standards in your own project.
+      status:
+      url:
+    - title: A fork-able starter project representing a simple, static site with a few common pages.
+      status:
+      url:
+    - title: Wayfinding components, such as progress indicators.
+      status:
+      url:

--- a/docs/_includes/child-sections.html
+++ b/docs/_includes/child-sections.html
@@ -5,7 +5,7 @@
   {% if child.maturity != null %}
     <div class="tooltip">
       <p class="tooltip-text" id="tooltip-text-{{ child.title | slugify }}">Read about the component maturity scale</p>
-      <a class="usa-label label-{{ child.maturity }}" href="{{ site.repos[0].url }}/wiki/Component-Maturity-Scale" aria-describedby="tooltip-text-{{ child.title | slugify }}">
+      <a class="usa-label label-{{ child.maturity }}" href="{{{{ site.baseurl }}/about-our-work/component-maturity-scale/" aria-describedby="tooltip-text-{{ child.title | slugify }}">
         {{ child.maturity }}
       </a>
     </div>

--- a/docs/_includes/sidenav/about-our-work.html
+++ b/docs/_includes/sidenav/about-our-work.html
@@ -8,5 +8,8 @@
     <li>
       <a {% if page.url contains 'about-our-work/product-roadmap' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/about-our-work/product-roadmap/">Product roadmap</a>
     </li>
+    <li>
+      <a {% if page.url contains 'about-our-work/component-maturity-scale' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/about-our-work/component-maturity-scale/">Component maturity scale</a>
+    </li>
   </ul>
 </nav>

--- a/docs/_includes/sidenav/mobile.html
+++ b/docs/_includes/sidenav/mobile.html
@@ -119,6 +119,9 @@
           <li>
             <a {% if page.url contains 'about-our-work/product-roadmap' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/about-our-work/product-roadmap/">Product roadmap</a>
           </li>
+          <li>
+            <a {% if page.url contains 'about-our-work/component-maturity-scale' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/about-our-work/component-maturity-scale/">Component maturity scale</a>
+          </li>
         </ul>
       </li>
     </ul>

--- a/docs/_layouts/styleguide.html
+++ b/docs/_layouts/styleguide.html
@@ -33,7 +33,7 @@
           {% if page.category == 'UI components' and page.maturity != null %}
             <div class="tooltip">
               <p class="tooltip-text" id="tooltip-text-{{ page.title | slugify }}">Read about the component maturity scale</p>
-              <a class="usa-label label-{{ page.maturity }}" href="{{ site.repos[0].url }}/wiki/Component-Maturity-Scale" aria-describedby="tooltip-text-{{ page.title | slugify }}">
+              <a class="usa-label label-{{ page.maturity }}" href="{{ site.baseurl }}/about-our-work/component-maturity-scale/" aria-describedby="tooltip-text-{{ page.title | slugify }}">
                 {{ page.maturity }}
               </a>
             </div>

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -1437,6 +1437,12 @@ $font-light: 300;
   }
 }
 
+.page-product-roadmap {
+  h2 {
+    color: $color-primary-darker;
+  }
+}
+
 .usa-center {
   text-align: center;
 }

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -412,11 +412,13 @@ $font-monospace:       Consolas, Monaco, 'Andale Mono', monospace;
   @include label-link($color-gold-lightest, $color-gold-lighter);
 }
 
-.label-beta {
+.label-beta,
+.label-in-progress {
   @include label-link($color-primary-alt-lightest, $color-primary-alt-light);
 }
 
-.label-recommended {
+.label-recommended,
+.label-done {
   @include label-link($color-green-lightest, $color-green-lighter);
 }
 
@@ -1439,6 +1441,13 @@ $font-light: 300;
   }
 }
 
+.page-product-roadmap {
+  .usa-label {
+    display: inline-block;
+    position: relative;
+  }
+}
+
 .usa-center {
   text-align: center;
 }
@@ -1457,37 +1466,37 @@ $font-light: 300;
       opacity: 1;
     }
   }
+}
 
-  .tooltip-text {
-    display: none;
+.tooltip-text {
+  display: none;
 
-    @include media($medium-screen) {
-      @include margin(0 null 0 20px);
-      background-color: $color-gray-dark;
-      border-radius: $border-radius;
-      bottom: 100%;
-      color: $color-white;
-      display: block;
-      font-size: 14px;
-      left: 50%;
-      padding: 7px 10px;
-      width: 267px;
-      opacity: 0;
-      position: absolute; // Position the tooltip text
-      transition: all 0.1s ease-in-out;
-      transition-delay: 0.1s;
-      z-index: 1;
+  @include media($medium-screen) {
+    @include margin(0 null 0 20px);
+    background-color: $color-gray-dark;
+    border-radius: $border-radius;
+    bottom: 100%;
+    color: $color-white;
+    display: block;
+    font-size: 14px;
+    left: 50%;
+    padding: 7px 10px;
+    width: 267px;
+    opacity: 0;
+    position: absolute; // Position the tooltip text
+    transition: all 0.1s ease-in-out;
+    transition-delay: 0.1s;
+    z-index: 1;
 
-      &::after {
-        border-width: 5px;
-        border-style: solid;
-        border-color: $color-base transparent transparent transparent;
-        content: " ";
-        left: 10%;
-        margin-left: -12px;
-        position: absolute;
-        top: 100%; // At the bottom of the tooltip
-      }
+    &::after {
+      border-width: 5px;
+      border-style: solid;
+      border-color: $color-base transparent transparent transparent;
+      content: " ";
+      left: 10%;
+      margin-left: -12px;
+      position: absolute;
+      top: 100%; // At the bottom of the tooltip
     }
   }
 }

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -1421,7 +1421,8 @@ $font-light: 300;
 
 .page-product-roadmap,
 .page-for-developers,
-.page-for-designers {
+.page-for-designers,
+.page-component-maturity-scale {
   .usa-content {
     > ul:not(.usa-content-list) {
       max-width: $text-max-width;
@@ -1439,6 +1440,7 @@ $font-light: 300;
 .usa-center {
   text-align: center;
 }
+
 
 // Custom tooltip styles -------------- //
 

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -1431,13 +1431,9 @@ $font-light: 300;
 }
 
 .page-for-developers,
-.page-for-designers {
-  h2 {
-    color: $color-primary-darker;
-  }
-}
-
-.page-product-roadmap {
+.page-for-designers,
+.page-product-roadmap,
+.page-component-maturity-scale {
   h2 {
     color: $color-primary-darker;
   }

--- a/docs/pages/about-our-work/component-maturity-scale.md
+++ b/docs/pages/about-our-work/component-maturity-scale.md
@@ -6,15 +6,11 @@ category: About our work
 lead: The component maturity scale is a way to indicate the level of robustness of any component or asset within the Draft U.S. Web Design Standards. Best practices for agile delivery include releasing software incrementally, before it’s perfect. We can (and should) release new items in the Standards following this principle, and we assess each component independently of every other component or the library as a whole.
 ---
 
-
-
 We communicate the robustness of each new pattern in two ways: by displaying its maturity level in the UI for each particular component, and by indicating its maturity in release notes and other documentation.
 
 For more information on how a component moves from one maturity level to the next, please review our draft design [contribution guidelines](https://github.com/18F/web-design-standards/blob/staging/CONTRIBUTING.md). They define, in detail, the assessments and activities our team conducts to determine whether a component is ready to move to the next level.
 
-
 Our system is inspired by http://usajobs.github.io/design-system/getting-started/#maturity, who outline a maturity scale of their own in their Getting Started and who use these labels on the individual component page.
-
 
 ## Hypothesis
 ### Definitions of done

--- a/docs/pages/about-our-work/component-maturity-scale.md
+++ b/docs/pages/about-our-work/component-maturity-scale.md
@@ -1,0 +1,63 @@
+---
+permalink: /about-our-work/component-maturity-scale/
+layout: styleguide
+title: Component maturity scale
+category: About our work
+lead: The component maturity scale is a way to indicate the level of robustness of any component or asset within the Draft U.S. Web Design Standards. Best practices for agile delivery include releasing software incrementally, before it’s perfect. We can (and should) release new items in the Standards following this principle, and we assess each component independently of every other component or the library as a whole.
+---
+
+
+
+We communicate the robustness of each new pattern in two ways: by displaying its maturity level in the UI for each particular component, and by indicating its maturity in release notes and other documentation.
+
+For more information on how a component moves from one maturity level to the next, please review our draft design [contribution guidelines](https://github.com/18F/web-design-standards/blob/staging/CONTRIBUTING.md). They define, in detail, the assessments and activities our team conducts to determine whether a component is ready to move to the next level.
+
+
+Our system is inspired by http://usajobs.github.io/design-system/getting-started/#maturity, who outline a maturity scale of their own in their Getting Started and who use these labels on the individual component page.
+
+
+## Hypothesis
+### Definitions of done
+* The user need has been identified, but the approach to solving the problem has not yet been decided.
+* The core team has decided to tackle this UI pattern.
+* The pattern has been listed in the public roadmap.
+
+## Proposed
+### Definitions of done
+Includes everything from the hypothesis phase, as well as:
+
+* Identifies what user need the pattern solves.
+* Lists alternative patterns that support this user need (along with reasons why the submitted pattern is the best choice).
+* Includes a rendering of the design: a wireframe, design mock-up, interaction pattern, prototype, or (link to) a finished pattern.
+* Describes any primary or secondary research that supports this pattern (include who you tested with, what kind of research you conducted, and links to any supporting documentation, including interview protocols, prototype used, and so on).
+
+## Alpha
+### Definitions of done
+Includes everything from the proposed phase, which has been reviewed by the design team, as well as:
+
+* The pattern has passed all heuristic assessments.
+* Our team hasn't surfaced any secondary research that would explicitly reject the pattern (Alternatively: The person submitting the pattern has attached secondary research that supports it).
+
+## Beta
+### Definitions of done
+Includes everything from the proposed and alpha phases, as well as:
+
+* Pattern is generally usable, on multiple devices, for people with relatively "normal" digital literacy.
+* Pattern works in multiple configurations with other components in the Standards.
+* First draft of documentation is written.
+* Pattern is available in beta in the Draft U.S. Web Design Standards.
+
+## Recommended
+### Definitions of done
+Includes everything in the proposed, alpha, and beta phases, as well as:
+
+* Pattern is usable, on multiple devices, by people with multiple disabilities (blind, low vision, cognitive disabilities, motor disabilities, low language skills, low digital literacy, and more).
+* Documentation, including context of use rationale, is complete.
+* Pattern has been in beta for [period of time] and external teams report few problems using it.
+
+## Deprecated
+### Definitions of done
+* Pattern has been removed from the pattern library and design stencils.
+* Pattern has been marked deprecated in release notes.
+
+### This is the end of the line, folks.

--- a/docs/pages/about-our-work/product-roadmap.md
+++ b/docs/pages/about-our-work/product-roadmap.md
@@ -15,35 +15,20 @@ lead: Here, you’ll find our product roadmap — an up-to-date report on the w
   <li>Using a federal website that incorporates the Standards as a member of the public</li>
 </ul>
 
-## Milestone 1
-
-- A public, up-to-date product road map.
-- A public maintenance plan.
-- A bare-bones HTML starter page, with CSS and JS pre-linked and necessary tags and classes.
-- Defined processes for active and public implementer support.
-- Contribution guidelines for both designers and developers.
-- Form patterns that include recommendations for just-in-time instructions.
-- UI components are comprised of clean, semantic code.
-- Simple "Getting Started" process and instructions.
-- A core set of common, usable web components.
-- Ready to go HTML templates (and related design stencils) for common types of government site pages.
-
-## Milestone 2
-
-- Form templates structured in short chunks.
-- Language toggle and other web components related to multilingual sites.
-- Case studies that illustrate how the Standards can be used.
-- Boilerplate language to include in government contracts.
-- The ability to quickly copy and paste code from the website.
-- Concise, focused documentation that is easy to find but out of the way.
-- Form patterns that allow for easy recovery of mistakes.
-- Website chrome in Spanish.
-- Easy ways to customize the Standards to fit an agency’s brand and needs.
-- Design stencils and assets.
-
-## Milestone 3
-
-- Interaction patterns for save-as-you-go functionality
-- Guidance on how to manage updates to the Standards in your own project.
-- A fork-able starter project representing a simple, static site with a few common pages.
-- Wayfinding components, such as progress indicators.
+{% for milestone in site.data.milestones %}
+<section id="milestone-{{ milestone.id }}">
+  <h2>{{ milestone.title }}</h2>
+  <ul>
+  {% for task in milestone.tasks %}
+    <li>
+      {{ task.title }}
+      {% if task.status %}
+          <a class="usa-label label-{{ task.status | slugify }}" href="{{ task.url }}" aria-describedby="tooltip-text-{{ task.title | slugify }}">
+            {{ task.status }}
+          </a>
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
+</section>
+{% endfor %}

--- a/docs/pages/about-our-work/product-roadmap.md
+++ b/docs/pages/about-our-work/product-roadmap.md
@@ -15,56 +15,35 @@ lead: Here, you’ll find our product roadmap — an up-to-date report on the w
   <li>Using a federal website that incorporates the Standards as a member of the public</li>
 </ul>
 
-## Deciding to use the Standards
-
-Decision makers, designers, and developers want to know if the Standards will work for their projects.
+## Milestone 1
 
 - A public, up-to-date product road map.
-- UI components are comprised of clean, semantic code.
-- The Standards offer core set of common, usable web components.
-- Deciders and implementers want to see case studies so they can assess whether it will work for their project.
-- Deciders want to know that they can customize the standards to fit their agency's brands and needs. Implementers want to be able to do this easily.
-
-Decision makers, designers, and developers want to know how the Standards will be maintained.
-
 - A public maintenance plan.
-- Guidance on how to manage updates to the standards in individual projects.
-- Contract managers want to know how to include use of the Standards in their contracts.
-- Boilerplate language to include in government contracts.
-
-## Working with the Standards
-
-Designers and developers need to be able to get started quickly.
-
 - A bare-bones HTML starter page, with CSS and JS pre-linked and necessary tags and classes.
-- Simple "Getting Started" process and instructions.
-- Ready to go HTML templates (and related design stencils) for common types of government site pages.
-- Ability to quickly copy/paste code from the website.
-- Design stencils and assets.
-- A starter project representing a simple, static site with a few common pages.
-
-Designers and developers want to know where to go for help.
-
 - Defined processes for active and public implementer support.
-- Concise, focused documentation that is easy to find but out of the way.
-
-## Giving back
-
-Contributors want to know how to share their suggestions for improving the Standards.
-
 - Contribution guidelines for both designers and developers.
-
-## General public
-
-Members of the public want easy-to-use forms and interactions.
-
 - Form patterns that include recommendations for just-in-time instructions.
+- UI components are comprised of clean, semantic code.
+- Simple "Getting Started" process and instructions.
+- A core set of common, usable web components.
+- Ready to go HTML templates (and related design stencils) for common types of government site pages.
+
+## Milestone 2
+
 - Form templates structured in short chunks.
-- Form patterns that allow for easy recovery of mistakes.
-- Interaction patterns for "Save as you go" functionality.
-- Way-finding components, such as progress indicators.
-
-Non-native English speakers want to be able to read and understand the content.
-
 - Language toggle and other web components related to multilingual sites.
+- Case studies that illustrate how the Standards can be used.
+- Boilerplate language to include in government contracts.
+- The ability to quickly copy and paste code from the website.
+- Concise, focused documentation that is easy to find but out of the way.
+- Form patterns that allow for easy recovery of mistakes.
 - Website chrome in Spanish.
+- Easy ways to customize the Standards to fit an agency’s brand and needs.
+- Design stencils and assets.
+
+## Milestone 3
+
+- Interaction patterns for save-as-you-go functionality
+- Guidance on how to manage updates to the Standards in your own project.
+- A fork-able starter project representing a simple, static site with a few common pages.
+- Wayfinding components, such as progress indicators.


### PR DESCRIPTION
## Description

Adds "Component maturity scale" and update "Product roadmap"

## Additional information

### Component maturity scale

<img width="1084" alt="screen shot 2016-07-11 at 5 59 36 pm" src="https://cloud.githubusercontent.com/assets/5249443/16751876/aa174af6-4791-11e6-91a4-ff220b346fd3.png">

### Product roadmap

<img width="1075" alt="screen shot 2016-07-11 at 5 59 51 pm" src="https://cloud.githubusercontent.com/assets/5249443/16751879/ad4e8e14-4791-11e6-8ea6-c8244fc03cbc.png">

Resolves: #1309, #1311. 

