### PR TITLE
[Image links]: Remove Firefox patch on media_link class

### DIFF
--- a/src/stylesheets/elements/_figure.scss
+++ b/src/stylesheets/elements/_figure.scss
@@ -11,13 +11,3 @@ img {
 .media_link {
   @include media-link();
 }
-
-// Patch for Firefox: max-width:100% is not respected within auto-width inline
-// blocks
-@-moz-document url-prefix() {
-  .media_link {
-    display: table;
-    table-layout: fixed;
-    width: 100%;
-  }
-}


### PR DESCRIPTION
## Description

Previously, we included a patch bc Firefox did not respect auto-width of images inside of inline blocks. It looks like that has been fixed, as you can see in the comment on 2016-02-09: https://bugzilla.mozilla.org/show_bug.cgi?id=932996

Links to: https://bugzilla.mozilla.org/show_bug.cgi?id=823483.

