### PR TITLE
[WIP] Refactor component styles

### DIFF
--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -152,7 +152,7 @@ button,
 }
 // scss-lint:enable PropertyCount
 
-[type="submit"]:disabled,
+.usa-button:disabled,
 .usa-button-disabled {
   background-color: $color-gray-lighter;
   color: $color-gray-dark;


### PR DESCRIPTION
#### ⚠️ 🚧  Work in progress 🚧 ⚠️ 

This is a refactoring of some of our component styles to be more modular. The goal here is to make it easier for users to `@import 'uswds/path/to/component';` and (within reason) not have massive headaches tracking down all of that component's SCSS "dependencies".

I think the end state of this will be that each component has its own directory, which will contain at least two files:

1. An SCSS partial (`path/to/component/_partial.scss`) that gets imported via the `uswds` entry point, or some other, higher-level import.
1. A self-contained SCSS entry point (e.g. `path/to/component/component.scss`, no underscore) that references all of its depencies via `@import`.

In some not-too-distant future, I would love to see the component styles, JavaScript, and even templates (see: [meta-template](https://github.com/shawnbot/meta-template)) colocated in the same directory.