### PR TITLE
Remove unused sinon dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "node-sass": "^3.4.2",
     "run-sequence": "^1.1.5",
     "should": "^8.3.1",
-    "sinon": "^1.17.5",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watch": "^0.17.1"

--- a/spec/unit/utils/dispatch.spec.js
+++ b/spec/unit/utils/dispatch.spec.js
@@ -1,6 +1,5 @@
 var should = require('should');
 var dispatch = require('../../../src/js/utils/dispatch');
-var sinon = require('sinon');
 
 describe('dispatch', function () {
 


### PR DESCRIPTION
This removes [Sinon](http://sinonjs.org/) from `package.json` and the unused import in our dispatch unit test.