### PR TITLE
[Form controls]: Add maxlength to date form fields

### DIFF
--- a/docs/_components/form-controls/05-date-input.md
+++ b/docs/_components/form-controls/05-date-input.md
@@ -15,15 +15,15 @@ lead: Three text fields are the easiest way for users to enter most dates.
     <div class="usa-date-of-birth">
       <div class="usa-form-group usa-form-group-month">
         <label for="date_of_birth_1">Month</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="tel" maxlength="2" min="1" max="12" value="">
       </div>
       <div class="usa-form-group usa-form-group-day">
         <label for="date_of_birth_2">Day</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="tel" maxlength="2" min="1" max="31" value="">
       </div>
       <div class="usa-form-group usa-form-group-year">
         <label for="date_of_birth_3">Year</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="tel" maxlength="4" min="1900" max="2000" value="">
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
## Description

Not sure if this is helpful, but on Chrome and Safari I can enter in an arbitrary length of numbers. Adding maxlength for these fields would limit user error. 

Also, type="number" doesn't work with maxlength but type="tel" does. This has the added convenience of bringing up the simpler number input on iOS which makes for easier number entry (though it is less semanticly clean).

## Additional information

Before:
![screen shot 2016-07-12 at 11 53 29 pm](https://cloud.githubusercontent.com/assets/216909/16792237/aa35702c-4894-11e6-9e7e-3d5b33af0012.png)

After: 
![screen shot 2016-07-13 at 12 57 25 am](https://cloud.githubusercontent.com/assets/216909/16792247/caee2c00-4894-11e6-8ccc-d6b70a280ca6.png)

[Maxlength ignored for type="number"](http://stackoverflow.com/questions/18510845/maxlength-ignored-for-input-type-number-in-chrome)
[The "tel" type](http://www.wufoo.com/html5/types/2-tel.html)
[Mobile Input Types](http://mobileinputtypes.com/)