### PR TITLE
[WIP] [Components]: Remove variables.scss from import

### DIFF
--- a/src/stylesheets/all.scss
+++ b/src/stylesheets/all.scss
@@ -8,7 +8,6 @@
 // Core -------------- //
 
 @import 'core/defaults';
-@import 'core/variables';
 @import 'core/fonts';
 @import 'core/base';
 @import 'core/grid-settings';


### PR DESCRIPTION
## Description

This removes `core/_variables.scss` from the import in the `stylesheets/all` file. There's already `defaults.scss` which have the variables. This will allow people to override our variables with their own by declaring their variables before the `all` import.

Resolves: #1168.

### Questions: 

Do the names of the files still make sense. variables.scss and defaults.scss or should we consider renaming them to, for example: 

1. `variables` (default variables) + `variables-custom` (for your own) 
2. `variables-defaults` and `variables-custom`/`variables`

Ideally, we can include some documentation on the site for how to do this.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed. [only styleguide lint errors unrelated to this but which i fixed in #1331]
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.

cc: @msecret 
