### PR TITLE
Move lodash.debounce to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bourbon-neat": "github:thoughtbot/neat#neat-1.8.0-node-sass",
     "classlist-polyfill": "^1.0.3",
     "cross-spawn": "^2.1.5",
+    "lodash.debounce": "^4.0.7",
     "normalize.css": "^3.0.3"
   },
   "devDependencies": {
@@ -59,7 +60,6 @@
     "jquery": "^2.2.0",
     "jsdom": "^9.0.0",
     "jsdom-global": "^2.1.0",
-    "lodash.debounce": "^4.0.7",
     "merge-stream": "^1.0.0",
     "mocha": "^2.4.5",
     "node-notifier": "^4.6.0",


### PR DESCRIPTION
This is a simple fix for errors related to the unmet `lodash.debounce` dependency when the package isn't npm installed with the `--dev` option. There's no reason that it should be a dev dependency since we're requiring it directly in our code [here](https://github.com/18F/web-design-standards/blob/8f130eb3384aaf33fa4c7782a8717ac2ba0df5af/src/js/initializers/footer.js#L1).

This will allow our module to be required directly in JS, and to be built with [browserify](http://browserify.org/) (and automatically with the [browserify CDN](https://wzrd.in/)).