### PR TITLE
[Grids]: De-nest grids

### DIFF
--- a/src/stylesheets/core/_grid.scss
+++ b/src/stylesheets/core/_grid.scss
@@ -1,9 +1,23 @@
+// Grid container
 .usa-grid,
 .usa-grid-full {
   @include outer-container();
   max-width: $site-max-width;
 }
 
+.usa-grid {
+  @include padding(null $site-margins-mobile);
+
+  @include media($medium-screen) {
+    @include padding(null $site-margins);
+  }
+}
+
+.usa-grid-full {
+  padding: 0;
+}
+
+// Grid items
 @include media($medium) {
   .usa-width-one-whole {
     @include span-columns(6);
@@ -121,17 +135,4 @@
 // Required if browser does not support :last-child
 .usa-end-row {
   @include omega();
-}
-
-
-.usa-grid {
-  @include padding(null $site-margins-mobile);
-
-  @include media($medium-screen) {
-    @include padding(null $site-margins);
-  }
-}
-
-.usa-grid-full {
-  padding: 0;
 }

--- a/src/stylesheets/core/_grid.scss
+++ b/src/stylesheets/core/_grid.scss
@@ -2,126 +2,127 @@
 .usa-grid-full {
   @include outer-container();
   max-width: $site-max-width;
+}
 
-  @include media($medium) {
-    .usa-width-one-whole {
-      @include span-columns(6);
-    }
+@include media($medium) {
+  .usa-width-one-whole {
+    @include span-columns(6);
+  }
 
-    .usa-width-one-half {
-      @include span-columns(3);
-    }
+  .usa-width-one-half {
+    @include span-columns(3);
+  }
 
-    .usa-width-one-third {
-      @include span-columns(2);
-    }
+  .usa-width-one-third {
+    @include span-columns(2);
+  }
 
-    .usa-width-two-thirds {
-      @include span-columns(4);
-    }
+  .usa-width-two-thirds {
+    @include span-columns(4);
+  }
 
-    .usa-width-one-fourth {
-      @include span-columns(3);
+  .usa-width-one-fourth {
+    @include span-columns(3);
 
-      &:nth-child(2n) {
-        margin-right: 0;
-      }
-    }
-
-    .usa-width-three-fourths {
-      @include span-columns(6);
-    }
-
-    .usa-width-one-sixth {
-      @include span-columns(2);
-
-      &:nth-child(3n) {
-        margin-right: 0;
-      }
-    }
-
-    .usa-width-five-sixths {
-      @include span-columns(4);
-    }
-
-    .usa-width-one-twelfth {
-      @include span-columns(2);
-
-      &:nth-child(3n) {
-        margin-right: 0;
-      }
+    &:nth-child(2n) {
+      margin-right: 0;
     }
   }
 
-  @include media($large) {
-    .usa-width-one-whole {
-      @include span-columns(12);
-    }
+  .usa-width-three-fourths {
+    @include span-columns(6);
+  }
 
-    .usa-width-one-half {
-      @include span-columns(6);
-    }
+  .usa-width-one-sixth {
+    @include span-columns(2);
 
-    .usa-width-one-third {
-      @include span-columns(4);
-    }
-
-    .usa-width-two-thirds {
-      @include span-columns(8);
-    }
-
-    .usa-width-one-fourth {
-      @include span-columns(3);
-
-      &:nth-child(2n) {
-        @include span-columns(3);
-      }
-
-      &:nth-child(4n) {
-        margin-right: 0;
-      }
-    }
-
-    .usa-width-three-fourths {
-      @include span-columns(9);
-    }
-
-    .usa-width-one-sixth {
-      @include span-columns(2);
-
-      &:nth-child(3n) {
-        @include span-columns(2);
-      }
-
-      &:nth-child(6n) {
-        margin-right: 0;
-      }
-    }
-
-    .usa-width-five-sixths {
-      @include span-columns(10);
-    }
-
-    .usa-width-one-twelfth {
-      @include span-columns(1);
-
-      &:nth-child(3n) {
-        @include span-columns(1);
-      }
-
-      &:nth-child(12n) {
-        margin-right: 0;
-      }
+    &:nth-child(3n) {
+      margin-right: 0;
     }
   }
 
-  // Specificies end of a row.
-  // Required if grid-box contains multiple rows.
-  // Required if browser does not support :last-child
-  .usa-end-row {
-    @include omega();
+  .usa-width-five-sixths {
+    @include span-columns(4);
+  }
+
+  .usa-width-one-twelfth {
+    @include span-columns(2);
+
+    &:nth-child(3n) {
+      margin-right: 0;
+    }
   }
 }
+
+@include media($large) {
+  .usa-width-one-whole {
+    @include span-columns(12);
+  }
+
+  .usa-width-one-half {
+    @include span-columns(6);
+  }
+
+  .usa-width-one-third {
+    @include span-columns(4);
+  }
+
+  .usa-width-two-thirds {
+    @include span-columns(8);
+  }
+
+  .usa-width-one-fourth {
+    @include span-columns(3);
+
+    &:nth-child(2n) {
+      @include span-columns(3);
+    }
+
+    &:nth-child(4n) {
+      margin-right: 0;
+    }
+  }
+
+  .usa-width-three-fourths {
+    @include span-columns(9);
+  }
+
+  .usa-width-one-sixth {
+    @include span-columns(2);
+
+    &:nth-child(3n) {
+      @include span-columns(2);
+    }
+
+    &:nth-child(6n) {
+      margin-right: 0;
+    }
+  }
+
+  .usa-width-five-sixths {
+    @include span-columns(10);
+  }
+
+  .usa-width-one-twelfth {
+    @include span-columns(1);
+
+    &:nth-child(3n) {
+      @include span-columns(1);
+    }
+
+    &:nth-child(12n) {
+      margin-right: 0;
+    }
+  }
+}
+
+// Specificies end of a row.
+// Required if grid-box contains multiple rows.
+// Required if browser does not support :last-child
+.usa-end-row {
+  @include omega();
+}
+
 
 .usa-grid {
   @include padding(null $site-margins-mobile);

--- a/src/stylesheets/core/_grid.scss
+++ b/src/stylesheets/core/_grid.scss
@@ -130,7 +130,7 @@
   }
 }
 
-// Specificies end of a row.
+// Specifies end of a row.
 // Required if grid-box contains multiple rows.
 // Required if browser does not support :last-child
 .usa-end-row {


### PR DESCRIPTION
## Description

As addressed in #971, the grid items do not need to be nested inside `usa-grid`. This de-nests it from that class. This is part of the refactor work in #1342.

Resolves #971.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.