### PR TITLE
[Website] Update incorrect documentation on variables

### DIFF
--- a/docs/pages/getting-started/developers.md
+++ b/docs/pages/getting-started/developers.md
@@ -124,8 +124,8 @@ You can also email us directly at uswebdesignstandards@gsa.gov.
 * Uses a **[modified BEM](https://pages.18f.gov/frontend/css-coding-styleguide/naming/)** approach created by 18F for naming CSS selectors. Objects in CSS are separated by single dashes. Multi-word objects are separated by an underscore (For example: `.usa-button-cool_feature-active`).
 * Uses **modular CSS** for scalable, modular, and flexible code.
 * Uses **nesting** when appropriate. Nest minimally with up to two levels of nesting.
-* **Global variables** are defined in the _variables.scss file. This is where custom theming can be done to change site-wide colors, fonts, etc.
-* Hard-coded magic numbers are avoided and, if necessary, defined in the `_variables.scss` file.
+* **Global variables** are defined in the `_defaults.scss` file. Custom theming can be done by copying `_variables.scss`, changing variable values and importing it before uswds in Sass.
+* Hard-coded magic numbers are avoided and, if necessary, defined in the `_defaults.scss` file.
 * Media queries are built **mobile first**.
 * **Spacing units** are as much as possible defined as rem or em units so they scale appropriately with text size. Pixels can be used for detail work and should not exceed 5px (For example: 3px borders).
 


### PR DESCRIPTION
## Description

The documentation on this is now incorrect as variables.scss is no longer being imported so is not technically where these things are defined.

## Additional information

Also, the way this was previously worded, it sounded like it was suggesting people to modify the src files of the standards which I've been working hard to stop from happening because it's a terrible practice.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
