### PR TITLE
Add coverage and build dirs to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,10 @@
-# Ensure that src and dist are published   
-#   
-!dist/    
+# Ensure that src and dist are published
+!dist/
 !src/
 
+build/
 config/
+coverage/
 spec/
 .github/
 .editorconfig


### PR DESCRIPTION
This is a v1.1.0 release patch that we should merge into `develop` as well. It adds the `build` (Fractal output) and `coverage` (code coverage) directories to `.npmignore` so that they won't be published.