### PR TITLE
[Website] Move accordion deprecation warning

### DIFF
--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -49,7 +49,7 @@ maturity: alpha
     <a name="deprecated"></a>
     <div class="usa-alert usa-alert-warning" style="margin-bottom: 1rem;">
       <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">Deprecated</h3>
+        <h3 class="usa-alert-heading">Deprecated version</h3>
         <p class="usa-alert-text">
           The accordion was changed <strong>July 2016</strong> in order to improve its
           implementation. Currently, both versions of the accordion work, but at some

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -47,11 +47,17 @@ maturity: alpha
       <li>Make sure interactive elements within the collapsible region are far enough from the headers that users don’t accidentally trigger a collapse. (The exact distance depends on the device.)</li>
     </ul>
     <a name="deprecated"></a>
-    <h4 class="usa-heading">Upgrading deprecated accordions</h4>
-    <p>The accordion was changed July 2016 in order to improve it's
-    implementation. Currently, both versions of the accordion work, but at some
-    point in the future, the deprecated accordion will no longer function correctly.
-    To upgrade your existing accordions to the new accordion:</p>
+    <div class="usa-alert usa-alert-warning" style="margin-bottom: 1rem;">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Deprecated</h3>
+        <p class="usa-alert-text">
+          The accordion was changed <strong>July 2016</strong> in order to improve it's
+          implementation. Currently, both versions of the accordion work, but at some
+          point in the future, the deprecated accordion will no longer function correctly.
+        </p>
+      </div>
+    </div>
+    <p>To upgrade your existing accordions to the new accordion:</p>
     <ul class="usa-content-list">
       <li>Remove the top level div that contains the <code>usa-accordion</code> or
       <code>usa-accordion-bordered</code> class.</li>
@@ -61,77 +67,3 @@ maturity: alpha
     </p>
   </div>
 </div>
-
-<div class="usa-alert usa-alert-warning" style="margin-bottom: 1rem;">
-  <div class="usa-alert-body">
-    <h3 class="usa-alert-heading">Deprecated</h3>
-    <p class="usa-alert-text">
-      The following accordion has been deprecated since July 2016. Please follow
-      <a href="#deprecated">the instructions</a> to update any existing
-      accordions to the new format.
-    </p>
-  </div>
-</div>
-
-<h6>Deprecated</h6>
-
-<div class="usa-accordion">
-  <ul class="usa-unstyled-list">
-    <li>
-      <button class="usa-button-unstyled"
-        aria-expanded="true" aria-controls="amendment-c-1">
-        First Amendment
-      </button>
-      <div id="amendment-c-1" class="usa-accordion-content">
-        <p>
-        Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled"
-        aria-controls="amendment-c-2">
-        Second Amendment
-      </button>
-      <div id="amendment-c-2" class="usa-accordion-content">
-        <p>
-        A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled"
-        aria-controls="amendment-c-3">
-        Third Amendment
-      </button>
-      <div id="amendment-c-3" class="usa-accordion-content">
-        <p>
-        No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled"
-        aria-controls="amendment-c-4">
-        Fourth Amendment
-      </button>
-      <div id="amendment-c-4" class="usa-accordion-content">
-        <p>
-        The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled"
-        aria-controls="amendment-c-5">
-        Fifth Amendment
-      </button>
-      <div id="amendment-c-5" class="usa-accordion-content">
-        <p>
-        No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
-        </p>
-      </div>
-    </li>
-  </ul>
-</div>
-

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -51,7 +51,7 @@ maturity: alpha
       <div class="usa-alert-body">
         <h3 class="usa-alert-heading">Deprecated</h3>
         <p class="usa-alert-text">
-          The accordion was changed <strong>July 2016</strong> in order to improve it's
+          The accordion was changed <strong>July 2016</strong> in order to improve its
           implementation. Currently, both versions of the accordion work, but at some
           point in the future, the deprecated accordion will no longer function correctly.
         </p>
@@ -69,9 +69,9 @@ maturity: alpha
 </div>
 
 <!--
-The following deprecated accordion is kept here for testing purposes for tthe
+The following deprecated accordion is kept here for testing purposes for the
 development team and should not be shown to users.
---!>
+-->
 <div style="display: none">
   <div class="usa-accordion">
     <ul class="usa-unstyled-list">

--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -67,3 +67,69 @@ maturity: alpha
     </p>
   </div>
 </div>
+
+<!--
+The following deprecated accordion is kept here for testing purposes for tthe
+development team and should not be shown to users.
+--!>
+<div style="display: none">
+  <div class="usa-accordion">
+    <ul class="usa-unstyled-list">
+      <li>
+        <button class="usa-button-unstyled"
+          aria-expanded="true" aria-controls="amendment-c-1">
+          First Amendment
+        </button>
+        <div id="amendment-c-1" class="usa-accordion-content">
+          <p>
+          Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+          </p>
+        </div>
+      </li>
+      <li>
+        <button class="usa-button-unstyled"
+          aria-controls="amendment-c-2">
+          Second Amendment
+        </button>
+        <div id="amendment-c-2" class="usa-accordion-content">
+          <p>
+          A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+          </p>
+        </div>
+      </li>
+      <li>
+        <button class="usa-button-unstyled"
+          aria-controls="amendment-c-3">
+          Third Amendment
+        </button>
+        <div id="amendment-c-3" class="usa-accordion-content">
+          <p>
+          No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+          </p>
+        </div>
+      </li>
+      <li>
+        <button class="usa-button-unstyled"
+          aria-controls="amendment-c-4">
+          Fourth Amendment
+        </button>
+        <div id="amendment-c-4" class="usa-accordion-content">
+          <p>
+          The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
+          </p>
+        </div>
+      </li>
+      <li>
+        <button class="usa-button-unstyled"
+          aria-controls="amendment-c-5">
+          Fifth Amendment
+        </button>
+        <div id="amendment-c-5" class="usa-accordion-content">
+          <p>
+          No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
+          </p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren't relevant. 

## Title Line Template: [Website] - [UI component]: Brief statement describing what this pull request solves.

Use the title line as the title of your pull request, then delete these lines.

Website: Issues that impact standards.usa.gov look, feel, or functionality.
UI component: Issues that impact the look, feel, or functionality of the standards themselves.

-->

## Description

Moves the deprecated accordion to a hidden div and moves the deprecation warning to the documentation to help with usability.

## Additional information

I decided to move the deprecated accordion to a hidden div because I think WDS devs need a way to test to ensure their code doesn't break the old accordion, as it's only deprecated not completely removed. A more complex options (but would have usability concerns) is for there to be a dropdown link to show the deprecated accordion.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
