### PR TITLE
Update README to better accommodate Windows implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,14 @@ The purpose of our coding styleguides are to create consistent coding practices 
 
 This project follows the 18F Front End Guide [CSS](https://pages.18f.gov/frontend/#css) and [JavaScript](https://pages.18f.gov/frontend/#javascript). Please use this guide for your reference.
 
+## Our use of branches
+
+The `staging` branch is the bleeding edge of development. When cutting a new [release](https://github.com/18F/web-design-standards/releases), we update the versioning on our files by branching off of the `staging` branch and submitting a pull request into our `release` branch. This helps to make `staging` a place that can always receive contributions, no matter where we are in the release process. New commits to `staging` are automatically deployed to [our staging site](https://standards-staging.usa.gov/).
+
+The `master` branch always holds the latest production-ready release. When cutting a [release](https://github.com/18F/web-design-standards/releases), we create a release branch from `staging` named for the new version: for example, `v0.9.x`. Once we’ve completed QA on that branch, we tag the release and merge it into the `master` branch.
+
+The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release and development branches, back when the site was hosted on `pages.18f.gov`. Those branches still auto deploy to 18F Pages, but will now only contain minimal redirects to the new site.
+
 ## Licenses and attribution
 
 ### A few parts of this project are not in the public domain

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Previously, the website and documentation for the Draft U.S. Web Design Standard
 * [Use the Standards](#using-the-standards)
   * [Download](#download)
   * [Install using npm](#install-using-npm)
+    * [Importing and copying assets](#importing-and-copying-assets)
+    * [Sass](#sass)
+    * [JavaScript](#javascript)
   * [Use another framework or package manager](#use-another-framework-or-package-manager)
 * [Our use of branches](#our-use-of-branches)
 * [Need installation help?](#need-installation-help)
@@ -124,7 +127,7 @@ $ npm -v
 3.10.8 # This line may vary depending on what version of Node you've installed.
 ```
 
-*INSTALLING NODE/NPM ON WINDOWS:* Team Treehouse has a tutorial on how to install Node.js/npm on your Windows machine: [http://blog.teamtreehouse.com/install-node-js-npm-windows](http://blog.teamtreehouse.com/install-node-js-npm-windows)
+**Windows installation:** Team Treehouse has a tutorial on how to install Node.js/npm on your Windows machine: [http://blog.teamtreehouse.com/install-node-js-npm-windows](http://blog.teamtreehouse.com/install-node-js-npm-windows)
 
 Your next step will to be to create a `package.json` file. You can do this manually, but an easier method is to use the `npm init` command. This command will prompt you with a few questions to create your `package.json` file. 
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To use this method, you will need to have Node/npm installed on your local devel
 Now let's check to make sure you have installed it correctly:
 
 ```shell
-$ npm -v
+npm -v
 3.10.8 # This line may vary depending on what version of Node you've installed.
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Previously, the website and documentation for the Draft U.S. Web Design Standard
 * [Background](#background)
 * [Recent updates](#recent-updates)
 * [Getting started](#getting-started)
-* [Use the Standards](#using-the-standards)
+* [Using the Standards](#using-the-standards)
   * [Download](#download)
-  * [Install using npm](#install-using-npm)
-    * [Importing and copying assets](#importing-and-copying-assets)
+  * [Install using `npm`](#install-using-npm)
+    * [Importing assets](#importing-assets)
     * [Sass](#sass)
     * [JavaScript](#javascript)
   * [Use another framework or package manager](#use-another-framework-or-package-manager)
@@ -45,17 +45,20 @@ We’re glad you’d like to use the Standards — here’s how you can get star
 
 ## Using the Standards
 
-There are a few different ways to use the Standards within your project. Which one you choose depends on the needs of your project and how you are most comfortable working.
+There are a few different ways to use the Standards within your project. Which one you choose depends on the needs of your project and how you are most comfortable working. Here are a few notes on what to consider when deciding which installation method to use:
+
+*Download the Standards if:*
+- You are not familiar with `npm` and package management.
+
+*Use the Standards `npm` package if:*
+- You are familiar with using `npm` and package management.
+- You would like to leverage Standards [Sass](#sass) files.
 
 ### Download
 
-To use the Draft Web Design Standards on your project, you’ll need to include the [CSS (*C*ascading *S*tyle *S*heets)](https://developer.mozilla.org/en-US/docs/Web/CSS) and JavaScript files in each HTML page or dynamic templates in your project.
+1. Download the [Standards zip file](https://github.com/18F/web-design-standards/releases/download/v0.13.1/uswds-0.13.1.zip) and open that file.
 
-First, download the Draft U.S. Web Design Standards assets using the link below:
-
-[https://github.com/18F/web-design-standards/releases/download/v0.13.1/uswds-0.13.1.zip](https://github.com/18F/web-design-standards/releases/download/v0.13.1/uswds-0.13.1.zip)
-
-You should now have a folder downloaded with the following file and folder structure:
+After extracting the zip file you should see the following file and folder structure:
 
 ```
 
@@ -72,7 +75,7 @@ uswds-0.13.1/
 └── fonts/
 ```
 
-Now you will want to copy these files and folders into a relevant place in your projects code base. Here is an example structure for how this might look:
+2. Copy these files and folders into a relevant place in your project's code base. Here is an example structure for how this might look:
 
 ```
 
@@ -85,11 +88,14 @@ example-project/
 └── index.html
 ```
 
-You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any of these types of assets that are unique to your project. 
+You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any assets that are unique to your project. 
 
-Next, you will want to import these assets into your HTML. Below is an example of the code for our example projects `index.html` file:
+3. To use the Standards on your project, you’ll need to reference the [CSS (*C*ascading *S*tyle *S*heets)](https://developer.mozilla.org/en-US/docs/Web/CSS) and JavaScript files in each HTML page or dynamic templates in your project.
+
+Here is an example of how to reference these assets in your `index.html` file:
 
 ```html
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -105,8 +111,7 @@ Next, you will want to import these assets into your HTML. Below is an example o
 </html>
 ```
 
-We offer both files, the CSS and the JavaScript, in two versions — a minified
-version, and an un-minified one. (In the examples above, we are using the minified files.) Use the minified files in a production environment or to reduce the file size of your downloaded assets. And the un-minified files are better if you are in a development environment or would like to debug the CSS or JavaScript assets in the browser.
+We offer both files, the CSS and the JavaScript, in two versions — a minified version, and an un-minified one. (In the examples above, we are using the minified files.) Use the minified files in a production environment or to reduce the file size of your downloaded assets. And the un-minified files are better if you are in a development environment or would like to debug the CSS or JavaScript assets in the browser.
 
 **NOTE:** This version of the Standards includes jQuery version `2.2.0` bundled within the JavaScript file. Please make sure that you’re not including any other version of jQuery on your page.
 
@@ -114,31 +119,30 @@ And that’s it — you should now be able to copy our code samples into our `in
 
 ### Install using npm
 
-`npm` is a package manager for Node.js based projects. The Draft U.S. Web Design Standards maintains a [`uswds` package](https://www.npmjs.com/package/uswds) for you to utilize both the pre-compiled and compiled files on your project.
+`npm` is a package manager for Node based projects. The Draft U.S. Web Design Standards maintains a [`uswds` package](https://www.npmjs.com/package/uswds) for you to utilize both the pre-compiled and compiled files on your project.
 
-To use this method, you will need to have Node/npm installed on your local development environment. Below is a link to find the install method that coincides with your operating system:
+1. Install `Node/npm`. Below is a link to find the install method that coincides with your operating system:
 
 - Node v4.2.3+, [Installation guides](https://nodejs.org/en/download/)
 
-**Note for Windows users:** If you are using Windows and are unfamiliar with Node.js or npm, we recommend following [Team Treehouse's tutorial](http://blog.teamtreehouse.com/install-node-js-npm-windows) for more information.
+**Note for Windows users:** If you are using Windows and are unfamiliar with `Node` or `npm`, we recommend following [Team Treehouse's tutorial](http://blog.teamtreehouse.com/install-node-js-npm-windows) for more information.
 
-Now let's check to make sure you have installed it correctly:
+2. Make sure you have installed it correctly:
 
 ```shell
 npm -v
 3.10.8 # This line may vary depending on what version of Node you've installed.
 ```
 
-Your next step will to be to create a `package.json` file. You can do this manually, but an easier method is to use the `npm init` command. This command will prompt you with a few questions to create your `package.json` file. 
+3. Create a `package.json` file. You can do this manually, but an easier method is to use the `npm init` command. This command will prompt you with a few questions to create your `package.json` file. 
 
-Now you are ready to add `uswds` to your project’s `package.json`. You can do so by using the following command:
+4. Add `uswds` to your project’s `package.json`:
 
 ```shell
 npm install --save uswds
 ```
 
-The `uswds` npm package will now be installed in `node_modules/uswds` as a dependecy. You can use the un-compiled files
-found in the `src/` or the compiled files in the `dist/` directory.
+The `uswds` module is now installed as a dependency. You can use the un-compiled files found in the `src/` or the compiled files in the `dist/` directory.
 
 ```
 node_modules/uswds/
@@ -154,9 +158,9 @@ node_modules/uswds/
     └── stylesheets/
 ```
 
-#### Importing and copying assets
+#### Importing assets
 
-Since you are already using npm, the Draft U.S. Web Design Standards team recommends leveraging the ability to write custom scripts. Here are some links to how we do this with our docs website using `npm` + [`gulp`](http://gulpjs.com/):
+Since you are already using `npm`, the Draft U.S. Web Design Standards team recommends leveraging the ability to write custom scripts. Here are some links to how we do this with our docs website using `npm` + [`gulp`](http://gulpjs.com/):
 
 [Link to `npm` scripts example in `web-design-standards-docs`](https://github.com/18F/web-design-standards-docs/blob/staging/package.json#L4)
 [Link to gulpfile.js example in `web-design-standards-docs`](https://github.com/18F/web-design-standards-docs/blob/staging/gulpfile.js)
@@ -179,7 +183,7 @@ Below is an example of how you might setup your main Sass file to achieve this:
 
 ```
 
-You can now use your copied version of `variables.scss` to override any styles to create a more custom look and feel to your application.
+You can now use your copied version of `_variables.scss` to override any styles to create a more custom look and feel to your application.
 
 #### JavaScript
 `require('uswds')` will load all of the Draft U.S. Web Design Standards’ JavaScript onto the page. Add this line to whatever initializer you use to load JavaScript into your application.
@@ -187,7 +191,7 @@ You can now use your copied version of `variables.scss` to override any styles t
 
 ### Use another framework or package manager
 
-If you’re using another framework or package manager that doesn’t support npm, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions](#download). Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
+If you’re using another framework or package manager that doesn’t support `npm`, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions](#download). Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
 
 If you’re interested in maintaining a package that helps us distribute the Draft U.S. Web Design Standards, the project’s build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](CONTRIBUTING.md#building-the-project-locally-with--gulp-) to locally build distributions for your framework or package manager.
 

--- a/README.md
+++ b/README.md
@@ -166,16 +166,16 @@ Since you are already using npm, the Draft U.S. Web Design Standards team recomm
 The Standards are easily customizable using the power of [Sass (Syntactically Awesome Style Sheets)](http://sass-lang.com/). The main Sass (SCSS) source file is located here:
 
 ```
-node_modules/uswds/src/stylesheets/all.scss
+node_modules/uswds/src/stylesheets/uswds.scss
 ```
 
-Global variables are defined in the `node_modules/uswds/src/stylesheets/core/_defaults.scss` file. Custom theming can be done by copying the `_variables.scss` file into your own project’s Sass folder, changing applicable variable values, and importing it before `all.scss`. 
+Global variables are defined in the `node_modules/uswds/src/stylesheets/core/_defaults.scss` file. Custom theming can be done by copying the `_variables.scss` file into your own project’s Sass folder, changing applicable variable values, and importing it before `uswds.scss`. 
 
 Below is an example of how you might setup your main Sass file to achieve this:
 
 ```
 @import 'variables.scss' # Custom Sass variables file
-@import 'node_modules/uswds/src/stylesheets/all.scss';
+@import 'node_modules/uswds/src/stylesheets/uswds.scss';
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The Standards are easily customizable using the power of [Sass (Syntactically Aw
 node_modules/uswds/src/stylesheets/uswds.scss
 ```
 
-Global variables are defined in the `node_modules/uswds/src/stylesheets/core/_defaults.scss` file. Custom theming can be done by copying the `_variables.scss` file into your own project’s Sass folder, changing applicable variable values, and importing it before `uswds.scss`. 
+Global variables are defined in the `node_modules/uswds/src/stylesheets/core/_variables.scss` file. Custom theming can be done by copying the `_variables.scss` file into your own project’s Sass folder, changing applicable variable values, and importing it before `uswds.scss`. 
 
 Below is an example of how you might setup your main Sass file to achieve this:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We’re glad you’d like to use the Standards — here’s how you can get star
 
 * Designers: [Check out our Getting Started for Designers information](https://standards.usa.gov/getting-started/designers/).
     * [Design files of all the assets included in the Standards are available for download](https://github.com/18F/web-design-standards-assets/archive/master.zip).
-* Developers: Follow the instructions in this README to get started.
+* Developers: [Follow the instructions in this README to get started.](#using-the-standards)
     * [CSS, JavaScript, image, and font files of all the assets on this site are available for download](https://github.com/18F/web-design-standards/releases/download/v0.13.1/uswds-0.13.1.zip).
 
 ## Using the Standards
@@ -46,13 +46,13 @@ There are a few different ways to use the Standards within your project. Which o
 
 ### Download
 
-To use the Draft Web Design Standards on your project, you’ll need to include the CSS and JavaScript files in each HTML page in your project.
+To use the Draft Web Design Standards on your project, you’ll need to include the [CSS (*C*ascading *S*tyle *S*heets)](http://www.w3schools.com/css/css_intro.asp) and JavaScript files in each HTML page or dynamic templates in your project.
 
-First, download the Draft Web Design Standards assets:
+First, download the Draft U.S. Web Design Standards assets using the link below:
 
 [https://github.com/18F/web-design-standards/releases/download/v0.13.1/uswds-0.13.1.zip](https://github.com/18F/web-design-standards/releases/download/v0.13.1/uswds-0.13.1.zip)
 
-Then, add the following folders into a relevant place in your code base — likely a directory where you keep third-party libraries:
+You should now have a folder downloaded with the following file and folder structure:
 
 ```
 
@@ -69,44 +69,55 @@ uswds-0.13.1/
 └── fonts/
 ```
 
-Refer to these files by adding the following `<link>` and `<script>` elements
-into each of your HTML pages:
+Now you will want to copy these files and folders into a relevant place in your projects code base. Here is an example structure for how this might look:
 
-Add this to your `<head>` element:
-
-```html
-<link rel="stylesheet" href="/path/to/your/assets/css/lib/uswds.min.css">
 ```
 
-Add this before the closing `</body>` tag:
+example-project/
+├── assets/
+│   ├── uswds-0.13.1/
+│   ├── stylesheets/
+│   ├── images/
+│   └── javascript/
+└── index.html
+```
+You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any of these types of assets that are unique to your project. 
+
+Next, you will want to import these assets into your HTML. Below is an example of the code for our example projects `index.html` file:
 
 ```html
-<script src="/path/to/your/assets/js/lib/uswds.min.js"></script>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>My Example Project</title>
+  <link rel="stylesheet" href="assets/uswds-0.13.1/css/uswds.min.css">
+</head>
+<body>
+  
+  <script src="assets/uswds-0.13.1/js/uswds.min.js"></script>
+</body>
+</html>
 ```
 
 We offer both files, the CSS and the JavaScript, in two versions — a minified
-version, and an un-minified one. (In the examples above, we are using the minified
-files.) Use the minified files in a production environment or to reduce the
-file size of your downloaded assets. And the un-minified files are better if you
-are in a development environment or would like to debug the CSS or JavaScript
-assets in the browser.
+version, and an un-minified one. (In the examples above, we are using the minified files.) Use the minified files in a production environment or to reduce the file size of your downloaded assets. And the un-minified files are better if you are in a development environment or would like to debug the CSS or JavaScript assets in the browser.
 
-This version of the Standards includes jQuery version `2.2.0` bundled within the
-JavaScript file. Please make sure that you’re not including any other version
-of jQuery on your page.
+**NOTE:** This version of the Standards includes jQuery version `2.2.0` bundled within the JavaScript file. Please make sure that you’re not including any other version of jQuery on your page.
 
-And that’s it — you should be set to use the Standards.
+And that’s it — you should now be able to copy our code samples into our `index.html` and start using the Standards.
 
 ### Install using npm
 
-If you have `node` installed on your machine, you can use npm to install the Standards. Add `uswds`
-to your project’s `package.json` as a dependency:
+If you have `node` installed on your machine, you can use [npm](https://www.npmjs.com/package/uswds) to install the Standards. Add `uswds`
+to your project’s `package.json`:
 
 ```shell
 npm install --save uswds
 ```
 
-The package will be installed in `node_modules/uswds`. You can use the un-compiled files
+The package will be installed in `node_modules/uswds` as a dependecy. You can use the un-compiled files
 found in the `src/` or the compiled files in the `dist/` directory.
 
 ```

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ example-project/
 │   └── javascript/
 └── index.html
 ```
+
 You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any of these types of assets that are unique to your project. 
 
 Next, you will want to import these assets into your HTML. Below is an example of the code for our example projects `index.html` file:
@@ -110,14 +111,30 @@ And that’s it — you should now be able to copy our code samples into our `in
 
 ### Install using npm
 
-If you have `node` installed on your machine, you can use [npm](https://www.npmjs.com/package/uswds) to install the Standards. Add `uswds`
-to your project’s `package.json`:
+`npm` is a package manager for Node.js based projects. The Draft U.S. Web Design Standards maintains a [`uswds` package](https://www.npmjs.com/package/uswds) for you to utilize both the pre-compiled and compiled files on your project.
+
+To use this method, you will need to have Node/npm installed on your local development environment. Below is a link to find the install method that coincides with your operating system:
+
+1. Node v4.2.3+, [Installation guides](https://nodejs.org/en/download/)
+
+Now let's check to make sure you have installed it correctly:
+
+```shell
+$ npm -v
+3.10.8 # This line may vary depending on what version of Node you've installed.
+```
+
+*INSTALLING NODE/NPM ON WINDOWS:* Team Treehouse has a tutorial on how to install Node.js/npm on your Windows machine: [http://blog.teamtreehouse.com/install-node-js-npm-windows](http://blog.teamtreehouse.com/install-node-js-npm-windows)
+
+Your next step will to be to create a `package.json` file. You can do this manually, but an easier method is to use the `npm init` command. This command will prompt you with a few questions to create your `package.json` file. 
+
+Now you are ready to add `uswds` to your project’s `package.json`. You can do so by using the following command:
 
 ```shell
 npm install --save uswds
 ```
 
-The package will be installed in `node_modules/uswds` as a dependecy. You can use the un-compiled files
+The `uswds` npm package will now be installed in `node_modules/uswds` as a dependecy. You can use the un-compiled files
 found in the `src/` or the compiled files in the `dist/` directory.
 
 ```
@@ -134,19 +151,36 @@ node_modules/uswds/
     └── stylesheets/
 ```
 
-`require('uswds')` will load all of the Draft U.S. Web Design Standards’ JavaScript onto the page. The `uswds` module itself does not export anything.
+#### Importing and copying assets
 
-The main Sass (SCSS) source file is here:
+Since you are already using npm, the Draft U.S. Web Design Standards team recommends leveraging the ability to write custom scripts. Here are some links to how we do this with our docs website using `npm` + [`gulp`](http://gulpjs.com/):
+
+[Link to `npm` scripts example in `web-design-standards-docs`](https://github.com/18F/web-design-standards-docs/blob/staging/package.json#L4)
+[Link to gulpfile.js example in `web-design-standards-docs`](https://github.com/18F/web-design-standards-docs/blob/staging/gulpfile.js)
+
+#### Sass
+
+The Standards are easily customizable using the power of [Sass (Syntactically Awesome Style Sheets)](http://sass-lang.com/). The main Sass (SCSS) source file is located here:
 
 ```
 node_modules/uswds/src/stylesheets/all.scss
 ```
 
-The non-minified CSS that’s been precompiled is here:
+Global variables are defined in the `node_modules/uswds/src/stylesheets/core/_defaults.scss` file. Custom theming can be done by copying the `_variables.scss` file into your own project’s Sass folder, changing applicable variable values, and importing it before `all.scss`. 
+
+Below is an example of how you might setup your main Sass file to achieve this:
 
 ```
-node_modules/uswds/dist/css/uswds.css
+@import 'variables.scss' # Custom Sass variables file
+@import 'node_modules/uswds/src/stylesheets/all.scss';
+
 ```
+
+You can now use your copied version of `variables.scss` to override any styles to create a more custom look and feel to your application.
+
+#### JavaScript
+`require('uswds')` will load all of the Draft U.S. Web Design Standards’ JavaScript onto the page. Add this line to whatever initializer you use to load JavaScript into your application.
+
 
 ### Use another framework or package manager
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ There are a few different ways to use the Standards within your project. Which o
 
 ### Download
 
-To use the Draft Web Design Standards on your project, you’ll need to include the [CSS (*C*ascading *S*tyle *S*heets)](http://www.w3schools.com/css/css_intro.asp) and JavaScript files in each HTML page or dynamic templates in your project.
+To use the Draft Web Design Standards on your project, you’ll need to include the [CSS (*C*ascading *S*tyle *S*heets)](https://developer.mozilla.org/en-US/docs/Web/CSS) and JavaScript files in each HTML page or dynamic templates in your project.
 
 First, download the Draft U.S. Web Design Standards assets using the link below:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Previously, the website and documentation for the Draft U.S. Web Design Standard
     * [Sass](#sass)
     * [JavaScript](#javascript)
   * [Use another framework or package manager](#use-another-framework-or-package-manager)
-* [Our use of branches](#our-use-of-branches)
 * [Need installation help?](#need-installation-help)
 * [Contributing to the code base](#contributing-to-the-codebase)
 * [Reuse of open-source style guides](#reuse-of-open-source-style-guides)
@@ -194,14 +193,6 @@ You can now use your copied version of `_variables.scss` to override any styles 
 If you’re using another framework or package manager that doesn’t support `npm`, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions](#download). Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
 
 If you’re interested in maintaining a package that helps us distribute the Draft U.S. Web Design Standards, the project’s build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](CONTRIBUTING.md#building-the-project-locally-with--gulp-) to locally build distributions for your framework or package manager.
-
-## Our use of branches
-
-The `staging` branch is the bleeding edge of development. When cutting a new [release](https://github.com/18F/web-design-standards/releases), we update the versioning on our files by branching off of the `staging` branch and submitting a pull request into our `release` branch. This helps to make `staging` a place that can always receive contributions, no matter where we are in the release process. New commits to `staging` are automatically deployed to [our staging site](https://standards-staging.usa.gov/).
-
-The `master` branch always holds the latest production-ready release. When cutting a [release](https://github.com/18F/web-design-standards/releases), we create a release branch from `staging` named for the new version: for example, `v0.9.x`. Once we’ve completed QA on that branch, we tag the release and merge it into the `master` branch.
-
-The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release and development branches, back when the site was hosted on `pages.18f.gov`. Those branches still auto deploy to 18F Pages, but will now only contain minimal redirects to the new site.
 
 ## Need installation help?
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ And that’s it — you should now be able to copy our code samples into our `in
 
 To use this method, you will need to have Node/npm installed on your local development environment. Below is a link to find the install method that coincides with your operating system:
 
-1. Node v4.2.3+, [Installation guides](https://nodejs.org/en/download/)
+- Node v4.2.3+, [Installation guides](https://nodejs.org/en/download/)
+
+**Note for Windows users:** If you are using Windows and are unfamiliar with Node.js or npm, we recommend following [Team Treehouse's tutorial](http://blog.teamtreehouse.com/install-node-js-npm-windows) for more information.
 
 Now let's check to make sure you have installed it correctly:
 
@@ -126,8 +128,6 @@ Now let's check to make sure you have installed it correctly:
 $ npm -v
 3.10.8 # This line may vary depending on what version of Node you've installed.
 ```
-
-**Windows installation:** Team Treehouse has a tutorial on how to install Node.js/npm on your Windows machine: [http://blog.teamtreehouse.com/install-node-js-npm-windows](http://blog.teamtreehouse.com/install-node-js-npm-windows)
 
 Your next step will to be to create a `package.json` file. You can do this manually, but an easier method is to use the `npm init` command. This command will prompt you with a few questions to create your `package.json` file. 
 


### PR DESCRIPTION
This pull request includes some updates in our `README.md` to better accommodate Windows users and also users of varying degrees of experience. A few things to note:

- Adding more definition around varying acronyms to be more explicit in what they mean or refer to.
- Added better examples around how folder and file structures work together
- Be more explicit on how to import and/or compile assets when installing with `npm`

Also, this PR is merging into https://github.com/18F/web-design-standards/pull/1530 (!)

Refs #1533 