### PR TITLE
Include `.usa-grid-full > :first-child` fix in 1.1.0 release

### DIFF
--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -209,7 +209,8 @@ dfn {
 // Removes top margin from first child and bottom margin from last child on
 // elements when they are within those layout elements.
 .usa-section,
-.usa-grid {
+.usa-grid,
+.usa-grid-full {
   > :first-child {
     margin-top: 0;
   }


### PR DESCRIPTION
This will include @juliaelman's fix for #1773 and #1768 in the 1.1.0 release.