### PR TITLE
[Lists]: Simplify lists to use browser defaults

### DIFF
--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -580,7 +580,7 @@ h2 + .tooltip {
 .preview-lists {
   padding-bottom: 0;
 
-  h6 {
+  .usa-heading-alt {
     margin-top: 0;
   }
 }

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -2,6 +2,7 @@
   @include unstyled-list();
 
   li {
+    @include margin(0 null);
     border-top: 1px solid $color-gray;
     font-size: $h4-font-size;
 

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -2,7 +2,6 @@
   @include unstyled-list();
 
   li {
-    @include margin(0 null);
     border-top: 1px solid $color-gray;
     font-size: $h4-font-size;
 

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -26,9 +26,13 @@
 // Unstyled list helper
 
 @mixin unstyled-list() {
+  @include margin(0 null);
   list-style-type: none;
-  margin: 0;
-  padding: 0;
+  padding-left: 0;
+
+  > li {
+    margin-bottom: 0;
+  }
 }
 
 // Content size helpers

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -26,23 +26,9 @@
 // Unstyled list helper
 
 @mixin unstyled-list() {
-  display: block;
   list-style-type: none;
   margin: 0;
   padding: 0;
-
-  > li {
-    display: list-item;
-    margin: 0;
-
-    &::before {
-      display: none;
-    }
-
-    &::after {
-      display: none;
-    }
-  }
 }
 
 // Content size helpers

--- a/src/stylesheets/elements/_list.scss
+++ b/src/stylesheets/elements/_list.scss
@@ -1,6 +1,6 @@
 ul,
 ol {
-  padding-left: 1.94em;
+  padding-left: 1.94em; // Approximately 15px left padding at default font size
 }
 
 li {

--- a/src/stylesheets/elements/_list.scss
+++ b/src/stylesheets/elements/_list.scss
@@ -1,5 +1,6 @@
 ul,
 ol {
+  @include margin(1em null);
   padding-left: 1.94em; // Approximately 15px left padding at default font size
 }
 

--- a/src/stylesheets/elements/_list.scss
+++ b/src/stylesheets/elements/_list.scss
@@ -1,20 +1,14 @@
 ul,
 ol {
-  @include margin(2em null 2em 0.9em);
-  list-style: none;
-  padding-left: 0;
-  display: table;
+  padding-left: 1.94em;
+}
 
-  li {
-    line-height: $base-line-height;
-    margin-bottom: 0.75em;
-    margin-top: 0.75em;
+li {
+  line-height: $base-line-height;
+  margin-bottom: 0.5em;
 
-    &::after {
-      content: '';
-      display: block;
-      margin-bottom: 0.5em;
-    }
+  &:last-child {
+    margin-bottom: 0;
   }
 }
 
@@ -31,49 +25,7 @@ p {
   }
 }
 
-ul li {
-  display: table-row;
-
-  &::before {
-    content: '\2022';
-    display: table-cell;
-    padding-right: 0.4em;
-  }
-}
-
-ol > li {
-  counter-increment: table-ol;
-  display: table-row;
-
-  &::before {
-    content: counter(table-ol) '.';
-    display: table-cell;
-    padding-right: 0.4em;
-    text-align: right;
-  }
-}
-
-li {
-  margin-bottom: 0.5em;
-}
-
 // Unstyled lists
-
 .usa-unstyled-list {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-
-  li {
-    display: list-item;
-    margin: 0;
-
-    &::before {
-      display: none;
-    }
-
-    &::after {
-      display: none;
-    }
-  }
+  @include unstyled-list;
 }


### PR DESCRIPTION
## Description

Simplifies lists to use browser defaults, and not use on pseudo selectors.

Resolves: #1091.

Dependent on #1374 for sidenav to look correct.

Notable change is that we are switching styles, and bullets will look slightly larger depending on your browser default. Below is Chrome.

## Screenshots
**Before** (custom list and bullets):
<img width="625" alt="screen shot 2016-08-03 at 1 02 13 pm" src="https://cloud.githubusercontent.com/assets/5249443/17381209/aefecd14-597f-11e6-9dab-d5fc4fc925bd.png">


**After** (Chrome browser default):
<img width="582" alt="screen shot 2016-08-03 at 1 39 50 pm" src="https://cloud.githubusercontent.com/assets/5249443/17381235/c8fa9d6a-597f-11e6-9477-61d00cafd5e6.png">

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
