### PR TITLE
Add support for .usa-current in header navigation

### DIFF
--- a/config/gulp/template-data.js
+++ b/config/gulp/template-data.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var fakeLink = function (text) {
+var fakeLink = function (text, current) {
   return {
     text: text,
     href: 'javascript:void(0)',
+    current: current || false
   };
 };
 
@@ -40,10 +41,7 @@ module.exports = {
             fakeLink('Page six'),
           ],
         },
-        {
-          text: 'Distinct from one another',
-          href: 'javascript:void(0)',
-        },
+        fakeLink('Distinct from one another', true),
       ],
     },
     secondary: {
@@ -52,7 +50,7 @@ module.exports = {
       },
       links: [
         fakeLink('Secondary priority link'),
-        fakeLink('Easy to comprehend'),
+        fakeLink('Easy to comprehend', true),
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preversion": "npm test",
     "version": "npm run prepublish",
     "watch": "watch 'npm run build' ./src",
-    "federalist": "gulp build"
+    "federalist": "npm i --dev && gulp build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preversion": "npm test",
     "version": "npm run prepublish",
     "watch": "watch 'npm run build' ./src",
-    "federalist": "npm i --dev && gulp build"
+    "federalist": "gulp build"
   },
   "repository": {
     "type": "git",
@@ -59,18 +59,20 @@
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",
     "gulp-zip": "^3.1.0",
-    "istanbul": "^0.4.5",
     "jquery": "^2.2.0",
-    "jsdom": "^9.0.0",
-    "jsdom-global": "^2.1.0",
-    "mocha": "^2.4.5",
     "node-notifier": "^4.6.0",
     "node-sass": "^3.4.2",
     "normalize.css": "^3.0.3",
     "run-sequence": "^1.1.5",
     "should": "^8.3.1",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0",
+    "vinyl-source-stream": "^1.1.0"
+  },
+  "devDependencies": {
+    "istanbul": "^0.4.5",
+    "jsdom": "^9.0.0",
+    "jsdom-global": "^2.1.0",
+    "mocha": "^2.4.5",
     "watch": "^0.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,16 +34,13 @@
   },
   "homepage": "https://github.com/18F/web-design-standards#readme",
   "dependencies": {
+    "@18f/stylelint-rules": "^1.2.0",
+    "lodash.debounce": "^4.0.7",
     "bourbon": "^4.2.6",
     "bourbon-neat": "https://github.com/thoughtbot/neat/archive/neat-1.8.0-node-sass.tar.gz",
+    "browserify": "^13.0.0",
     "classlist-polyfill": "^1.0.3",
     "cross-spawn": "^2.1.5",
-    "lodash.debounce": "^4.0.7",
-    "normalize.css": "^3.0.3"
-  },
-  "devDependencies": {
-    "@18f/stylelint-rules": "^1.2.0",
-    "browserify": "^13.0.0",
     "del": "^2.2.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
@@ -69,6 +66,7 @@
     "mocha": "^2.4.5",
     "node-notifier": "^4.6.0",
     "node-sass": "^3.4.2",
+    "normalize.css": "^3.0.3",
     "run-sequence": "^1.1.5",
     "should": "^8.3.1",
     "vinyl-buffer": "^1.0.0",

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -203,6 +203,17 @@
       }
     }
   }
+
+  @include media($nav-width) {
+    a.usa-current {
+      // undo the sidenav style
+      border-left: 0;
+
+      span {
+        @include nav-border;
+      }
+    }
+  }
 }
 
 // Secondary navigation ----------- //

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -205,7 +205,7 @@
   }
 
   @include media($nav-width) {
-    a.usa-current {
+    a.usa-current { // stylelint-disable-line selector-no-qualifying-type
       // undo the sidenav style
       border-left: 0;
       padding-left: 1rem;
@@ -289,7 +289,7 @@
   }
 
   @include media($nav-width) {
-    a.usa-current {
+    a.usa-current { // stylelint-disable-line selector-no-qualifying-type
       // undo the sidenav style
       border-left: 0;
       padding-left: 0;

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -208,6 +208,7 @@
     a.usa-current {
       // undo the sidenav style
       border-left: 0;
+      padding-left: 1rem;
 
       span {
         @include nav-border;
@@ -284,6 +285,14 @@
       @include media($nav-width) {
         display: none;
       }
+    }
+  }
+
+  @include media($nav-width) {
+    a.usa-current {
+      // undo the sidenav style
+      border-left: 0;
+      padding-left: 0;
     }
   }
 }

--- a/src/templates/nav-primary.html
+++ b/src/templates/nav-primary.html
@@ -16,7 +16,7 @@
       {% endfor %}
     </ul>
     {% else %}
-    <a class="usa-nav-link" href="{{ link.href }}">
+    <a class="usa-nav-link{% if link.current %} usa-current{% endif %}" href="{{ link.href }}">
       <span>{{ link.text }}</span>
     </a>
     {% endif %}

--- a/src/templates/nav-secondary.html
+++ b/src/templates/nav-secondary.html
@@ -12,7 +12,9 @@
     {% endif %}
     {% for link in nav.links %}
     <li>
-      <a href="{{ link.href }}">{{ link.text }}</a>
+      <a href="{{ link.href }}"{% if link.current %} class="usa-current"{% endif %}>
+        {{ link.text }}
+      </a>
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
Fixes #1833.

This PR adds explicit support for the `usa-current` class on links in `.usa-nav-primary` and `.usa-nav-secondary` scopes by removing the left-hand border. Current primary nav links get a permanent underline (a la `:hover`), and secondary nav links are bolded blue. For testing purposes, I've made the last links in both navigation lists "current" in the page templates:

![image](https://cloud.githubusercontent.com/assets/113896/24729578/c0869be8-1a13-11e7-95cc-ca1da2c5302c.png)

When collapsed on smaller screens, they look like the side nav:

![image](https://cloud.githubusercontent.com/assets/113896/24729835/ea2df83c-1a14-11e7-9a02-1ce8cd238ced.png)

#### Previews:
* [landing page](https://federalist.fr.cloud.gov/preview/18f/web-design-standards/feature-primary-nav-current/html/page-landing.html)
* [docs page](https://federalist.fr.cloud.gov/preview/18f/web-design-standards/feature-primary-nav-current/html/page-docs.html)

Also in this PR is a reorganization of `package.json` needed to get our builds working on Federalist again. Now, basically every npm dependency is a "production" dependency (because Federalist runs `npm install --only=production`, which excludes dev deps), and our only _true_ dev dependencies are those not required to build the distribution: unit testing, code coverage, and watch utilities.