### PR TITLE
Fix errant .usa-nav height: 100%

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -40,7 +40,6 @@
   $sliding-panel-width: 26rem;
 
   @include position(fixed, 0 0 0 auto);
-  @include size($sliding-panel-width 100%);
   @include transform(translateX($sliding-panel-width));
 
   background: $color-white;
@@ -50,6 +49,7 @@
   flex-direction: column;
   overflow-y: auto;
   padding: 2rem;
+  width: $sliding-panel-width;
   z-index: $z-index-nav;
 
   @include media($nav-width) {


### PR DESCRIPTION
This is a fix for #1754 that replaces the call to our Sass `size()` mixin for our navigation at mobile screen widths (which sets both the width and height) with setting only `width`.

cc @mgwalker for visibility, and help testing with his use case