### PR TITLE
Fixing mobile.js from having duplicative events from firing

### DIFF
--- a/src/js/components/header/mobile.js
+++ b/src/js/components/header/mobile.js
@@ -3,6 +3,8 @@ var addClass = require('../../utils/add-class');
 var removeClass = require('../../utils/remove-class');
 var dispatch = require('../../utils/dispatch');
 
+var clickHandler = ('ontouchstart' in document.documentElement ? 'touchstart' : 'click');
+
 function toggleClass (element, className) {
   if (element.classList) {
     element.classList.toggle(className);
@@ -25,7 +27,6 @@ function handleNavElements (e) {
 
 function mobileInit () {
   var navElements = select('.usa-menu-btn, .usa-overlay, .usa-nav-close');
-  var clickHandler = ('ontouchstart' in document.documentElement ? 'touchstart' : 'click');
 
   navElements.forEach(function (element) {
     dispatch(element, clickHandler, handleNavElements);

--- a/src/js/components/header/mobile.js
+++ b/src/js/components/header/mobile.js
@@ -9,20 +9,26 @@ function toggleClass (element, className) {
   }
 }
 
-function mobileInit () {
-  var navElements = select('.usa-menu-btn, .usa-overlay, .usa-nav-close');
+function handleNavElements (e) {
+
   var toggleElements = select('.usa-overlay, .usa-nav');
   var navCloseElement = select('.usa-nav-close')[ 0 ];
 
+  toggleElements.forEach(function (element) {
+    toggleClass(element, 'is-visible');
+  });
+  toggleClass(document.body, 'usa-mobile_nav-active');
+  navCloseElement.focus();
+  shouldTrigger = false;
+  return false;
+}
+
+function mobileInit () {
+  var navElements = select('.usa-menu-btn, .usa-overlay, .usa-nav-close');
+  var clickHandler = ('ontouchstart' in document.documentElement ? 'touchstart' : 'click');
+
   navElements.forEach(function (element) {
-    dispatch(element, 'click touchstart', function (e) {
-      toggleElements.forEach(function (element) {
-        toggleClass(element, 'is-visible');
-      });
-      toggleClass(document.body, 'usa-mobile_nav-active');
-      navCloseElement.focus();
-      return false;
-    });
+    dispatch(element, clickHandler, handleNavElements);
   });
 }
 


### PR DESCRIPTION
This pull request fixes the issue around the mobile sidenav touch events not *actually* closing the sidenav. The error occurred due to the fact that both the `click` and `touchstart` would fire at the same time, this never actually closing the the mobile "touch" version of the sidenav.

Fixes #1496 