### PR TITLE
Add pre-release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,15 +67,16 @@ example, any of the following should trigger a major version increment:
 
     1. Branch off `develop`:
   
-      ```sh
-      git fetch origin
-      git checkout -b feature-foo origin/develop
-      ```
+        ```sh
+        git fetch origin
+        git checkout -b feature-foo origin/develop
+        ```
       
-    1. As a naming convention, your branch name can be anything except `master`,
-       `develop`, or with the `release-` or `hotfix-` prefix
+    1. Name your branch pretty much anything except `master`, `develop`, or
+       with the `release-` or `hotfix-` prefix. Suggested prefixes include
+       `refactor-`, `feature-`, `docs-`, and `patch-`.
 
-    1. Changes are merged back into the `develop` branch
+    1. File your pull request to merge into the `develop` branch.
   
 * When publishing a new release:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -201,4 +201,4 @@ If you need help or have any questions, please reach out to us:
 [uswds on npm]: https://npmjs.com/package/uswds
 [what is npm]: https://docs.npmjs.com/getting-started/what-is-npm
 [Slack]: https://slack.com/
-[release candidate]: https://en.wikipedia.org/wiki/Software_release_life_cycle#Release_candidate
+[release candidates]: https://en.wikipedia.org/wiki/Software_release_life_cycle#Release_candidate

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,10 +7,11 @@ Standards](https://standards.usa.gov).
 ## Table of contents
 1. [Principles](#principles)
 1. [Versioning](#versioning)
-  1. [What is a release?](#what-is-a-release)
-  1. [The public API](#the-public-api)
+    1. [What is a release?](#what-is-a-release)
+    1. [The public API](#the-public-api)
 1. [Release process](#release-process)
-  1. [Git(/Hub) workflow](#git-workflow)
+    1. [Git(/Hub) workflow](#git-workflow)
+    1. [Pre-releases](#pre-releases)
 1. [Questions?](#questions)
 
 
@@ -58,88 +59,128 @@ example, any of the following should trigger a major version increment:
 ### Git workflow
 
 * We have two main branches that are never deleted:
-  * `master` always points to the latest release
-  * `develop` contains changes being prepped for a release
+
+    * `master` always points to the latest release
+    * `develop` contains changes being prepped for a release
 
 * When introducing a change (feature, bug fix, etc.):
 
-  1. Branch off `develop`:
+    1. Branch off `develop`:
   
       ```sh
       git fetch origin
       git checkout -b feature-foo origin/develop
       ```
       
-  1. As a naming convention, your branch name can be anything except `master`,
-     `develop`, or with the `release-` or `hotfix-` prefix
+    1. As a naming convention, your branch name can be anything except `master`,
+       `develop`, or with the `release-` or `hotfix-` prefix
 
-  1. Changes are merged back into the `develop` branch
+    1. Changes are merged back into the `develop` branch
   
 * When publishing a new release:
 
-  1. Branch off `develop` and use the branch name format `release-{version}`,
-     e.g.
+    1. Branch off `develop` and use the branch name format `release-{version}`,
+       e.g.
 
-      ```sh
-      git fetch origin
-      git checkout -b release-1.0.0 origin/develop
-      ```
+        ```sh
+        git fetch origin
+        git checkout -b release-1.0.0 origin/develop
+        ```
 
-  1. Run [`npm version`][npm version] with `--no-tag` to increment the version
-     number semantically. (Versions are tagged on the `master` branch.)
+    1. Run [`npm version`][npm version] with `--no-tag` to increment the version
+       number semantically. (Versions are tagged on the `master` branch.)
      
-    * For minor and major versions, publish a pre-release:
-  
+        * For minor and major versions, publish a pre-release:
+
+            ```sh
+            npm version prerelease --no-tag
+            ```
+
+        * Otherwise, run either `npm version minor --no-tag` or `npm version major
+          --no-tag`
+
+        * In either case, [`npm version`][npm version] will increment the version
+          number in `package.json` and commit the changes to git.
+
+    1. Open a [pull request] from your `release-` branch to merge into `master`.
+       List the key changes for a release in the pull request description. (The
+       diff will show you exactly what has changed since the previous release.)
+       See [the v1.0.0 pull request](https://github.com/18F/web-design-standards/pull/1726)
+       for an example.
+
+    1. Tag the release on the `master` branch **or** create the tag when you
+       draft the release notes.
+
+    1. Merge the release commits back into `develop` from `master` with a [pull
+       request].
+
+    1. Write the release notes on GitHub:
+
+        1. [Draft the release][draft release] from the corresponding tag on the
+           `master` branch.
+
+        1. Have at least one team member review the release notes.
+
+        1. Publish the [release](https://github.com/18F/web-design-standards/releases)
+           on GitHub.
+
+    1. Update the docs site with the new version number and release notes:
+
+        1. Update the `uswds` Node dependency to the new version, e.g.:
+
+            ```sh
+            cd path/to/web-design-standards-docs
+            export VERSION=1.0.0
+            git fetch origin
+            git checkout -b release-${VERSION} origin/develop
+            npm install --save-dev uswds@${VERSION}
+            ```
+
+        1. Update the `version` [variable in
+           _config.yml](https://github.com/18F/web-design-standards-docs/blob/master/_config.yml#L3).
+
+        1. Follow the above release process to merge the changes to `master` via a
+           [pull request on the docs repo](https://github.com/18F/web-design-standards-docs/compare),
+           minus the GitHub release notes.
+
+### Pre-releases
+
+When releasing potentially disruptive changes, it's good practice to publish pre-releases of
+planned versions. These are sometimes also called [release candidates]. Here's how it works:
+
+1. Create a new branch from the release branch (`release-X.Y.Z`) with an additional
+   [pre-release identifier](http://semver.org/#spec-item-9), such as `release-1.1.0-pre`,
+   `release-1.1.0-alpha`, `release-1.1.0-rc1`.
+   
+1. Follow the [release process](#git-workflow) for your pre-release branch, with the following
+   modifications:
+   
+   * Publish to npm with a [dist-tag](https://docs.npmjs.com/cli/dist-tag), e.g.
+   
       ```sh
-      npm version prerelease --no-tag
+      npm version 1.1.0-pre
+      npm publish --tag dev
       ```
       
-    * Otherwise, run either `npm version minor --no-tag` or `npm version major
-      --no-tag`
-
-    * In either case, [`npm version`][npm version] will increment the version
-      number in `package.json` and commit the changes to git.
-
-  1. Open a [pull request] from your `release-` branch to merge into `master`.
-     List the key changes for a release in the pull request description. (The
-     diff will show you exactly what has changed since the previous release.)
-     See [the v1.0.0 pull request](#TODO) for an example.
-
-  1. Tag the release on the `master` branch **or** create the tag when you
-     draft the release notes.
-
-  1. Merge the release commits back into `develop` from `master` with a [pull
-     request].
-
-  1. Write the release notes on GitHub:
-
-    1. [Draft the release][draft release] from the corresponding tag on the
-       `master` branch.
-
-    1. Have at least one team member review the release notes.
-
-    1. Publish the [release](https://github.com/18F/web-design-standards/releases)
-       on GitHub.
-
-  1. Update the docs site with the new version number and release notes:
-
-    1. Update the `uswds` Node dependency to the new version, e.g.:
-
+   * Mark the GitHub release as a "pre-release", and be sure to note how long you intend on
+     waiting for show-stopping bug reports before proceeding with the release.
+     
+   * Include instructions for installing the pre-release from npm with the dist-tag, e.g.:
+   
       ```sh
-      cd path/to/web-design-standards-docs
-      export VERSION=1.0.0
-      git fetch origin
-      git checkout -b release-${VERSION} origin/develop
-      npm install --save-dev uswds@${VERSION}
+      npm install --save uswds@dev
       ```
-
-    1. Update the `version` [variable in
-       _config.yml](https://github.com/18F/web-design-standards-docs/blob/master/_config.yml#L3).
-
-    1. Follow the above release process to merge the changes to `master` via a
-       [pull request on the docs repo](https://github.com/18F/web-design-standards-docs/compare),
-       minus the GitHub release notes.
-
+      
+   * Directly notify users who may be impacted by the proposed changes, and encourage
+     them to alert us of any new issues within the prescribed testing period.
+     
+1. If you receive reports of any regressions (specifically, **new issues** introduced in
+   the release), you can decide whether to address them in another pre-release or file
+   them for the next official release. If you decide to move proceed with the release,
+   it's good practice to alert users of the issue in your release notes, preferably with
+   a `:warning:` emoji or similar.
+   
+1. Otherwise, proceed with the next versioned release!
 
 ## Questions?
 If you need help or have any questions, please reach out to us:
@@ -159,3 +200,4 @@ If you need help or have any questions, please reach out to us:
 [uswds on npm]: https://npmjs.com/package/uswds
 [what is npm]: https://docs.npmjs.com/getting-started/what-is-npm
 [Slack]: https://slack.com/
+[release candidate]: https://en.wikipedia.org/wiki/Software_release_life_cycle#Release_candidate


### PR DESCRIPTION
This adds [pre-release instructions](https://github.com/18F/web-design-standards/blob/docs-prerelease/RELEASE.md#pre-releases) to our release document, and fixes a couple of other things there:

1. Some nested list formatting was off because I indented them with 2 spaces rather than 4. 😬 
1. I added the link to our 1.0.0 PR where there was a `#TODO`.

Fixes #1883.