### PR TITLE
v0.14.0 release tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ dist/
 # Ignore gulp-generated vendor files
 #
 src/stylesheets/lib
-
-scss-lint.yml

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -1,7 +1,7 @@
 // Alert variables ---------- //
-$usa-custom-alerts:() !default;
+$usa-custom-alerts: () !default;
 
-$usa-alerts: ( 
+$usa-alerts: (
   success: $color-green-lightest,
   warning: $color-gold-lightest,
   error: $color-secondary-lightest,


### PR DESCRIPTION
A couple of things to adjust for the v0.14.0 release:

- Adjust whitespace (missing and stray spaces) in the _excellent_ new custom alerts SCSS.
- Remove unnecessary `scss-lint.yml` entry from `.gitignore`, which was added [here](https://github.com/18F/web-design-standards/pull/1504/files#diff-a084b794bc0759e7a6b77810e01874f2).