### PR TITLE
Template docs and gulp task tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ You can now use your copied version of `_variables.scss` to override any styles 
 `require('uswds')` will load all of the U.S. Web Design Standards’ JavaScript onto the page. Add this line to whatever initializer you use to load JavaScript into your application.
 
 #### Templates
-Templates are a way to include customizable HTML for your project. You can either use the pre-compiled version of the templates (`src/templates`) or the compiled version (`dist/html`). Both are part of the Standards `npm` package and what you use depends on whether or not your project uses dynamic templating (e.g. Jinja, Nunjucks). To see an example of how to compile these files, check out our [html gulp task](https://github.com/18F/web-design-standards/blob/develop/config/gulp/html.js).
+Templates are a way to include customizable HTML for your project. You can either use the [Nunjucks](https://mozilla.github.io/nunjucks/) templates in `src/templates` or the raw HTML files in `dist/html`. Both are part of the Standards `npm` package, and what you use depends on whether or not your project uses dynamic templating (e.g. Jinja, Nunjucks). Check out our [html gulp task](https://github.com/18F/web-design-standards/blob/develop/config/gulp/html.js) to see how we compile these into static HTML.
 
 You can find our basic HTML files by [downloading the latest package](https://github.com/18F/web-design-standards/releases/download/v1.0.0/uswds-1.0.0.zip) and looking inside of the `html` folder.
 

--- a/config/gulp/html.js
+++ b/config/gulp/html.js
@@ -5,7 +5,7 @@ var pkg = require('../../package.json');
 
 gulp.task('html', function (done) {
   return gulp.src([
-      'src/templates/*.html'
+      'src/templates/**/*.html'
     ])
     .pipe(nunjucks.compile({
       lang: 'en-US',


### PR DESCRIPTION
Two quick things:

1. I reworded the "Templates" section of the README to say:

    > Templates are a way to include customizable HTML for your project. You can either use the [Nunjucks](https://mozilla.github.io/nunjucks/) templates in `src/templates` or the raw HTML files in `dist/html`. Both are part of the Standards `npm` package, and what you use depends on whether or not your project uses dynamic templating (e.g. Jinja, Nunjucks). Check out our [html gulp task](https://github.com/18F/web-design-standards/blob/develop/config/gulp/html.js) to see how we compile these into static HTML.

1. I changed the source glob for our `html` gulp task from `src/templates/*.html` to `src/templates/**/*.html` so that we can organize our templates (e.g. with `components` and `page-templates` subdirs) without having to change anything there.