### PR TITLE
Set default value for `$asset-pipeline`

### DIFF
--- a/src/stylesheets/core/_defaults.scss
+++ b/src/stylesheets/core/_defaults.scss
@@ -23,6 +23,7 @@ $lead-line-height:    1.7 !default;
 $font-sans:           'Source Sans Pro', $helvetica !default;
 $font-serif:          'Merriweather', $georgia !default;
 $font-path:           '../fonts' !default;
+$asset-pipeline:      false !default;
 
 $font-normal:         400 !default;
 $font-bold:           700 !default;

--- a/src/stylesheets/core/_fonts.scss
+++ b/src/stylesheets/core/_fonts.scss
@@ -3,7 +3,7 @@
   '#{$font-path}/sourcesanspro-light-webfont',
   300,
   normal,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -12,7 +12,7 @@
   '#{$font-path}/sourcesanspro-regular-webfont',
   400,
   normal,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -21,7 +21,7 @@
   '#{$font-path}/sourcesanspro-italic-webfont',
   400,
   italic,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -30,7 +30,7 @@
   '#{$font-path}/sourcesanspro-bold-webfont',
   700,
   normal,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -39,7 +39,7 @@
   '#{$font-path}/merriweather-light-webfont',
   300,
   normal,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -48,7 +48,7 @@
   '#{$font-path}/merriweather-regular-webfont',
   400,
   normal,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -57,7 +57,7 @@
   '#{$font-path}/merriweather-italic-webfont',
   400,
   italic,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -66,6 +66,6 @@
   '#{$font-path}/merriweather-bold-webfont',
   700,
   normal,
-  $asset-pipeline: false,
+  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );

--- a/src/stylesheets/core/_fonts.scss
+++ b/src/stylesheets/core/_fonts.scss
@@ -3,7 +3,6 @@
   '#{$font-path}/sourcesanspro-light-webfont',
   300,
   normal,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -12,7 +11,6 @@
   '#{$font-path}/sourcesanspro-regular-webfont',
   400,
   normal,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -21,7 +19,6 @@
   '#{$font-path}/sourcesanspro-italic-webfont',
   400,
   italic,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -30,7 +27,6 @@
   '#{$font-path}/sourcesanspro-bold-webfont',
   700,
   normal,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -39,7 +35,6 @@
   '#{$font-path}/merriweather-light-webfont',
   300,
   normal,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -48,7 +43,6 @@
   '#{$font-path}/merriweather-regular-webfont',
   400,
   normal,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -57,7 +51,6 @@
   '#{$font-path}/merriweather-italic-webfont',
   400,
   italic,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );
 
@@ -66,6 +59,5 @@
   '#{$font-path}/merriweather-bold-webfont',
   700,
   normal,
-  $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf
 );


### PR DESCRIPTION
* If you look at http://bourbon.io/docs/#font-face, the `asset-pipeline`
  argument sent to the bourbon `font-face` mixin is what is used
* This update enables Rails apps to override `$asset-pipeline` and use
  font mixin provided by the design standards
* See https://github.com/18F/uswds-rails-gem/issues/14