### PR TITLE
Refactor banner & header JS to export init functions

### DIFF
--- a/src/js/components/banner.js
+++ b/src/js/components/banner.js
@@ -3,15 +3,22 @@ var addClass = require('../utils/add-class');
 var removeClass = require('../utils/remove-class');
 var dispatch = require('../utils/dispatch');
 
-var headers = select('.usa-banner-header');
-headers.forEach(function (header) {
-  var click = function (e) {
-    (event.preventDefault) ? event.preventDefault() : event.returnValue = false;
-    var expanded = this.getAttribute('aria-expanded') === 'true';
-    var toggleClass = expanded ? addClass : removeClass;
-    toggleClass(header, 'usa-banner-header-expanded');
-  };
-  select('[aria-controls]').forEach(function (button) {
-    dispatch(button, 'click', click.bind(button));
+function bannerClickHandler (event) {
+  (event.preventDefault) ? event.preventDefault() : event.returnValue = false;
+  
+  var expanded = this.getAttribute('aria-expanded') === 'true';
+  var toggleClass = expanded ? addClass : removeClass;
+  toggleClass(header, 'usa-banner-header-expanded');
+}
+
+function bannerInit () {
+  var headers = select('.usa-banner-header');
+
+  headers.forEach(function (header) {
+    select('[aria-controls]').forEach(function (button) {
+      dispatch(button, 'click', headerClickHandler.bind(button));
+    });
   });
-});
+}
+
+module.exports = bannerInit;

--- a/src/js/components/banner.js
+++ b/src/js/components/banner.js
@@ -3,20 +3,21 @@ var addClass = require('../utils/add-class');
 var removeClass = require('../utils/remove-class');
 var dispatch = require('../utils/dispatch');
 
-function bannerClickHandler (event) {
+function headerClickHandler (event) {
   (event.preventDefault) ? event.preventDefault() : event.returnValue = false;
   
-  var expanded = this.getAttribute('aria-expanded') === 'true';
+  var expanded = event.target.getAttribute('aria-expanded') === 'true';
   var toggleClass = expanded ? addClass : removeClass;
-  toggleClass(header, 'usa-banner-header-expanded');
+  toggleClass(this, 'usa-banner-header-expanded');
 }
 
 function bannerInit () {
   var headers = select('.usa-banner-header');
 
   headers.forEach(function (header) {
+    var headerClick = headerClickHandler.bind(header);
     select('[aria-controls]').forEach(function (button) {
-      dispatch(button, 'click', headerClickHandler.bind(button));
+      dispatch(button, 'click', headerClick);
     });
   });
 }

--- a/src/js/components/header/mobile.js
+++ b/src/js/components/header/mobile.js
@@ -3,23 +3,27 @@ var addClass = require('../../utils/add-class');
 var removeClass = require('../../utils/remove-class');
 var dispatch = require('../../utils/dispatch');
 
-var navElements = select('.usa-menu-btn, .usa-overlay, .usa-nav-close');
-var toggleElements = select('.usa-overlay, .usa-nav');
-var navCloseElement = select('.usa-nav-close')[ 0 ];
-
-navElements.forEach(function (element) {
-  dispatch(element, 'click touchstart', function (e) {
-    toggleElements.forEach(function (element) {
-      toggleClass(element, 'is-visible');
-    });
-    toggleClass(document.body, 'usa-mobile_nav-active');
-    navCloseElement.focus();
-    return false;
-  });
-});
-
 function toggleClass (element, className) {
   if (element.classList) {
     element.classList.toggle(className);
   }
 }
+
+function mobileInit () {
+  var navElements = select('.usa-menu-btn, .usa-overlay, .usa-nav-close');
+  var toggleElements = select('.usa-overlay, .usa-nav');
+  var navCloseElement = select('.usa-nav-close')[ 0 ];
+
+  navElements.forEach(function (element) {
+    dispatch(element, 'click touchstart', function (e) {
+      toggleElements.forEach(function (element) {
+        toggleClass(element, 'is-visible');
+      });
+      toggleClass(document.body, 'usa-mobile_nav-active');
+      navCloseElement.focus();
+      return false;
+    });
+  });
+}
+
+module.exports = mobileInit;

--- a/src/js/components/header/search.js
+++ b/src/js/components/header/search.js
@@ -3,10 +3,7 @@ var addClass = require('../../utils/add-class');
 var removeClass = require('../../utils/remove-class');
 var dispatch = require('../../utils/dispatch');
 
-var searchForm = select('.js-search-form')[ 0 ];
-var searchButton = select('.js-search-button')[ 0 ];
-var searchButtonContainer = select('.js-search-button-container')[ 0 ];
-var searchDispatcher;
+var searchForm, searchButton, searchButtonContainer, searchDispatcher;
 
 if (searchButton && searchForm) {
   dispatch(searchButton, 'click touchstart', searchButtonClickHandler);
@@ -50,3 +47,15 @@ function searchFormContains (element) {
   return (searchForm && searchForm.contains(element)) ||
          (searchButtonContainer && searchButtonContainer.contains(element));
 }
+
+function searchInit () {
+  searchForm = select('.js-search-form')[ 0 ];
+  searchButton = select('.js-search-button')[ 0 ];
+  searchButtonContainer = select('.js-search-button-container')[ 0 ];
+
+  if (searchButton && searchForm) {
+    dispatch(searchButton, 'click touchstart', searchButtonClickHandler);
+  }
+}
+
+module.exports = searchInit;

--- a/src/js/components/header/search.js
+++ b/src/js/components/header/search.js
@@ -5,10 +5,6 @@ var dispatch = require('../../utils/dispatch');
 
 var searchForm, searchButton, searchButtonContainer, searchDispatcher;
 
-if (searchButton && searchForm) {
-  dispatch(searchButton, 'click touchstart', searchButtonClickHandler);
-}
-
 function searchButtonClickHandler (event) {
   if (isOpen(searchForm)) {
     closeSearch();

--- a/src/js/initializers/banner.js
+++ b/src/js/initializers/banner.js
@@ -1,9 +1,9 @@
 var whenDOMReady = require('../utils/when-dom-ready');
+var bannerInit = require('../components/banner');
 
-whenDOMReady(function initBanner () {
+whenDOMReady(function () {
 
-  // Banner
-  require('../components/banner');
+  bannerInit();
 
 });
 

--- a/src/js/initializers/header.js
+++ b/src/js/initializers/header.js
@@ -1,12 +1,14 @@
 var whenDOMReady = require('../utils/when-dom-ready');
+var searchInit = require('../components/header/search');
+var mobileInit = require('../components/header/mobile');
 
 whenDOMReady(function initHeaders () {
 
   // Search Toggle
-  require('../components/header/search');
+  searchInit();
 
   // Mobile Navigation
-  require('../components/header/mobile');
+  mobileInit();  
 
 });
 

--- a/src/js/initializers/header.js
+++ b/src/js/initializers/header.js
@@ -8,7 +8,7 @@ whenDOMReady(function initHeaders () {
   searchInit();
 
   // Mobile Navigation
-  mobileInit();  
+  mobileInit();
 
 });
 


### PR DESCRIPTION
This mainly wraps the banner & header (search & mobile) initialisation code in exported functions, but also does a little tidying up to ensure some DOM selections happen _after_ the DOM is ready.

@shawnbot: Can you review?

@maya: I'm not sure how to QA all of this. Could you give the three changed files (gov banner, search header, mobile header) a quick pass before you merge?