### PR TITLE
Remove un-needed attributes from address form template

### DIFF
--- a/src/html/address-form.html
+++ b/src/html/address-form.html
@@ -74,7 +74,7 @@
       </div>
 
       <label for="zip">ZIP</label>
-      <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-" data-politespace>
+      <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-">
     </fieldset>
   </form>
 

--- a/src/html/address-form.html
+++ b/src/html/address-form.html
@@ -74,7 +74,7 @@
       </div>
 
       <label for="zip">ZIP</label>
-      <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-">
+      <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?">
     </fieldset>
   </form>
 


### PR DESCRIPTION
This pull request is for removing `data-politespace` from the address form template html example. It is merging in with @shawnbot work [here](https://github.com/18F/web-design-standards/pull/1606).