### PR TITLE
Fixing accordion nested lists

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -81,6 +81,7 @@ $accordion-border: 3px solid $color-gray-lightest;
     // TODO deprecated ruleset based on old accordion.
     > li {
       @include accordion-list-item-styles;
+
     }
 
     // TODO deprecated ruleset based on old accordion.
@@ -96,6 +97,10 @@ $accordion-border: 3px solid $color-gray-lightest;
 
   > li {
     @include accordion-list-item-styles;
+  }
+
+  > ul li ul {
+    list-style-type: disc;
   }
 
 }

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -65,6 +65,10 @@ $accordion-border: 3px solid $color-gray-lightest;
   background-size: 1.3rem;
 }
 
+@mixin accordion-nested-list {
+  list-style-type: disc;
+}
+
 .usa-accordion,
 .usa-accordion-bordered {
   @include accordion-list-styles;
@@ -99,8 +103,8 @@ $accordion-border: 3px solid $color-gray-lightest;
     @include accordion-list-item-styles;
   }
 
-  > ul li ul {
-    list-style-type: disc;
+  > ul ul {
+    @include accordion-nested-list;
   }
 
 }

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -85,7 +85,6 @@ $accordion-border: 3px solid $color-gray-lightest;
     // TODO deprecated ruleset based on old accordion.
     > li {
       @include accordion-list-item-styles;
-
     }
 
     // TODO deprecated ruleset based on old accordion.

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -66,12 +66,21 @@ $accordion-border: 3px solid $color-gray-lightest;
 }
 
 @mixin accordion-nested-list {
-  list-style-type: disc;
+  > ul li ul {
+    list-style: disc ;
+    > li > ul {
+      list-style: circle;
+      > li > ul {
+        list-style: square;
+      }
+    }
+  }
 }
 
 .usa-accordion,
 .usa-accordion-bordered {
   @include accordion-list-styles;
+  @include accordion-nested-list;
 
   + .usa-accordion,
   + .usa-accordion-bordered {
@@ -100,10 +109,6 @@ $accordion-border: 3px solid $color-gray-lightest;
 
   > li {
     @include accordion-list-item-styles;
-  }
-
-  > ul ul {
-    @include accordion-nested-list;
   }
 
 }

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -67,7 +67,7 @@ $accordion-border: 3px solid $color-gray-lightest;
 
 @mixin accordion-nested-list {
   > ul li ul {
-    list-style: disc ;
+    list-style: disc;
     > li > ul {
       list-style: circle;
       > li > ul {


### PR DESCRIPTION
fixes #1719 

If an unordered list was created inside an accordion element it would receive the 2nd tier `list-style` because the accordion itself was a `<ul>`

![screen shot 2017-04-03 at 12 46 52 pm](https://cloud.githubusercontent.com/assets/776987/24622982/87f7e55a-186c-11e7-9d85-f8bae52cde38.png)