### PR TITLE
[UI component] Using sr-only mixing for .usa-sr-only class

### DIFF
--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -6,14 +6,13 @@
 }
 
 // Screen reader only helper
-.usa-sr-only {
+@mixin sr-only() {
   position: absolute;
   left: -999em;
 }
 
-@mixin sr-only() {
-  position: absolute;
-  left: -999em;
+.usa-sr-only {
+  @include sr-only();
 }
 
 // Aria hidden helper


### PR DESCRIPTION
## Description

Refactoring .usa-sr-only class to use sr-only() mixin

## Additional information

### Before

    // Screen reader only helper
    .usa-sr-only {
    position: absolute;
    left: -999em;
    }

    @mixin sr-only() {
      position: absolute;
      left: -999em;
    }

### After
```
// Screen reader only helper
@mixin sr-only() {
  position: absolute;
  left: -999em;
}

.usa-sr-only {
  @include sr-only();
}
```


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.

