### PR TITLE
[Media block]: Update media block to make it more abstract and usable

### DIFF
--- a/src/html/header-basic-mega.html
+++ b/src/html/header-basic-mega.html
@@ -17,7 +17,7 @@
         <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
           <div class="usa-banner-guidance-gov usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>
                 <strong>The .gov means it’s official.</strong>
                 <br>
@@ -27,7 +27,7 @@
           </div>
           <div class="usa-banner-guidance-ssl usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
             </div>
           </div>

--- a/src/html/header-basic.html
+++ b/src/html/header-basic.html
@@ -17,7 +17,7 @@
         <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
           <div class="usa-banner-guidance-gov usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>
                 <strong>The .gov means it’s official.</strong>
                 <br>
@@ -27,7 +27,7 @@
           </div>
           <div class="usa-banner-guidance-ssl usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
             </div>
           </div>

--- a/src/html/header-extended-mega.html
+++ b/src/html/header-extended-mega.html
@@ -17,7 +17,7 @@
         <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
           <div class="usa-banner-guidance-gov usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>
                 <strong>The .gov means it’s official.</strong>
                 <br>
@@ -27,7 +27,7 @@
           </div>
           <div class="usa-banner-guidance-ssl usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
             </div>
           </div>

--- a/src/html/header-extended.html
+++ b/src/html/header-extended.html
@@ -17,7 +17,7 @@
         <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
           <div class="usa-banner-guidance-gov usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>
                 <strong>The .gov means it’s official.</strong>
                 <br>
@@ -27,7 +27,7 @@
           </div>
           <div class="usa-banner-guidance-ssl usa-width-one-half">
             <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-text">
+            <div class="usa-media_block-body">
               <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
             </div>
           </div>

--- a/src/stylesheets/components/_media-block.scss
+++ b/src/stylesheets/components/_media-block.scss
@@ -1,13 +1,12 @@
-.usa-media_block-img {
+@mixin media-block-img($margin-right: 1rem) {
   float: left;
-  margin-right: 1rem;
+  margin-right: $margin-right;
 }
 
-.usa-media_block-heading {
-  clear: none;
-  margin-top: 0;
+.usa-media_block-img {
+  @include media-block-img;
 }
 
-.usa-media_block-text {
+.usa-media_block-body {
   overflow: hidden;
 }


### PR DESCRIPTION
## Description

Updates the markup + CSS of media blocks to make them more abstract. There's also a mixin to control the margins of the image.

Mostly changing `usa-media_block-text` to `usa-media_block-body` bc that content does not always have to be text, it can be images or other elements.

The change is happening in the `add-templates` branch and would like to get this is prior to the next release to avoid regressions.

Noting that we're using 1rem as the default margin right now, which works for small images like the banner images, but this won't work as well for large images. People can customize this on a needed basis, cc @donjo. 

Will open a corresponding PR to the docs repo to update the navbar.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.

