### PR TITLE
Removes !default form $em-base value

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -8,7 +8,9 @@
 // own partials, then @import '{path/to/uswds/}core/variables'.
 
 // Typography
-$em-base:             10px !default;
+// Removing the !default from $em-base so we are not inheriting that 
+// value from Bourbon.
+$em-base:             10px;
 $base-font-size:      rem(17px) !default;
 $small-font-size:     rem(14px) !default;
 $lead-font-size:      rem(20px) !default;


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/18F/web-design-standards/issues/1590#issuecomment-263463434), the issue here is the order of inheritance around the `$em-base` variable. This pull request removes the `!default` value and stabilizes the base font size.

Fixes #1590 