### PR TITLE
Removing the 18F Dashboard

### DIFF
--- a/WHO_IS_USING_USWDS.md
+++ b/WHO_IS_USING_USWDS.md
@@ -2,7 +2,6 @@
 
 Below are a list of website and applications currently using the U.S. Web Design Standards. If your project is currently using the Standards and you do not see it on this list, please feel free to submit a pull request or email the core team at uswebdesignstandards@gsa.gov.
 
-- [18F dashboard](http://federalist.18f.gov.s3-website-us-east-1.amazonaws.com/site/18f/discover-our-work/)
 - [18F Micropurchasing](https://micropurchase.18f.gov/)
 - [18F](https://18f.gsa.gov)
 - [Access NYC](https://access.nyc.gov/)


### PR DESCRIPTION
The Dashboard is no longer live or supported.