### PR TITLE
Document what code coverage means to us

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,17 @@ The purpose of our coding styleguides are to create consistent coding practices 
 
 This project follows the 18F Front End Guide [CSS](https://pages.18f.gov/frontend/#css) and [JavaScript](https://pages.18f.gov/frontend/#javascript). Please use this guide for your reference.
 
+### Code coverage
+
+We use [code coverage](https://en.wikipedia.org/wiki/Code_coverage) tools to understand how much of our JavaScript is tested by our [unit test suite](spec/unit). Code coverage is one way (among many) of measuring code _quality_ more generally. Here's how it works for contributions:
+
+1. Each pull request creates a new coverage report on [Code Climate](https://codeclimate.com/).
+1. Code Climate then posts a status message back to GitHub that lists the coverage percentage on that branch, and the difference between that number and the one last reported on our default branch.
+
+For JavaScript contributions, we will review the code coverage percentage and change to ensure that the quality of our code is not dramatically affected.
+
+High code coverage numbers are generally good, and we would prefer that our coverage increases over time. We will not categorically reject contributions that reduce code coverage, but we may ask contributors to refactor their code, add new unit tests, or modify existing tests to avoid significant reductions in coverage.
+
 ## Our use of branches
 
 See the [release documentation](RELEASE.md#release-process) for more information on our git/GitHub release workflow.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # U.S. Web Design Standards
 
-[![CircleCI Build Status](https://circleci.com/gh/18F/web-design-standards/tree/develop.svg?style=shield)](https://circleci.com/gh/18F/web-design-standards/tree/develop)
+[![CircleCI Build Status](https://circleci.com/gh/18F/web-design-standards/tree/develop.svg?style=shield)](https://circleci.com/gh/18F/web-design-standards/tree/develop) [![Test Coverage](https://codeclimate.com/github/18F/web-design-standards/badges/coverage.svg)](https://codeclimate.com/github/18F/web-design-standards/coverage)
 
 The [U.S. Web Design Standards](https://standards.usa.gov) include a library of open source UI components and a visual style guide for U.S. federal government websites.
 


### PR DESCRIPTION
Fixes #1704:

1. Add the Code Climate badge to [README](https://github.com/18F/web-design-standards/tree/docs-code-coverage/README.md).
1. Add "Code coverage" section to [CONTRIBUTING](https://github.com/18F/web-design-standards/tree/docs-code-coverage/CONTRIBUTING.md#code-coverage).