### PR TITLE
Add grid offset classes

### DIFF
--- a/src/stylesheets/core/_grid.scss
+++ b/src/stylesheets/core/_grid.scss
@@ -152,3 +152,48 @@
 .usa-end-row {
   @include omega();
 }
+
+// Grid Offsets
+.usa-offset-one-twelfth {
+  @include shift(1 of 12);
+}
+
+.usa-offset-one-sixth {
+  @include shift(2 of 12);
+}
+
+.usa-offset-one-fourth {
+  @include shift(3 of 12);
+}
+
+.usa-offset-one-third {
+  @include shift(4 of 12);
+}
+
+.usa-offset-five-twelfths {
+  @include shift(5 of 12);
+}
+
+.usa-offset-one-half {
+  @include shift(6 of 12);
+}
+
+.usa-offset-seven-twelfths {
+  @include shift(7 of 12);
+}
+
+.usa-offset-two-thirds {
+  @include shift(8 of 12);
+}
+
+.usa-offset-three-fourths {
+  @include shift(9 of 12);
+}
+
+.usa-offset-five-sixths {
+  @include shift(10 of 12);
+}
+
+.usa-offset-eleven-twelfths {
+  @include shift(11 of 12);
+}


### PR DESCRIPTION
## Description

I'm working on the sam.gov project with GSA. We needed offset classes that work with the grid. They should work like bootstrap offsets, so that when applied, the content within this class will be shifted x columns to the right. Neat provides the shift mixin to easily accomplish this.

This is a quick implementation that solves the particular needs of our project.

## Additional information

[Offset concept as implemented by Bootstrap](http://getbootstrap.com/css/#grid-offsetting)
