### PR TITLE
Replace 'ol li' rule w/ 'ol > li' rule (1007-var_for_asset_paths branch)

### DIFF
--- a/src/stylesheets/elements/_list.scss
+++ b/src/stylesheets/elements/_list.scss
@@ -37,7 +37,7 @@ ul li {
   }
 }
 
-ol li {
+ol > li {
   counter-increment: table-ol;
   display: table-row;
 


### PR DESCRIPTION
This is a port of #1329 to the 1007-var_for_asset_paths branch, which [cg-style](https://github.com/18F/cg-style) uses.  Until that repository starts pulling directly from uswds' master branch, it'd be nice if we could have this hotfix, since the cloud.gov documentation needs to include bulleted lists within ordered lists.

@msecret does this look OK to merge?