### PR TITLE
Removing :first-child and :last-child margin for .usa-grid-full.

### DIFF
--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -248,7 +248,8 @@ dfn {
 // Removes top margin from first child and bottom margin from last child on
 // elements when they are within those layout elements.
 .usa-section,
-.usa-grid {
+.usa-grid,
+.usa-grid-full {
   > :first-child {
     margin-top: 0;
   }


### PR DESCRIPTION
Tested this on our docs site locally and everything looks good on the site, page templates demo. Would be good to take another visual walk through to double check and make sure this works 💯  before merging in. 

On another note, we'll need to be explicit about this change in whatever release this goes out with. 🚀 