### PR TITLE
[Website]: Remove deadlink from form controls and form templates accessibility section

### DIFF
--- a/docs/_components/form-controls/form-controls.md
+++ b/docs/_components/form-controls/form-controls.md
@@ -9,6 +9,6 @@ lead: Form controls allow users to enter information into a page.
 
 {% include accessibility.html %}
 
-<p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines in the “Form Templates” section</a>.</p>
+<p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines in the “Form Templates” section</a>.</p>
 
 {% include child-sections.html parent='Form controls' %}

--- a/docs/_includes/accessibility.html
+++ b/docs/_includes/accessibility.html
@@ -1,6 +1,6 @@
 <h3 class="usa-heading heading-margin-alt">Accessibility</h3>
 
-<p>As you customize these templates, make sure they continue to meet the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for all form controls</a> as well as the accessibility guidelines for each individual control.</p>
+<p>As you customize these templates, make sure they meet the accessibility guidelines in this introduction and as described for each control.</p>
 <p>In addition, when creating forms with multiple controls or customizing these templates, be sure to:</p>
 
 <ul class="usa-content-list">

--- a/docs/_includes/accessibility.html
+++ b/docs/_includes/accessibility.html
@@ -1,7 +1,6 @@
 <h3 class="usa-heading heading-margin-alt">Accessibility</h3>
 
 <p>As you customize these templates, make sure they meet the accessibility guidelines in this introduction and as described for each control.</p>
-<p>In addition, when creating forms with multiple controls or customizing these templates, be sure to:</p>
 
 <ul class="usa-content-list">
   <li>Display form controls in the same order in HTML as they appear on screen. Do not use CSS to rearrange the form controls. Screen readers narrate forms in the order they appear in the HTML.</li>


### PR DESCRIPTION
## Description

Removes deadlink from form controls and form templates section and updates the sentence text. 

Also fixes an incorrect link on form controls that was linking to itself when it should be linking to form templates.

## Additional information
### This is what it looks like:

<img width="595" alt="screen shot 2016-07-12 at 10 57 00 am" src="https://cloud.githubusercontent.com/assets/5249443/16777766/c5296700-481f-11e6-9769-0a85f0088403.png">

Resolves: #1313.