### PR TITLE
Refactor accordion logic; fix nested button events

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -24,13 +24,21 @@ function showPanelListener (el, ev) {
   return false;
 }
 
-function getTargetOf (button) {
-  var id = button.getAttribute('aria-controls');
+/**
+ * @name getTargetOf
+ * @desc Get the target of an element, according to the id listed in its
+ * `aria-controls` attribute.
+ * @param {HTMLElement} source the source element
+ * @return {Element} the target element
+ * @throws {Error} an error is thrown if no such target exists
+ */
+function getTargetOf (source) {
+  var id = source.getAttribute('aria-controls');
   var target = document.getElementById(id);
   if (target) {
     return target;
   } else {
-    throw new Error('No accordion button target with id "' + id + '" exists');
+    throw new Error('No accordion target with id "' + id + '" exists');
   }
 }
 

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -1,13 +1,8 @@
 'use strict';
 var select = require('../utils/select');
 
-var SELECTOR_BUTTON = 'ul > li > button, .usa-accordion-button';
-var SELECTOR_BUTTON_EXPANDED = SELECTOR_BUTTON
-  .split(', ')
-  .map(function (selector) {
-    return selector + '[aria-expanded=true]';
-  })
-  .join(', ');
+var SELECTOR_BUTTON = 'button.usa-accordion-button';
+var SELECTOR_BUTTON_EXPANDED = SELECTOR_BUTTON + '[aria-expanded=true]';
 
 /**
  * @name showPanelListener

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -88,12 +88,12 @@ Accordion.prototype.$ = function (selector) {
 
 /**
  * @param {HTMLElement} button
- * @return {Accordion}
+ * @param {Boolean} expanded
  */
-Accordion.prototype.hide = function (button) {
+Accordion.prototype.toggle = function (button, expanded) {
   var target = getTargetOf(button);
-  button.setAttribute('aria-expanded', false);
-  target.setAttribute('aria-hidden', true);
+  button.setAttribute('aria-expanded', expanded);
+  target.setAttribute('aria-hidden', !expanded);
   return this;
 };
 
@@ -101,11 +101,16 @@ Accordion.prototype.hide = function (button) {
  * @param {HTMLElement} button
  * @return {Accordion}
  */
+Accordion.prototype.hide = function (button) {
+  return this.toggle(button, false);
+};
+
+/**
+ * @param {HTMLElement} button
+ * @return {Accordion}
+ */
 Accordion.prototype.show = function (button) {
-  var target = getTargetOf(button);
-  button.setAttribute('aria-expanded', true);
-  target.setAttribute('aria-hidden', false);
-  return this;
+  return this.toggle(button, true);
 };
 
 /**


### PR DESCRIPTION
This is a slight refactoring of our accordion JavaScript intended to fix #1762. Specifically:

* Introduce common variables for the CSS selectors used to query for accordion button elements.
* Make DRY the accordion's `show()` and `hide()` methods, which both now rely on a single function to get the "target" of a clicked button via the `aria-controls` attribute.
* Add a `select()` method, the equivalent of `querySelector()`, to make instances of `this.$(selector)[ 0 ]` more readable.