### PR TITLE
Run "npm publish", not just "publish"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "main": "src/js/start.js",
   "scripts": {
-    "check-publish": "publish",
+    "check-publish": "npm publish",
     "prepublish": "gulp copy-vendor-sass && gulp build",
     "prestart": "gulp copy-vendor-sass",
     "build:package": "gulp copy-vendor-sass && gulp release",


### PR DESCRIPTION
The last PR, #1731, [failed on Circle CI](https://circleci.com/gh/18F/web-design-standards/1211) because it couldn't find the `publish` command. This updates `package.json` to run `npm publish`. :crossed_fingers: 