### PR TITLE
Add comment about Bourbon and Neat Installation

### DIFF
--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -1,8 +1,9 @@
 /*! uswds @version */
 
+// As the notes below indicate, doing a 'standard' 'bourbon install' and 'neat install' well put the actual SCSS in it's own subdirectory.
 // Vendor -------------- //
-@import 'lib/bourbon';
-@import 'lib/neat';
+@import 'lib/bourbon'; // Most likely this would say: 'bourbon/bourbon'
+@import 'lib/neat'; // Most likely, this would be: 'neat/neat'
 @import 'lib/normalize';
 
 // Core -------------- //


### PR DESCRIPTION
As indicated in the basic instructions for both of these great libraries, doing a 'normal' setup *should* result in subdirectories being created, and, we would need to indicate this in our @import(s).

<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

Bourbon and Neat are usually installed to their own subdirectories, and the current import statements imply that they are just all thrown in together with lib/

This relatively minor fix just addresses the import directory structure.

Before you hit Submit, make sure you’ve done whichever of these applies to you:
