### PR TITLE
[WIP] [Website] - [UI Component]: Refactor accordion component

### DIFF
--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -24,7 +24,9 @@ gulp.task('eslint', function (done) {
 
 });
 
-gulp.task(task, [ 'eslint' ], function (done) {
+gulp.task(task, [
+  'eslint'
+], function (done) {
 
   dutil.logMessage(task, 'Compiling JavaScript');
 

--- a/spec/unit/accordion/accordion.spec.js
+++ b/spec/unit/accordion/accordion.spec.js
@@ -7,7 +7,7 @@ var Accordion = require('../../../src/js/components/accordion.js');
 // `aria` prefixed attributes
 var EXPANDED = 'aria-expanded';
 var CONTROLS = 'aria-controls';
-var HIDDEN   = 'aria-hidden';
+var HIDDEN   = 'hidden';
 
 describe('Accordion component', function () {
   var $el;
@@ -20,7 +20,7 @@ describe('Accordion component', function () {
 
     $('body').append($component);
 
-    accordion = new Accordion($component.get()[0]);
+    accordion = new Accordion($component.get(0));
 
     $el = $(accordion.root);
     $button = $el.find('button');
@@ -45,7 +45,7 @@ describe('Accordion component', function () {
       $button.attr(CONTROLS).should.not.be.undefined();
     });
 
-    describe('when show is triggered', function () {
+    describe('when show() is called', function () {
       beforeEach(function () {
         accordion.show(button);
       });
@@ -58,12 +58,12 @@ describe('Accordion component', function () {
         $button.attr(EXPANDED).should.equal('true');
       });
 
-      it('toggles "aria-hidden" to false', function () {
-        $content.attr(HIDDEN).should.equal('false');
+      it('toggles "hidden" to false', function () {
+        $content.prop(HIDDEN).should.equal(false);
       });
     });
 
-    describe('when hide is triggered', function () {
+    describe('when hide() is called', function () {
       beforeEach(function() {
         accordion.show(button);
         accordion.hide(button);
@@ -73,10 +73,33 @@ describe('Accordion component', function () {
         $button.attr(EXPANDED).should.equal('false');
       });
 
-      it('toggles "aria-hidden" to true', function () {
-        $content.attr(HIDDEN).should.equal('true');
+      it('toggles "hidden" to true', function () {
+        $content.prop(HIDDEN).should.equal(true);
       });
     });
+
+    describe('when toggle() is called', function () {
+      beforeEach(function() {
+        accordion.show(button);
+      });
+
+      it('toggles "aria-expanded" to false', function () {
+        accordion.toggle(button);
+        $button.attr(EXPANDED).should.equal('false');
+      });
+
+      it('toggles "aria-expanded" back to true', function () {
+        accordion.toggle(button);
+        accordion.toggle(button);
+        $button.attr(EXPANDED).should.equal('true');
+      });
+
+      it('toggles "aria-expanded" to false explicitly', function () {
+        accordion.toggle(button, false);
+        $button.attr(EXPANDED).should.equal('false');
+      });
+    });
+
   });
 });
 


### PR DESCRIPTION
## 🚧 ⚠️  Work in progress ⚠️ 🚧
## Description

This PR refactors the accordion component in the following ways:
1. Accordions now set the [`hidden` attribute/property](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute) instead of `aria-hidden`, which is a more appropriate way to hide content for all UAs, rather than just screen readers (and which, in [browsers that support it](http://caniuse.com/#feat=hidden), does not require any additional CSS).
   
   ⚠️  **This is a breaking change, as users may be relying on `aria-hidden`.** We should decide whether to support `aria-hidden` (and swap it out for `hidden` if it's used). cc #1513
2. Accordion instances now have a `toggle(button [, expanded])` method, which behaves similarly to [Element.classList.toggle](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) in that if the second argument is not a boolean the toggled state of the `button` is inverted from its current state. This is called by `show()`, `hide()`, the `click` event listener.
3. The accordion now supports multiple space-separated IDs in the `aria-controls` attribute, as [specified in WAI-ARIA](http://w3c.github.io/aria/aria/aria.html#aria-controls).
   
   Because we're using `document.getElementById(id)` now instead of using `select('#' + id)`, we also support IDs that would produce invalid or incorrect selectors (e.g. `foo.bar` is valid in HTML5, but would produce the selector `#foo.bar`).
4. The accordion now supports expanding multiple panels.
   
   ⚠️  **This is a breaking change, as users may be relying on the exclusivity of panel visibility.** We should look at how the accordion is being used and consider whether to make the previous behavior the default and opt in to multi-selectable panels with `aria-multiselectable="true"`, which is what [the WAI-ARIA accordion "widget" definition](http://w3c.github.io/aria/practices/aria-practices.html#accordion) dictates:
   
   > The accordion component must have a role of `tablist` and have `aria-multiselectable="true"`. This will enable an assistive technology, such as screen reader, to convey that the tablist is an accordion or a multi selectable tablist. This will also tell the user that the keyboard navigation matches an accordion and not a tablist.
   
   ...or to change the default behavior and require users who want only one panel to be open at once to opt in with `aria-multiselectable="false"`.
5. The accordion's "internal" `select()` and `selectAll()` methods now more closely mimic their `querySelector()` and `querySelectorAll()` equivalents: the former returns a single element, and the latter returns an Array.
## Additional information

Before you hit Submit, make sure you’ve done whichever of these applies to you:
- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
