### PR TITLE
[Politespace + jQuery removal] Fixing Politespace in combination with jQuery removal.

### DIFF
--- a/docs/doc_assets/js/start.js
+++ b/docs/doc_assets/js/start.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $ = require('jquery');
+window.$ = window.jQuery = require('../../../node_modules/jquery/dist/jquery');
 var calculateAnchorPosition = require('./components/calculate-anchor-position');
 var stickyNav = require('./components/sticky-nav');
 

--- a/docs/doc_assets/js/start.js
+++ b/docs/doc_assets/js/start.js
@@ -1,6 +1,6 @@
 'use strict';
 
-window.$ = window.jQuery = require('../../../node_modules/jquery/dist/jquery');
+window.$ = window.jQuery = require('jquery');
 var calculateAnchorPosition = require('./components/calculate-anchor-position');
 var stickyNav = require('./components/sticky-nav');
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cross-spawn": "^2.1.5",
     "jquery": "^2.2.0",
     "normalize.css": "^3.0.3",
-    "politespace": "^0.1.4",
+    "politespace": "0.1.4",
     "prismjs": "^1.5.1"
   },
   "devDependencies": {

--- a/src/js/initializers/politespace.js
+++ b/src/js/initializers/politespace.js
@@ -1,11 +1,9 @@
 var verifyjQuery = require('../utils/verify-jquery');
-// window.jQuery = require('jquery');
 
 // jQuery Plugin
 
 if (verifyjQuery(window)) {
 
-  console.log('loading Politespace');
   var $ = window.jQuery;
 
   // README: This is necessary because politespace doesn't properly export anything
@@ -44,9 +42,8 @@ if (verifyjQuery(window)) {
   };
 
 	// auto-init on enhance (which is called on domready)
-  $(document).ready(function () {
+  $(function () {
     $('[data-' + componentName + ']').politespace();
   });
 
 }
-


### PR DESCRIPTION
This pull request fixes a few issues with  [`Politespace`](https://github.com/filamentgroup/politespace/) that occur due to the removal of `jQuery` + updates the `Politespace` API:

- `jQuery` was not being added to the `docs` correctly and was failing silently 😭 
- `Politespace` has recently (within the past 9 days) updated their package. I have explicitly stated in the `package.json` the usage of v0.1.4, which resolves the handling of this error. 

Since we are [removing `Politespace` and moving towards `Fieldkit`](https://github.com/18F/web-design-standards/issues/1385#issuecomment-239886877), my recommendation is for the team to *not* spend the time upgrading.