### PR TITLE
Replace 'ol li' rule w/ 'ol > li' rule

### DIFF
--- a/src/stylesheets/elements/_list.scss
+++ b/src/stylesheets/elements/_list.scss
@@ -41,7 +41,7 @@ ul li {
   }
 }
 
-ol li {
+ol > li {
   counter-increment: table-ol;
   display: table-row;
 


### PR DESCRIPTION
I think this fixes #1328 so that unordered lists nested within ordered lists work as expected.
