### PR TITLE
Render checked AND disabled checkbox properly

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -199,7 +199,8 @@ legend {
   box-shadow: 0 0 0 2px $color-white, 0 0 0 4px $color-primary, 0 0 3px 4px $color-focus, 0 0 7px 4px $color-focus;
 }
 
-[type=checkbox]:checked + label::before {
+[type=checkbox]:checked + label::before,
+[type=checkbox]:checked:disabled + label::before {
   background-image: url('#{$image-path}/correct8.png');
   background-image: url('#{$image-path}/correct8.svg');
   background-position: 50%;


### PR DESCRIPTION
## Render checked AND disabled checkbox properly

This allows for a checkox that is both `checked` and `disabled` to render as disabled but with the check. 

## Additional information

Example code:
`<input type="checkbox" id="usds-checkbox" disabled checked>`

Before:
![before](https://cloud.githubusercontent.com/assets/2932572/21235046/25732754-c2c3-11e6-92db-e5e56ca57324.png)

With this PR:
![after](https://cloud.githubusercontent.com/assets/2932572/21235095/5a97b760-c2c3-11e6-9ae6-06aebd05faed.png)

