### PR TITLE
[Grids]: Add missing 5/12 and 7/12 grid items 

### DIFF
--- a/src/stylesheets/core/_grid.scss
+++ b/src/stylesheets/core/_grid.scss
@@ -66,6 +66,14 @@
       margin-right: 0;
     }
   }
+
+  .usa-width-five-twelfths {
+    @include span-columns(2);
+  }
+
+  .usa-width-seven-twelfths {
+    @include span-columns(4);
+  }
 }
 
 @include media($large) {
@@ -117,6 +125,7 @@
     @include span-columns(10);
   }
 
+
   .usa-width-one-twelfth {
     @include span-columns(1);
 
@@ -127,6 +136,14 @@
     &:nth-child(12n) {
       margin-right: 0;
     }
+  }
+
+  .usa-width-five-twelfths {
+    @include span-columns(5);
+  }
+
+  .usa-width-seven-twelfths {
+    @include span-columns(7);
   }
 }
 


### PR DESCRIPTION
## Description

As pointed out in #1383, we are missing grid items for 5/12 and 7/12. This PR adds it in. This builds off of #1487, so lets merge that in first. This is part of the refactor work in #1342.

Resolves: #1383.

I did not add it in to the examples but showing it here for demonstration purposes.

### This is what it looks like at full screen:

<img width="1019" alt="screen shot 2016-09-16 at 1 34 33 pm" src="https://cloud.githubusercontent.com/assets/5249443/18600505/d6236e9e-7c12-11e6-91b3-2f3c52207a46.png">

### This is what it looks like at medium screen:

<img width="692" alt="screen shot 2016-09-16 at 1 34 50 pm" src="https://cloud.githubusercontent.com/assets/5249443/18600508/d9c08802-7c12-11e6-8fbf-06b1ebd1b775.png">

**Note**: I change it to 1/3 and 2/3 at medium. We could also change it to 1/2 and 1/2 or leave it as is 5/12 and 7/12. 

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
