### PR TITLE
update the bourbon-neat dependency to use a tarball instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/18F/web-design-standards#readme",
   "dependencies": {
     "bourbon": "^4.2.6",
-    "bourbon-neat": "github:thoughtbot/neat#neat-1.8.0-node-sass",
+    "bourbon-neat": "https://github.com/thoughtbot/neat/archive/neat-1.8.0-node-sass.tar.gz",
     "classlist-polyfill": "^1.0.3",
     "cross-spawn": "^2.1.5",
     "normalize.css": "^3.0.3"


### PR DESCRIPTION
## Description

[This update](https://github.com/18F/web-design-standards/commit/a189a6f7b4358e558ed9a9eeced13e0b218f666c) to the bourbon-neat dependency causes builds to fail when `git` is not installed.

Example:
```
npm ERR! git clone --template=/root/.npm/_git-remotes/_templates --mirror git@github.com:thoughtbot/neat.git /root/.npm/_git-remotes/git-github-com-thoughtbot-neat-git-neat-1-8-0-node-sass-31bad44b: undefined
npm ERR! git clone --template=/root/.npm/_git-remotes/_templates --mirror git@github.com:thoughtbot/neat.git /root/.npm/_git-remotes/git-github-com-thoughtbot-neat-git-neat-1-8-0-node-sass-31bad44b: undefined
npm ERR! Linux 4.4.47-boot2docker
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install"
npm ERR! node v6.9.5
npm ERR! npm  v3.10.10
npm ERR! code ENOGIT

npm ERR! not found: git
npm ERR!
npm ERR! Failed using git.
npm ERR! This is most likely not a problem with npm itself.
npm ERR! Please check if you have git installed and in your PATH.
```

__FYI: we are using docker and our docker images were not installing `git`. We have fixed this by installing `git` but this PR would remove that requirement.__