### PR TITLE
Removing gov banner mention

### DIFF
--- a/docs/_components/headers/headers.html
+++ b/docs/_components/headers/headers.html
@@ -3,7 +3,7 @@ layout: styleguide
 title: Headers
 category: UI components
 permalink: /headers/
-lead: 'Headers help users identify where they are and provide a quick, organized way to reach the main sections of a website. Our headers include an “official website of the U.S. government” banner, branding to identify the site, and horizontal navigation.'
+lead: 'Headers help users identify where they are and provide a quick, organized way to reach the main sections of a website. Our headers include branding to identify the site and horizontal navigation.'
 maturity: alpha
 ---
 


### PR DESCRIPTION
Julia let me know that we don't include the "Official U.S. government site" banner in our headers -- updated the copy to reflect this.