### PR TITLE
Use sass variable for font path

### DIFF
--- a/src/stylesheets/core/_defaults.scss
+++ b/src/stylesheets/core/_defaults.scss
@@ -22,7 +22,7 @@ $lead-line-height:    1.7 !default;
 
 $font-sans:           'Source Sans Pro', $helvetica !default;
 $font-serif:          'Merriweather', $georgia !default;
-$font-path:           '../fonts'  !default;
+$font-path:           '../fonts' !default;
 
 $font-normal:         400 !default;
 $font-bold:           700 !default;

--- a/src/stylesheets/core/_defaults.scss
+++ b/src/stylesheets/core/_defaults.scss
@@ -22,6 +22,7 @@ $lead-line-height:    1.7 !default;
 
 $font-sans:           'Source Sans Pro', $helvetica !default;
 $font-serif:          'Merriweather', $georgia !default;
+$font-path:           '../fonts'  !default;
 
 $font-normal:         400 !default;
 $font-bold:           700 !default;

--- a/src/stylesheets/core/_fonts.scss
+++ b/src/stylesheets/core/_fonts.scss
@@ -1,6 +1,6 @@
 @include font-face(
   'Source Sans Pro',
-  '../fonts/sourcesanspro-light-webfont',
+  '#{$font-path}/sourcesanspro-light-webfont',
   300,
   normal,
   $asset-pipeline: false,
@@ -9,7 +9,7 @@
 
 @include font-face(
   'Source Sans Pro',
-  '../fonts/sourcesanspro-regular-webfont',
+  '#{$font-path}/sourcesanspro-regular-webfont',
   400,
   normal,
   $asset-pipeline: false,
@@ -18,7 +18,7 @@
 
 @include font-face(
   'Source Sans Pro',
-  '../fonts/sourcesanspro-italic-webfont',
+  '#{$font-path}/sourcesanspro-italic-webfont',
   400,
   italic,
   $asset-pipeline: false,
@@ -27,7 +27,7 @@
 
 @include font-face(
   'Source Sans Pro',
-  '../fonts/sourcesanspro-bold-webfont',
+  '#{$font-path}/sourcesanspro-bold-webfont',
   700,
   normal,
   $asset-pipeline: false,
@@ -36,7 +36,7 @@
 
 @include font-face(
   'Merriweather',
-  '../fonts/merriweather-light-webfont',
+  '#{$font-path}/merriweather-light-webfont',
   300,
   normal,
   $asset-pipeline: false,
@@ -45,7 +45,7 @@
 
 @include font-face(
   'Merriweather',
-  '../fonts/merriweather-regular-webfont',
+  '#{$font-path}/merriweather-regular-webfont',
   400,
   normal,
   $asset-pipeline: false,
@@ -54,7 +54,7 @@
 
 @include font-face(
   'Merriweather',
-  '../fonts/merriweather-italic-webfont',
+  '#{$font-path}/merriweather-italic-webfont',
   400,
   italic,
   $asset-pipeline: false,
@@ -63,7 +63,7 @@
 
 @include font-face(
   'Merriweather',
-  '../fonts/merriweather-bold-webfont',
+  '#{$font-path}/merriweather-bold-webfont',
   700,
   normal,
   $asset-pipeline: false,

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -16,6 +16,7 @@ $lead-line-height:    1.7;
 
 $font-sans:           'Source Sans Pro', $helvetica;
 $font-serif:          'Merriweather', $georgia;
+$font-path:           '../fonts'
 
 $font-normal:         400;
 $font-bold:           700;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -16,7 +16,6 @@ $lead-line-height:    1.7;
 
 $font-sans:           'Source Sans Pro', $helvetica;
 $font-serif:          'Merriweather', $georgia;
-$font-path:           '../fonts'
 
 $font-normal:         400;
 $font-bold:           700;


### PR DESCRIPTION
* Fix for issue we are seeing when overwriting font rules in Rails apps
* See https://github.com/18F/uswds-rails-gem/issues/7 for more details