### PR TITLE
[Website] - [UI component]:Forms required placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/
 # Ignore gulp-generated vendor files
 #
 src/stylesheets/lib
+
+scss-lint.yml

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prismjs": "^1.5.1"
   },
   "devDependencies": {
-    "@18f/stylelint-rules": "^1.0.1",
+    "@18f/stylelint-rules": "^1.2.0",
     "browserify": "^13.0.0",
     "del": "^2.2.0",
     "gulp": "^3.9.0",

--- a/src/html/address-form.html
+++ b/src/html/address-form.html
@@ -5,7 +5,7 @@
       <label for="mailing-address-1">Street address 1</label>
       <input id="mailing-address-1" name="mailing-address-1" type="text">
 
-      <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">Optional</span></label>
+      <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">(Optional)</span></label>
       <input id="mailing-address-2" name="mailing-address-2" type="text">
 
       <div>
@@ -77,4 +77,3 @@
       <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-" data-politespace>
     </fieldset>
   </form>
-

--- a/src/html/name-form.html
+++ b/src/html/name-form.html
@@ -5,17 +5,16 @@
       <label for="title">Title</label>
       <input class="usa-input-tiny" id="title" name="title" type="text">
 
-      <label for="first-name">First name <span class="usa-additional_text">Required</span></label>
+      <label for="first-name">First name <span class="usa-input-required">(Required)</span></label>
       <input id="first-name" name="first-name" type="text" required="" aria-required="true">
 
       <label for="middle-name">Middle name</label>
       <input id="middle-name" name="middle-name" type="text">
 
-      <label for="last-name">Last name <span class="usa-additional_text">Required</span></label>
+      <label for="last-name">Last name <span class="usa-input-required">(Required)</span></label>
       <input id="last-name" name="last-name" type="text" required="" aria-required="true">
 
       <label for="suffix">Suffix</label>
       <input class="usa-input-tiny" id="suffix" name="suffix" type="text">
     </fieldset>
   </form>
-

--- a/src/html/name-form.html
+++ b/src/html/name-form.html
@@ -5,13 +5,13 @@
       <label for="title">Title</label>
       <input class="usa-input-tiny" id="title" name="title" type="text">
 
-      <label for="first-name">First name <span class="usa-input-required">(*Required)</span></label>
+      <label for="first-name" class="usa-input-required">First name</label>
       <input id="first-name" name="first-name" type="text" required="" aria-required="true">
 
       <label for="middle-name">Middle name</label>
       <input id="middle-name" name="middle-name" type="text">
 
-      <label for="last-name">Last name <span class="usa-input-required">(*Required)</span></label>
+      <label for="last-name" class="usa-input-required">Last name</label>
       <input id="last-name" name="last-name" type="text" required="" aria-required="true">
 
       <label for="suffix">Suffix</label>

--- a/src/html/name-form.html
+++ b/src/html/name-form.html
@@ -5,13 +5,13 @@
       <label for="title">Title</label>
       <input class="usa-input-tiny" id="title" name="title" type="text">
 
-      <label for="first-name">First name <span class="usa-input-required">(Required)</span></label>
+      <label for="first-name">First name <span class="usa-input-required">(*Required)</span></label>
       <input id="first-name" name="first-name" type="text" required="" aria-required="true">
 
       <label for="middle-name">Middle name</label>
       <input id="middle-name" name="middle-name" type="text">
 
-      <label for="last-name">Last name <span class="usa-input-required">(Required)</span></label>
+      <label for="last-name">Last name <span class="usa-input-required">(*Required)</span></label>
       <input id="last-name" name="last-name" type="text" required="" aria-required="true">
 
       <label for="suffix">Suffix</label>

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -125,7 +125,6 @@ input {
 }
 
 .usa-additional_text {
-  font-style: italic;
   font-weight: normal;
 }
 

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -125,7 +125,6 @@ input {
 }
 
 .usa-additional_text {
-  float: right;
   font-style: italic;
   font-weight: normal;
 }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -90,6 +90,11 @@ select {
   padding-top: 3px;
 }
 
+.usa-input-required {
+  @extend .usa-additional_text;
+  color: $color-secondary-dark;
+}
+
 label {
   display: block;
   margin-top: 3rem;

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -90,9 +90,9 @@ select {
   padding-top: 3px;
 }
 
-.usa-input-required {
-  @extend .usa-additional_text;
-  color: $color-secondary-dark;
+.usa-input-required:after {
+  color: $color-secondary-darkest;
+  content: ' (*Required)';
 }
 
 label {


### PR DESCRIPTION
## Forms required placement
## Description

In response to [issue 1350](https://github.com/18F/web-design-standards/issues/1350), moved required text from right to left, added asterisk, parenthesis and color to text, and removed italics.   
## Additional information
- Followed the proposed solution from the issue. 
- Added asterisk to help improve the usability for screen readers. Most screen readers users hear the word 'star' in association with ta form input they automatically assume that ta response is required. [usablility.com/au](http://usability.com.au/2013/05/accessible-forms-2-required-fields-and-extra-information/)
- Removed the italics because of legibility for people with dyslexia. When italic fonts are used on a web page, the individual letters can have a slightly jagged line compared to a non-italic font. This “pixelation,” coupled with their “lean to the left” makes them hard for a dyslexic person to read. The effect is compounded if the text is also small. [http://accessites.org](http://accessites.org/site/2006/11/designing-for-dyslexics-part-3-of-3) 
