### PR TITLE
[UI component] [Tables]: Add background color for thead > tr > td

### DIFF
--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -4,7 +4,8 @@ table {
   min-width: 100%;
 
   thead {
-    th {
+    th,
+    td {
       background-color: $color-gray-lightest;
     }
   }


### PR DESCRIPTION
## Description

Applies the background color used for th elements within the thead to td elements also within the thead.

## Additional Information

The vets.gov [Survivors' and Dependents' Assistance](https://www.vets.gov/education/gi-bill/survivors-dependent-assistance/) page contains a table utilizing the web design standards table styles. The old format of this table fails during automated accessibility testing (with axe section 508 rules) due to blank contents of the upper left cell:

```
All non-empty td element in table larger than 3 by 3 must have an associated table header
```

```
<table>
  <caption>...</caption>
  <thead>
    <tr>
      <th></th>
      <th scope="col">Column Header 1</th>
      <th scope="col">Column Header 2</th>
    </tr>
  </thead>

  <tbody>
    <tr>
      <td scope="row">Row Header 1</td>
      <td>...</td>
      <td>...</td>
    </tr>

    <tr>
      <td scope="row">Row Header 2</td>
      <td>...</td>
      <td>...</td>
    </tr>
  </tbody>
</table>
```

To correct this I've changed all row and column headers to th elements, and the upper left element to a td (https://github.com/department-of-veterans-affairs/vets-website/pull/2915)

```
<table>
  <caption>...</caption>
  <thead>
    <tr>
      <td></td>
      <th scope="col">Column Header 1</th>
      <th scope="col">Column Header 2</th>
    </tr>
  </thead>

  <tbody>
    <tr>
      <th scope="row">Row Header 1</th>
      <td>...</td>
      <td>...</td>
    </tr>

    <tr>
      <th scope="row">Row Header 2</th>
      <td>...</td>
      <td>...</td>
    </tr>
  </tbody>
</table>
```

I'm not entirely sure it's the best solution, but it feels semantically accurate since the cell is primarily for spacing, and not used as a header. From a visual perspective the thead in its entirety should be shaded to match the th cells.

![survivors__and_dependents__assistance__vets_gov](https://cloud.githubusercontent.com/assets/215266/18139523/2a1fdd1c-6f6f-11e6-8e68-2e98f3f717fe.png)

We've made the change to our project, but feel this could be adopted upstream. Please let me know if you have any alternative recommendations or suggestions!