### PR TITLE
point branches section at release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,7 @@ This project follows the 18F Front End Guide [CSS](https://pages.18f.gov/fronten
 
 ## Our use of branches
 
-The `staging` branch is the bleeding edge of development. When cutting a new [release](https://github.com/18F/web-design-standards/releases), we update the versioning on our files by branching off of the `staging` branch and submitting a pull request into our `release` branch. This helps to make `staging` a place that can always receive contributions, no matter where we are in the release process. New commits to `staging` are automatically deployed to [our staging site](https://standards-staging.usa.gov/).
-
-The `master` branch always holds the latest production-ready release. When cutting a [release](https://github.com/18F/web-design-standards/releases), we create a release branch from `staging` named for the new version: for example, `v0.9.x`. Once we’ve completed QA on that branch, we tag the release and merge it into the `master` branch.
-
-The branches `18f-pages` and `18f-pages-staging` _used_ to be the primary release and development branches, back when the site was hosted on `pages.18f.gov`. Those branches still auto deploy to 18F Pages, but will now only contain minimal redirects to the new site.
+See the [release documentation](RELEASE.md#release-process) for more information on our git/GitHub release workflow.
 
 ## Licenses and attribution
 


### PR DESCRIPTION
This updates our contributing docs "Our use of branches" section to point at the release docs.