### PR TITLE
Adding `npm run watch` command to package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,23 @@ npm test
 This command runs the gulp task for `eslint` and our test suite for the `uswds` package. It is an alias for `gulp eslint test`.
 
 ```sh
+npm run build
+```
+
+This command builds the `uswds` package. It is an alias for `gulp build`.
+
+```sh
 npm run build:package
 ```
 
 This command builds the `uswds` package, which includes the zip files generated for release purposes. It is an alias for `gulp copy-vendor-sass && gulp release`.
+
+
+```sh
+npm run watch
+```
+
+This command watches for any changes that happen in the `src` directory and rebuilds the package if any changes are made.
 
 ## Coding guidelines
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "prepublish": "gulp copy-vendor-sass && gulp build",
     "prestart": "gulp copy-vendor-sass",
     "build:package": "gulp copy-vendor-sass && gulp release",
+    "build": "gulp build",
     "test": "gulp eslint test",
     "preversion": "npm test",
-    "version": "npm run prepublish"
+    "version": "npm run prepublish",
+    "watch": "watch 'npm run build' ./src"
   },
   "repository": {
     "type": "git",
@@ -66,6 +68,7 @@
     "should": "^8.3.1",
     "sinon": "^1.17.5",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "watch": "^0.17.1"
   }
 }


### PR DESCRIPTION
This pull request adds in a command for `npm run watch`. This is helpful for when folks are using things like `npm link` locally and re-builds the package when changes are made to it.

Folks will also need to run `npm install` once this change merges in.