### PR TITLE
Reorganize build tasks

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -10,7 +10,7 @@ var filter = require('gulp-filter');
 var replace = require('gulp-replace');
 var runSequence = require('run-sequence');
 var del = require('del');
-var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task = 'sass';
 
 var entryFileFilter = filter('all.scss', { restore: true });
 var normalizeCssFilter = filter('normalize.css', { restore: true });
@@ -53,7 +53,10 @@ gulp.task('copy-vendor-sass', function (done) {
  * XXX the 'stylelint' prerequisite is commented out here because
  * there are currently a TON of linting errors in our SCSS files.
  */
-gulp.task(task, [ /* 'stylelint' */ ], function (done) {
+gulp.task(task, [
+  // 'stylelint',
+  'copy-vendor-sass',
+], function (done) {
 
   dutil.logMessage(task, 'Compiling Sass');
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "src/js/start.js",
   "scripts": {
-    "prepublish": "gulp copy-vendor-sass && gulp build",
-    "prestart": "gulp copy-vendor-sass",
-    "build:package": "gulp copy-vendor-sass && gulp release",
+    "prepublish": "gulp build",
+    "postinstall": "gulp build",
+    "build:package": "gulp release",
     "build": "gulp build",
     "test": "gulp eslint test",
     "preversion": "npm test",


### PR DESCRIPTION
This removes references to the `copy-vendor-sass` gulp task from `package.json` and moves it into the dependency list for `gulp build` so that it _always_ gets run before all of the other build tasks. The problem before this change was that `copy-vendor-sass` wasn't running as part of the install process, so when I referenced this branch from the `package.json` in 18F/web-design-standards-docs#54, the module would install and build without the vendor files.

The only thing that's a bit weird here is that when the module is installed (via `npm install`) it runs `npm build` twice: once in the `postinstall` script, and another in the `prepublish` script. I don't know why the latter runs during `install`, but my hope is that we could ditch the `prepublish` script.

cc @rogeruiz 