### PR TITLE
[Gov banner]: Add gov banner to headers and site

### DIFF
--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -1,15 +1,39 @@
 <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 <header class="usa-header site-header" role="banner">
-  <div class="usa-disclaimer">
-    <div class="usa-disclaimer-official">
-      <img src="{{ site.baseurl }}/assets/img/favicons/favicon-40.png" alt="U.S. flag">
-      <p>An official website of the United States government</p>
+  <!-- Gov banner BEGIN -->
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+        <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+        <p>An official website of the United States government</p>
+        <button class="usa-accordion-button usa-banner-button"
+          aria-expanded="false" aria-controls="gov-banner">
+          <span class="usa-banner-button-text">Here's how you know</span>
+        </button>
+        </div>
+      </header>
+      <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+        <div class="usa-banner-guidance-gov usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+          <div class="usa-media_block-text">
+            <p>
+              <strong>The .gov means it’s official.</strong>
+              <br>
+              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+            </p>
+          </div>
+        </div>
+        <div class="usa-banner-guidance-ssl usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+          <div class="usa-media_block-text">
+            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+          </div>
+        </div>
+      </div>
     </div>
-    <p class="usa-disclaimer-stage">
-      This site is currently in alpha.
-      <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a>
-    </p>
   </div>
+  <!-- Gov banner END -->
   <div class="usa-navbar site-header-navbar">
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo site-logo" id="logo">

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -4,7 +4,7 @@
   <div class="usa-banner">
     <div class="usa-accordion">
       <header class="usa-banner-header">
-        <div class="usa-grid usa-banner-inner site-banner-inner">
+        <div class="usa-grid usa-banner-inner">
         <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
         <p>An official website of the United States government</p>
         <button class="usa-accordion-button usa-banner-button"

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -4,7 +4,7 @@
   <div class="usa-banner">
     <div class="usa-accordion">
       <header class="usa-banner-header">
-        <div class="usa-grid usa-banner-inner">
+        <div class="usa-grid usa-banner-inner site-banner-inner">
         <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
         <p>An official website of the United States government</p>
         <button class="usa-accordion-button usa-banner-button"

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -26,7 +26,6 @@ $font-monospace:       Consolas, Monaco, 'Andale Mono', monospace;
     position: absolute;
   }
 
-  .usa-disclaimer-official,
   .site-logo {
     margin-left: $site-margins-mobile;
 
@@ -35,14 +34,13 @@ $font-monospace:       Consolas, Monaco, 'Andale Mono', monospace;
     }
   }
 
-  .usa-disclaimer-stage {
-    margin-right: $site-margins-mobile;
-
-    @include media($nav-width) {
-      margin-right: $site-margins;
-    }
+  .usa-banner-inner {
+    max-width: 100%;
   }
 
+  .usa-banner-content {
+    margin-left: 0;
+  }
 
   .usa-button-list {
     float: right;
@@ -70,10 +68,6 @@ $font-monospace:       Consolas, Monaco, 'Andale Mono', monospace;
       @include margin(0 null);
     }
   }
-}
-
-.site-banner-inner {
-  max-width: 100%;
 }
 
 .site-header-navbar {

--- a/docs/doc_assets/css/styleguide.scss
+++ b/docs/doc_assets/css/styleguide.scss
@@ -72,6 +72,10 @@ $font-monospace:       Consolas, Monaco, 'Andale Mono', monospace;
   }
 }
 
+.site-banner-inner {
+  max-width: 100%;
+}
+
 .site-header-navbar {
   border-bottom: none;
   @include media($nav-width) {

--- a/src/html/header-basic-mega.html
+++ b/src/html/header-basic-mega.html
@@ -1,6 +1,40 @@
 
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
   <header class="usa-header usa-header-basic-megamenu" role="banner">
+      <!-- Gov banner BEGIN -->
+    <div class="usa-banner">
+      <div class="usa-accordion">
+        <header class="usa-banner-header">
+          <div class="usa-grid usa-banner-inner">
+          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government</p>
+          <button class="usa-accordion-button usa-banner-button"
+            aria-expanded="false" aria-controls="gov-banner">
+            <span class="usa-banner-button-text">Here's how you know</span>
+          </button>
+          </div>
+        </header>
+        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+          <div class="usa-banner-guidance-gov usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+            <div class="usa-media_block-text">
+              <p>
+                <strong>The .gov means it’s official.</strong>
+                <br>
+                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner-guidance-ssl usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+            <div class="usa-media_block-text">
+              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Gov banner END -->
     <div class="usa-nav-container">
       <div class="usa-navbar">
         <button class="usa-menu-btn">Menu</button>

--- a/src/html/header-extended-mega.html
+++ b/src/html/header-extended-mega.html
@@ -1,6 +1,40 @@
 
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
   <header class="usa-header usa-header-extended" role="banner">
+    <!-- Gov banner BEGIN -->
+    <div class="usa-banner">
+      <div class="usa-accordion">
+        <header class="usa-banner-header">
+          <div class="usa-grid usa-banner-inner">
+          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government</p>
+          <button class="usa-accordion-button usa-banner-button"
+            aria-expanded="false" aria-controls="gov-banner">
+            <span class="usa-banner-button-text">Here's how you know</span>
+          </button>
+          </div>
+        </header>
+        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+          <div class="usa-banner-guidance-gov usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+            <div class="usa-media_block-text">
+              <p>
+                <strong>The .gov means it’s official.</strong>
+                <br>
+                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner-guidance-ssl usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+            <div class="usa-media_block-text">
+              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Gov banner END -->
     <div class="usa-navbar">
       <button class="usa-menu-btn">Menu</button>
       <div class="usa-logo" id="logo">

--- a/src/html/header-extended.html
+++ b/src/html/header-extended.html
@@ -1,6 +1,40 @@
 
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
   <header class="usa-header usa-header-extended" role="banner">
+    <!-- Gov banner BEGIN -->
+    <div class="usa-banner">
+      <div class="usa-accordion">
+        <header class="usa-banner-header">
+          <div class="usa-grid usa-banner-inner">
+          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government</p>
+          <button class="usa-accordion-button usa-banner-button"
+            aria-expanded="false" aria-controls="gov-banner">
+            <span class="usa-banner-button-text">Here's how you know</span>
+          </button>
+          </div>
+        </header>
+        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+          <div class="usa-banner-guidance-gov usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+            <div class="usa-media_block-text">
+              <p>
+                <strong>The .gov means it’s official.</strong>
+                <br>
+                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner-guidance-ssl usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+            <div class="usa-media_block-text">
+              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Gov banner END -->
     <div class="usa-navbar">
       <button class="usa-menu-btn">Menu</button>
       <div class="usa-logo" id="logo">

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -141,7 +141,9 @@
     @include padding(0 null null 0);
     display: inline;
     height: initial;
+    margin-left: 3px;
     position: relative;
+    vertical-align: middle;
     width: initial;
   }
 


### PR DESCRIPTION
## Description

Adds the gov banner to the headers and site.

TODO:

- [x] Design review
  - For the site itself everything on the page and navigation is left aligned, but what should we do about the grid when you open the banner? It centers it so it's not aligned with the page. Should we left align it too?

cc: @bradnunnally @donjo 

### Screenshot
<img width="1247" alt="screen shot 2016-09-07 at 9 48 17 am" src="https://cloud.githubusercontent.com/assets/5249443/18322221/7a903c16-74e6-11e6-98c8-956b28cd3f89.png">

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
