### PR TITLE
[Website] Removing descendent reference from unstyled list utility.

### DIFF
--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -31,7 +31,7 @@
   margin: 0;
   padding: 0;
 
-  > li {
+  li {
     display: list-item;
     margin: 0;
 


### PR DESCRIPTION
## Description

This pull request cancels out the list styles from the websites sidenav that were introduced [here](https://github.com/18F/web-design-standards/commit/1bea7f69873bf753fe268508bbbdd2a5a3f549a2#diff-fced6c74fbf3140d02e92fd710e888eeL34). I am assuming that this does not work as expected b/c it is a mixin, but would need to do some more digging to verify.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.

