### PR TITLE
Migrate release process to the repo

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@ Standards](https://standards.usa.gov).
   1. [The public API](#the-public-api)
 1. [Release process](#release-process)
   1. [Git(/Hub) workflow](#git-workflow)
+1. [Questions?](#questions)
 
 
 ## Principles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,107 @@
+# Releasing the Web Design Standards
+
+This is our official process for releasing new versions of the Web Design Standards **after v1.0**.
+
+
+## Table of contents
+1. [Principles](#principles)
+1. [Versioning](#versioning)
+  1. [What is a release?](#what-is-a-release)
+  1. [The public API](#the-public-api)
+1. [Release process](#release-process)
+  1. [Git(/Hub) workflow](#git-workflow)
+
+
+## Principles
+1. Follow well-established [versioning practices](#versioning)
+1. Provide detailed notes for each [release](#what-is-a-release)
+1. Encourage contributions and thank contributors for their hard work
+
+
+## Versioning
+[Semantic versioning][semver] is a method of numbering release versions that aims to help users understand the implications of
+upgrading from one [release](#what-is-a-release) to another. Semantic version numbers take the form `major.minor.patch`, where:
+
+* Bug fixes increment the `patch` number (e.g. `1.0.0` to `1.0.1`)
+* New features increment the `minor` number and reset `patch` (e.g. `1.0.1` to `1.1.0`)
+* Changes to the [public API](#public-api) (so-called "breaking changes") increment the `major` version and reset `minor` and `patch` (e.g. `1.1.2` to `2.0.0`)
+
+### What is a release?
+Technically, release of the Web Design Standards core code "lives" in two different places:
+
+1. On GitHub as a [tag][git tag] and corresponding [release][releases]
+1. On [npm][what is npm] as a release of the [`uswds` package][uswds on npm] with the same version number as the GitHub release
+
+### The public API
+In most software projects, the "public API" corresponds to a single set of programming constructs, such as public classes or functions.
+Because the Standards consist of tightly-bound HTML, CSS, and JavaScript, we must consider any "breaking" change to _any_ of these as
+a change to the public API. For instance, any of the following should trigger a major version increment:
+
+* Changing the name of any `.usa-` class name (documented or not)
+* Changing the way in which elements with `.usa-` class names are structured in HTML
+* Changing the HTML "API" for any of our interactive components, such as the [accordion](https://standards.usa.gov/accordions/)
+
+
+## Release process
+
+### Git workflow
+
+* We have two main branches that are never deleted:
+  * `master` always points to the latest release
+  * `develop` contains changes being prepped for a release
+
+* **TODO**: Migrate `staging` to `develop`
+
+* When introducing a change (feature, bug fix, etc.):
+  1. Branch off `develop`:
+  
+      ```sh
+      git fetch origin
+      git co -b feature-foo origin/develop
+      ```
+      
+  1. As a naming convention, your branch name can be anything except `master`, `develop`, or with the `release-` or `hotfix-` prefix
+  1. Changes are merged back into the `develop` branch
+  
+* When publishing a new release:
+
+  1. Branch off `develop` and use the branch name format `release-{version}`, e.g.
+
+      ```sh
+      git fetch origin
+      git co -b release-1.0.0 origin/develop
+      ```
+  
+  1. Merge release commits back into `master` _and_ `develop`
+  1. Run [`npm version`][npm version] with `--no-tag` to increment the version number semantically.
+     (Versions are tagged on the `master` branch.)
+     
+    * For minor and major versions, publish a pre-release:
+  
+      ```sh
+      npm version prerelease --no-tag
+      ```
+      
+    * Otherwise, run either `npm version minor --no-tag` or `npm version major --no-tag`
+    * In either case, `npm version` will increments the version number in `package.json` and commit the changes to git
+
+  1. That is the only thing that happens on a release branch!
+  1. Merge into `master` with a PR
+  1. List the key changes for a release in the description of the PR that merges the release branch into master.
+     (The diff will show you exactly what has changed since the previous release.)
+  1. Tag the release on the `master` branch
+  1. Write the release notes on GitHub:
+    1. Draft the release from the corresponding tag on master
+    1. Have folks on the team review it
+    1. Publish the release!
+  1. Update the docs site with the new version number and release notes
+
+
+
+[git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
+[releases]: https://github.com/18F/web-design-standards/releases
+[new release]: https://github.com/18F/web-design-standards/releases/new
+[what is npm]: https://docs.npmjs.com/getting-started/what-is-npm
+[uswds on npm]: https://npmjs.com/package/uswds
+[semver]: http://semver.org/
+[npm version]: https://docs.npmjs.com/cli/version

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -140,6 +140,13 @@ example, any of the following should trigger a major version increment:
        minus the GitHub release notes.
 
 
+## Questions?
+If you need help or have any questions, please reach out to us:
+
+* File an [issue on GitHub](https://github.com/18F/web-design-standards/issues/new).
+* Email us at [uswebdesignstandards@gsa.gov](mailto:uswebdesignstandards@gsa.gov).
+* [Sign up](https://chat.18f.gov/) for our public [Slack] channel.
+
 
 [draft release]: https://github.com/18F/web-design-standards/releases/new
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
@@ -150,3 +157,4 @@ example, any of the following should trigger a major version increment:
 [semver]: http://semver.org/
 [uswds on npm]: https://npmjs.com/package/uswds
 [what is npm]: https://docs.npmjs.com/getting-started/what-is-npm
+[Slack]: https://slack.com/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Releasing the Web Design Standards
 
-This is our official process for releasing new versions of the Web Design Standards **after v1.0**.
+This is our official process for releasing new versions of the [U.S. Web Design
+Standards](https://standards.usa.gov).
 
 
 ## Table of contents
@@ -19,27 +20,36 @@ This is our official process for releasing new versions of the Web Design Standa
 
 
 ## Versioning
-[Semantic versioning][semver] is a method of numbering release versions that aims to help users understand the implications of
-upgrading from one [release](#what-is-a-release) to another. Semantic version numbers take the form `major.minor.patch`, where:
+[Semantic versioning][semver] is a method of numbering release versions that
+aims to help users understand the implications of upgrading from one
+[release](#what-is-a-release) to another. Semantic version numbers take the
+form `major.minor.patch`, where:
 
 * Bug fixes increment the `patch` number (e.g. `1.0.0` to `1.0.1`)
-* New features increment the `minor` number and reset `patch` (e.g. `1.0.1` to `1.1.0`)
-* Changes to the [public API](#public-api) (so-called "breaking changes") increment the `major` version and reset `minor` and `patch` (e.g. `1.1.2` to `2.0.0`)
+* New features increment the `minor` number and reset `patch` (e.g. `1.0.1` to
+  `1.1.0`)
+* Changes to the [public API](#public-api) (breaking changes) increment the
+  `major` version and reset `minor` and `patch` (e.g. `1.1.2` to `2.0.0`)
 
 ### What is a release?
-Technically, release of the Web Design Standards core code "lives" in two different places:
+Technically, release of the Web Design Standards core code "lives" in two
+different places:
 
 1. On GitHub as a [tag][git tag] and corresponding [release][releases]
 1. On [npm][what is npm] as a release of the [`uswds` package][uswds on npm] with the same version number as the GitHub release
 
 ### The public API
-In most software projects, the "public API" corresponds to a single set of programming constructs, such as public classes or functions.
-Because the Standards consist of tightly-bound HTML, CSS, and JavaScript, we must consider any "breaking" change to _any_ of these as
-a change to the public API. For instance, any of the following should trigger a major version increment:
+In most software projects, the "public API" corresponds to a single set of
+programming constructs, such as public classes or functions.  Because the
+Standards consist of tightly-bound HTML, CSS, and JavaScript, we must consider
+any "breaking" change to _any_ of these as a change to the public API. For
+example, any of the following should trigger a major version increment:
 
 * Changing the name of any `.usa-` class name (documented or not)
-* Changing the way in which elements with `.usa-` class names are structured in HTML
-* Changing the HTML "API" for any of our interactive components, such as the [accordion](https://standards.usa.gov/accordions/)
+* Changing the way in which elements with `.usa-` class names are structured in
+  HTML
+* Changing the HTML "API" for any of our interactive components, such as the
+  [accordion](https://standards.usa.gov/accordions/)
 
 
 ## Release process
@@ -50,31 +60,32 @@ a change to the public API. For instance, any of the following should trigger a 
   * `master` always points to the latest release
   * `develop` contains changes being prepped for a release
 
-* **TODO**: Migrate `staging` to `develop`
-
 * When introducing a change (feature, bug fix, etc.):
+
   1. Branch off `develop`:
   
       ```sh
       git fetch origin
-      git co -b feature-foo origin/develop
+      git checkout -b feature-foo origin/develop
       ```
       
-  1. As a naming convention, your branch name can be anything except `master`, `develop`, or with the `release-` or `hotfix-` prefix
+  1. As a naming convention, your branch name can be anything except `master`,
+     `develop`, or with the `release-` or `hotfix-` prefix
+
   1. Changes are merged back into the `develop` branch
   
 * When publishing a new release:
 
-  1. Branch off `develop` and use the branch name format `release-{version}`, e.g.
+  1. Branch off `develop` and use the branch name format `release-{version}`,
+     e.g.
 
       ```sh
       git fetch origin
-      git co -b release-1.0.0 origin/develop
+      git checkout -b release-1.0.0 origin/develop
       ```
-  
-  1. Merge release commits back into `master` _and_ `develop`
-  1. Run [`npm version`][npm version] with `--no-tag` to increment the version number semantically.
-     (Versions are tagged on the `master` branch.)
+
+  1. Run [`npm version`][npm version] with `--no-tag` to increment the version
+     number semantically. (Versions are tagged on the `master` branch.)
      
     * For minor and major versions, publish a pre-release:
   
@@ -82,26 +93,60 @@ a change to the public API. For instance, any of the following should trigger a 
       npm version prerelease --no-tag
       ```
       
-    * Otherwise, run either `npm version minor --no-tag` or `npm version major --no-tag`
-    * In either case, `npm version` will increments the version number in `package.json` and commit the changes to git
+    * Otherwise, run either `npm version minor --no-tag` or `npm version major
+      --no-tag`
 
-  1. That is the only thing that happens on a release branch!
-  1. Merge into `master` with a PR
-  1. List the key changes for a release in the description of the PR that merges the release branch into master.
-     (The diff will show you exactly what has changed since the previous release.)
-  1. Tag the release on the `master` branch
+    * In either case, [`npm version`][npm version] will increment the version
+      number in `package.json` and commit the changes to git.
+
+  1. Open a [pull request] from your `release-` branch to merge into `master`.
+     List the key changes for a release in the pull request description. (The
+     diff will show you exactly what has changed since the previous release.)
+     See [the v1.0.0 pull request](#TODO) for an example.
+
+  1. Tag the release on the `master` branch **or** create the tag when you
+     draft the release notes.
+
+  1. Merge the release commits back into `develop` from `master` with a [pull
+     request].
+
   1. Write the release notes on GitHub:
-    1. Draft the release from the corresponding tag on master
-    1. Have folks on the team review it
-    1. Publish the release!
-  1. Update the docs site with the new version number and release notes
+
+    1. [Draft the release][draft release] from the corresponding tag on the
+       `master` branch.
+
+    1. Have at least one team member review the release notes.
+
+    1. Publish the [release](https://github.com/18F/web-design-standards/releases)
+       on GitHub.
+
+  1. Update the docs site with the new version number and release notes:
+
+    1. Update the `uswds` Node dependency to the new version, e.g.:
+
+      ```sh
+      cd path/to/web-design-standards-docs
+      export VERSION=1.0.0
+      git fetch origin
+      git checkout -b release-${VERSION} origin/develop
+      npm install --save-dev uswds@${VERSION}
+      ```
+
+    1. Update the `version` [variable in
+       _config.yml](https://github.com/18F/web-design-standards-docs/blob/master/_config.yml#L3).
+
+    1. Follow the above release process to merge the changes to `master` via a
+       [pull request on the docs repo](https://github.com/18F/web-design-standards-docs/compare),
+       minus the GitHub release notes.
 
 
 
+[draft release]: https://github.com/18F/web-design-standards/releases/new
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
-[releases]: https://github.com/18F/web-design-standards/releases
 [new release]: https://github.com/18F/web-design-standards/releases/new
-[what is npm]: https://docs.npmjs.com/getting-started/what-is-npm
-[uswds on npm]: https://npmjs.com/package/uswds
-[semver]: http://semver.org/
 [npm version]: https://docs.npmjs.com/cli/version
+[pull request]: https://github.com/18F/web-design-standards/compare
+[releases]: https://github.com/18F/web-design-standards/releases
+[semver]: http://semver.org/
+[uswds on npm]: https://npmjs.com/package/uswds
+[what is npm]: https://docs.npmjs.com/getting-started/what-is-npm


### PR DESCRIPTION
This is the first step in #1686: Migrate release principles and workflow description to `RELEASE.md`. I could use some eyes on this from everyone tagged as a reviewer. You can see the doc in its rendered form here:

https://github.com/18F/web-design-standards/blob/feature-release-process/RELEASE.md

I have one concern: the filename `RELEASE` is a _little_ too similar to `README` for my taste. They're hard to distinguish quickly in the file listing on github, so I wonder if we should call it something else?