### PR TITLE
Reference Neat 1.8 branch without node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/18F/web-design-standards#readme",
   "dependencies": {
     "bourbon": "^4.2.6",
-    "bourbon-neat": "^1.7.3",
+    "bourbon-neat": "github:thoughtbot/neat#neat-1.8.0-node-sass",
     "classlist-polyfill": "^1.0.3",
     "cross-spawn": "^2.1.5",
     "jquery": "^2.2.0",


### PR DESCRIPTION
This is a fix for #1554, which involves pointing our `package.json` at a branch of Neat that our friends at Thoughtbot [made for us](https://github.com/thoughtbot/neat/issues/505#issuecomment-258548222) to nix `node-sass` from their dependencies.

The trade-off here is that we've introduced github as a new dependency, and we're relying on Thoughtbot to keeping that branch around. I hope that, if we decide to go through with this change, we can switch back to the npm-hosted version when we upgrade to Neat 2.x in #1555.