### PR TITLE
Fix mysterious minified CSS build failures

### DIFF
--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -37,30 +37,22 @@ gulp.task(task, [ 'eslint' ], function (done) {
     debug: true,
   });
 
-  defaultStream = defaultStream.bundle()
+  var stream = defaultStream.bundle()
     .pipe(source('components.js'))
     .pipe(buffer())
     .pipe(rename({ basename: dutil.pkg.name }))
     .pipe(gulp.dest('dist/js'));
 
-  var minifiedStream = browserify({
-    entries: 'src/js/start.js',
-    debug: true,
-  });
-
-  minifiedStream = minifiedStream.bundle()
-    .pipe(source('components.js'))
-    .pipe(buffer())
+  stream
     .pipe(sourcemaps.init({ loadMaps: true }))
-      .pipe(uglify())
-      .on('error', gutil.log)
-      .pipe(rename({
-        basename: dutil.pkg.name,
-        suffix: '.min',
-      }))
+    .pipe(uglify())
+    .on('error', gutil.log)
+    .pipe(rename({
+      suffix: '.min',
+    }))
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('dist/js'));
 
-  return merge(defaultStream, minifiedStream);
+  return stream;
 
 });

--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -6,7 +6,6 @@ var buffer = require('vinyl-buffer');
 var source = require('vinyl-source-stream');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
-var merge = require('merge-stream');
 var rename = require('gulp-rename');
 var eslint = require('gulp-eslint');
 var task = 'javascript';

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var dutil = require('./doc-util');
 var sass = require('gulp-sass');
+var cssnano = require('gulp-cssnano');
 var autoprefixer = require('gulp-autoprefixer');
 var sourcemaps = require('gulp-sourcemaps');
 var rename = require('gulp-rename');
@@ -50,54 +51,49 @@ gulp.task('copy-vendor-sass', function (done) {
   return stream;
 });
 
-gulp.task(task, [ 'stylelint' ], function (done) {
+gulp.task(task, [ /* 'stylelint' */ ], function (done) {
 
   dutil.logMessage(task, 'Compiling Sass');
 
-  var entryFile = 'src/stylesheets/uswds.scss';
-
-  var replaceVersion = replace(
-    /\buswds @version\b/g,
-    'uswds v' + pkg.version
-  );
-
-  var defaultStream = gulp.src(entryFile)
+  var stream = gulp.src('src/stylesheets/uswds.scss')
+    // 1. do the version replacement
+    .pipe(replace(
+      /\buswds @version\b/g,
+      'uswds v' + pkg.version
+    ))
+    // 2. convert SCSS to CSS
     .pipe(
       sass({ outputStyle: 'expanded' })
         .on('error', sass.logError)
     )
+    // 3. run it through autoprefixer
     .pipe(
       autoprefixer({
         browsers: supportedBrowsers,
         cascade: false,
       })
     )
-    .pipe(rename({ basename: dutil.pkg.name }))
-    .pipe(replaceVersion)
+    // 4. write dist/css/uswds.css
     .pipe(gulp.dest('dist/css'));
 
-  var minifiedStream = gulp.src(entryFile)
+  // we can reuse this stream for minification!
+  stream
+    // 1. initialize sourcemaps
     .pipe(sourcemaps.init({ loadMaps: true }))
-    .pipe(
-      sass({ outputStyle: 'compressed' })
-        .on('error', sass.logError)
-    )
-    .pipe(
-      autoprefixer({
-        browsers: supportedBrowsers,
-        cascade: false,
-      })
-    )
+    // 2. minify with cssnano
+    .pipe(cssnano({
+      safe: true,
+      // XXX see https://github.com/ben-eb/cssnano/issues/340
+      mergeRules: false,
+    }))
+    // 3. rename to uswds.min.css
     .pipe(rename({
-      basename: dutil.pkg.name,
       suffix: '.min',
     }))
-    .pipe(sourcemaps.write('.', { addComment: false }))
-    .pipe(replaceVersion)
+    // 4. write dist/css/uswds.min.css.map
+    .pipe(sourcemaps.write('.'))
+    // 5. write dist/css/uswds.min.css
     .pipe(gulp.dest('dist/css'));
 
-  var streams = merge(defaultStream, minifiedStream);
-
-  return streams;
-
+  return stream;
 });

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -50,7 +50,7 @@ gulp.task('copy-vendor-sass', function (done) {
   return stream;
 });
 
-gulp.task(task, [ /* 'stylelint' */ ], function (done) {
+gulp.task(task, [ 'stylelint' ], function (done) {
 
   dutil.logMessage(task, 'Compiling Sass');
 

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -6,7 +6,6 @@ var autoprefixer = require('gulp-autoprefixer');
 var sourcemaps = require('gulp-sourcemaps');
 var rename = require('gulp-rename');
 var linter = require('@18f/stylelint-rules');
-var merge = require('merge-stream');
 var pkg = require('../../package.json');
 var filter = require('gulp-filter');
 var replace = require('gulp-replace');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-clean": "^0.3.1",
+    "gulp-cssnano": "^2.1.2",
     "gulp-eslint": "^1.1.1",
     "gulp-filter": "^3.0.1",
     "gulp-mocha": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "jquery": "^2.2.0",
     "jsdom": "^9.0.0",
     "jsdom-global": "^2.1.0",
-    "merge-stream": "^1.0.0",
     "mocha": "^2.4.5",
     "node-notifier": "^4.6.0",
     "node-sass": "^3.4.2",

--- a/spec/sass/build.spec.js
+++ b/spec/sass/build.spec.js
@@ -12,7 +12,7 @@ var distPath = path.resolve(
 );
 
 var build = function (done) {
-  child.exec('npm run build', {}, function() { done(); });
+  child.exec('`npm bin`/gulp sass', {}, function () { done(); });
 };
 
 before(function (done) {


### PR DESCRIPTION
This is, I think, a more robust fix for #1642. TL;DR:

* Refactor `sass` gulp task to use [cssnano] and use a single stream with multiple outputs ("expanded" and minified CSS w/sourcemap)
* Similarly refactor the `javascript` gulp task to reuse the same stream for minification
* Nix the `merge-stream` dependency
* Speed up `mocha spec/sass/build.spec.js` by having it only run `gulp sass` instead of `npm run build`, which does a bunch of other, unrelated work

After merging #1664 (thanks, @bruffridge!), I ran the tests a bunch of times locally and discovered that gulp was _still_ doing something funky with the "default" and "minified" streams in our `sass` task—but only under certain and rather mysterious conditions. As far as I can tell, either [merge-stream](https://www.npmjs.com/package/merge-stream) (which we used to "merge" the two streams so that gulp would get an `end` stream event only when both streams were complete) was not detecting completion of both streams or ignoring the minified one altogether, or gulp was for some reason failing to sync the minified virtual file to disk. My script to test this was:

```sh
rm -r dist/css; gulp sass && ls -la dist/css
```

I ran this a bunch, and at some point, without any local modifications, I was able to get this to reliably produce _only_ `dist/css/uswds.css`, and not the minified version. So I refactored, and ended up with a gulp task that recycles the "default" stream and passes it through [cssnano] with an additional `rename()` and sourcemap transform. After refactoring, I consistently ended up with all three `dist/css` files (the expanded CSS, minified CSS, and sourcemap).

As a bonus, I applied the same refactoring to our JavaScript minification, which should also be much faster now that we're not spawning two separate (but identical) browserify bundles in parallel. This allowed us to nix the `merge-stream` dependency altogether. 🎉 

[cssnano]: http://cssnano.co/