### PR TITLE
[Sidenav]: Add unstyled list mixin to inner list in sidenav

### DIFF
--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -40,6 +40,7 @@
 }
 
 .usa-sidenav-sub_list {
+  @include unstyled-list();
   margin: 0;
   width: 100%;
 


### PR DESCRIPTION
## Description

Since adding the direct selector to the unstyled list mixin, the styles don't carry down to another list in the sidenav. This adds the mixin to the sublist.

Supersedes #1372.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.

