### PR TITLE
Fix accordion content flash on page load

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -110,7 +110,6 @@ $accordion-border: 3px solid $color-gray-lightest;
 
 .usa-accordion-content {
   background-color: $color-white;
-  display: block;
   overflow: auto;
   padding: 3rem;
 
@@ -120,6 +119,10 @@ $accordion-border: 3px solid $color-gray-lightest;
 
   > *:last-child {
     margin-bottom: 0;
+  }
+
+  &:not([aria-hidden]) {
+    @include sr-only();
   }
 
   @include accessibly-hidden();


### PR DESCRIPTION
As outlined in #1465, the accordion content "flashes" on initial page load. This is due to the fact that `aria-hidden` attribute is added to the accordion content via JavaScript and on [`whenDOMReady`](https://github.com/18F/web-design-standards/blob/staging/src/js/utils/when-dom-ready.js) and determines it's display value. To avoid this flickering from happening, I have removed the default `display:block;` value and set an explicit value for when there is no JS, this the attributes not being added.

On another note, @nickbristow reviewed and pointed out that `aria-hidden` should not have an explicit display value associated with it (see https://github.com/18F/web-design-standards/issues/1120). Going to open a separate issue so we can re-think how we handle the display properties outside of ARIA attributes.