### PR TITLE
[WIP] [Checkbox/radio buttons]: Update hit area so it's not too long

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -138,19 +138,20 @@ legend {
   margin-left: -2rem;
   opacity: 0;
   position: absolute;
+  width: auto;
 
   .lt-ie9 & {
     border: 0;
     float: left;
     margin: 0.4em 0.4em 0 0;
     position: static;
-    width: auto;
   }
 }
 
 [type="checkbox"] + label,
 [type="radio"] + label {
   cursor: pointer;
+  display: inline-block;
   font-weight: 400;
   margin-bottom: 0.5em;
 }


### PR DESCRIPTION
### ⚠️🚧 work in progress 🚧 ⚠️
## Description

Since the checkbox and label are actually just the label, the input shouldn't need a width. The `width: 100%` is causing it to overshoot.

Resolves: #1490

**TODO**:
- [ ] Test in all browsers.

Before you hit Submit, make sure you’ve done whichever of these applies to you:
- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
