### PR TITLE
Tidy gulp

### DIFF
--- a/config/gulp/doc-util.js
+++ b/config/gulp/doc-util.js
@@ -1,5 +1,6 @@
 var pkg = require('../../package.json');
 var gutil = require('gulp-util');
+var chalk = gutil.colors;
 var notifier = require('node-notifier');
 
 var shellPrefix = '$';
@@ -9,50 +10,50 @@ function drawFlag () {
   // American Flag in ASCII
   //
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
 
 }
@@ -82,12 +83,12 @@ module.exports = {
     message = message || 'Draft U.S. Web Design Standards';
 
     gutil.log(
-      gutil.colors.yellow('v' + pkg.version),
+      chalk.yellow('v' + pkg.version),
       message
     );
     drawFlag();
     //gutil.log(
-      //gutil.colors.yellow('v' + pkg.version),
+      //chalk.yellow('v' + pkg.version),
       //'The following gulp commands are available'
     //);
 
@@ -97,8 +98,8 @@ module.exports = {
 
     gutil.log(
       shellPrefix,
-      gutil.colors.cyan(name),
-      gutil.colors.magenta(message)
+      chalk.cyan(name),
+      chalk.magenta(message)
     );
 
   },
@@ -107,8 +108,8 @@ module.exports = {
 
     gutil.log(
       shellPrefix,
-      gutil.colors.cyan(name),
-      gutil.colors.yellow(message)
+      chalk.cyan(name),
+      chalk.yellow(message)
     );
 
   },
@@ -116,8 +117,8 @@ module.exports = {
   logData: function (name, message) {
 
     gutil.log(
-      gutil.colors.cyan(name),
-      gutil.colors.yellow(message)
+      chalk.cyan(name),
+      chalk.yellow(message)
     );
 
   },
@@ -125,8 +126,8 @@ module.exports = {
   logError: function (name, message) {
 
     gutil.log(
-      gutil.colors.red(name),
-      gutil.colors.yellow(message)
+      chalk.red(name),
+      chalk.yellow(message)
     );
     notify(this.dirName + ' gulp ' + name, message, true);
 
@@ -135,8 +136,8 @@ module.exports = {
   logMessage: function (name, message) {
 
     gutil.log(
-      gutil.colors.cyan(name),
-      gutil.colors.green(message)
+      chalk.cyan(name),
+      chalk.green(message)
     );
     notify(this.dirName + ' gulp ' + name, message, false);
 

--- a/config/gulp/fonts.js
+++ b/config/gulp/fonts.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 var dutil = require('./doc-util');
-var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task = 'fonts';
 
 gulp.task(task, function (done) {
 

--- a/config/gulp/images.js
+++ b/config/gulp/images.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 var dutil = require('./doc-util');
-var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task = 'images';
 
 gulp.task(task, function (done) {
 

--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -9,7 +9,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var merge = require('merge-stream');
 var rename = require('gulp-rename');
 var linter = require('gulp-eslint');
-var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task = 'javascript';
 
 gulp.task('eslint', function (done) {
 

--- a/config/gulp/release.js
+++ b/config/gulp/release.js
@@ -1,10 +1,9 @@
 var gulp = require('gulp');
 var dutil = require('./doc-util');
-var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
 var spawn = require('cross-spawn');
 var runSequence = require('run-sequence');
 var del = require('del');
-
+var task = 'release';
 
 gulp.task('make-tmp-directory', function (done) {
 

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -10,7 +10,7 @@ var filter = require('gulp-filter');
 var replace = require('gulp-replace');
 var runSequence = require('run-sequence');
 var del = require('del');
-var task = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task = 'sass';
 
 var entryFileFilter = filter('all.scss', { restore: true });
 var normalizeCssFilter = filter('normalize.css', { restore: true });


### PR DESCRIPTION
- Don't infer the task name from `__filename` in fonts, images, and javascript gulp configs.
- Reference `gutil.colors` as [chalk](https://www.npmjs.com/package/chalk) in doc-utils so it's clearer which terminal color API we're using.