### PR TITLE
Adding docs to zip file distribution

### DIFF
--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -19,6 +19,21 @@ gulp.task('clean-dist', function (done) {
 
 });
 
+gulp.task('docs', function (done) {
+   
+  dutil.logMessage('docs', 'Copying documentation dist dir');
+
+  var stream = gulp.src([
+    'README.md',
+    'LICENSE.md',
+    'CONTRIBUTING.md'
+    ])
+    .pipe(gulp.dest('dist'));
+
+  return stream;
+
+});
+
 gulp.task('build', function (done) {
 
   dutil.logIntroduction();
@@ -29,6 +44,7 @@ gulp.task('build', function (done) {
 
   runSequence(
     'clean-dist',
+    'docs',
     [
       'sass',
       'javascript',


### PR DESCRIPTION
Decided to just add this task directly to `build.js` instead of creating it's own file/task. Not entirely sure where we would reuse this specific task other than here so it made sense to live in this build file.