### PR TITLE
Update text max-width to ch (character) units

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -8,7 +8,7 @@
 // own partials, then @import '{path/to/uswds/}core/variables'.
 
 // Typography
-// Removing the !default from $em-base so we are not inheriting that 
+// Removing the !default from $em-base so we are not inheriting that
 // value from Bourbon.
 $em-base:             10px;
 $base-font-size:      rem(17px) !default;
@@ -106,7 +106,7 @@ $image-path:  '../img' !default;
 $asset-pipeline:      false !default;
 
 // Magic Numbers
-$text-max-width:      53rem !default;
+$text-max-width:      66ch !default; // 66 characters comfortable reading length
 $lead-max-width:      77rem !default;
 $site-max-width:      1040px !default;
 $site-margins:        3rem !default;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -106,7 +106,7 @@ $image-path:  '../img' !default;
 $asset-pipeline:      false !default;
 
 // Magic Numbers
-$text-max-width:      66ch !default; // 66 characters comfortable reading length
+$text-max-width:      66ch !default; // 66 characters optimal reading length
 $lead-max-width:      77rem !default;
 $site-max-width:      1040px !default;
 $site-margins:        3rem !default;

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -118,10 +118,6 @@ dfn {
   }
 }
 
-.usa-content-list {
-  max-width: $text-max-width;
-}
-
 .usa-sans {
   p,
   a,

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -112,7 +112,8 @@ dfn {
 // Custom typography
 
 .usa-content {
-  p {
+  p,
+  > ul {
     max-width: $text-max-width;
   }
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -112,9 +112,7 @@ dfn {
 // Custom typography
 
 .usa-content {
-  p:not(.usa-font-lead) {
-    max-width: $text-max-width;
-  }
+  max-width: $text-max-width;
 }
 
 .usa-content-list {

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -112,7 +112,9 @@ dfn {
 // Custom typography
 
 .usa-content {
-  max-width: $text-max-width;
+  p {
+    max-width: $text-max-width;
+  }
 }
 
 .usa-content-list {


### PR DESCRIPTION
## Description

Uses character units for text max-width. Removes unneeded `p:not(.usa-font-lead)` declaration. 

Fixes #1866.