### PR TITLE
updating lists and alerts when used in content body

### DIFF
--- a/src/components/alerts/alerts.njk
+++ b/src/components/alerts/alerts.njk
@@ -34,3 +34,9 @@
     </div>
   </div>
 
+  <div class="usa-alert usa-alert-info usa-alert-paragraph">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading">Information Status - Paragraph Width</h3>
+      <p class="usa-alert-text">Multi line. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui atione voluptatem sequi nesciunt. Neque porro quisquam est, qui doloremipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+    </div>
+  </div>

--- a/src/components/labels/labels.njk
+++ b/src/components/labels/labels.njk
@@ -1,7 +1,5 @@
+<h6>Small</h6>
+<span class="usa-label">New</span>
 
-  <h6>Small</h6>
-  <span class="usa-label">New</span>
-
-  <h6>Large</h6>
-  <span class="usa-label-big">New</span>
-
+<h6>Large</h6>
+<span class="usa-label-big">New</span>

--- a/src/components/test/kitchen-sink.config.yml
+++ b/src/components/test/kitchen-sink.config.yml
@@ -5,6 +5,11 @@ context:
   page:
     title: This is your page title
     lead: The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.
+    body: This is the content body where we will test some ordered and unordered lists. Just long enough to wrap to a new line to test content width.
+    lists:
+      - This is a very long sentence that should go to a new line when it is among other pieces of paragraph text.
+      - This is a short sentence that isn't long enough to go to a new line.
+      - This is the third sentence.
 
   before:
     - component: hero

--- a/src/components/test/kitchen-sink.config.yml
+++ b/src/components/test/kitchen-sink.config.yml
@@ -31,9 +31,37 @@ context:
       - text: Yet another page
 
   inner:
-    - title: Accordions
+    - title: Accordions - Borderless
       id: accordions
       component: accordion
+    - title: Accordions - Bordered
+      id: accordions-bordered
+      component: accordion--bordered
+      context:
+        accordion:
+          variant: bordered
+          items:
+            - title: First Amendment
+              id: b1
+              expanded: true
+              content: |
+                Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+            - title: Second Amendment
+              id: b2
+              content: |
+                A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+            - title: Third Amendment
+              id: b3
+              content: |
+                No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+            - title: Fourth Amendment
+              id: b4
+              content: |
+                The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
+            - title: Fifth Amendment
+              id: b5
+              content: |
+                No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
 
   after:
     - component: graphic-list

--- a/src/components/test/kitchen-sink.njk
+++ b/src/components/test/kitchen-sink.njk
@@ -16,6 +16,22 @@
 
       <p class="usa-font-lead">{{ page.lead }}</p>
 
+      <p class="usa-content">
+        {{ page.body }}
+        
+          <ul>
+          {% for list in page.lists %}
+            <li>{{ list }}</li>
+          {% endfor %}
+          </ul>
+
+          <ol>
+          {% for list in page.lists %}
+            <li>{{ list }}</li>
+          {% endfor %}
+        </ol>
+      </p>
+
       {% for spec in inner %}
       <section id="{{ spec.id }}">
         <h2>{{ spec.title }}</h2>

--- a/src/components/test/kitchen-sink.njk
+++ b/src/components/test/kitchen-sink.njk
@@ -18,7 +18,7 @@
 
       <p class="usa-content">
         {{ page.body }}
-        
+
         <ul>
         {% for list in page.lists %}
           <li>{{ list }}</li>
@@ -38,7 +38,7 @@
         {% if spec.include %}
           {% include spec.include %}
         {% elseif spec.component %}
-          {% render '@' + spec.component, spec.context, true %}
+          {% render '@' + spec.component, spec.context, spec.merge %}
         {% else %}
           {{ spec.content }}
         {% endif %}

--- a/src/components/test/kitchen-sink.njk
+++ b/src/components/test/kitchen-sink.njk
@@ -19,16 +19,16 @@
       <p class="usa-content">
         {{ page.body }}
         
-          <ul>
-          {% for list in page.lists %}
-            <li>{{ list }}</li>
-          {% endfor %}
-          </ul>
+        <ul>
+        {% for list in page.lists %}
+          <li>{{ list }}</li>
+        {% endfor %}
+        </ul>
 
-          <ol>
-          {% for list in page.lists %}
-            <li>{{ list }}</li>
-          {% endfor %}
+        <ol>
+        {% for list in page.lists %}
+          <li>{{ list }}</li>
+        {% endfor %}
         </ol>
       </p>
 

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -46,6 +46,10 @@ $alerts: map-merge($usa-alerts, $usa-custom-alerts);
   p:first-child {
     margin-top: 0.8rem;
   }
+
+  p:last-child {
+    margin-bottom: 0.8rem;
+  }
 }
 
 .usa-alert-heading {

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -25,6 +25,7 @@ $alerts: map-merge($usa-alerts, $usa-custom-alerts);
   ul {
     margin-bottom: 0;
     margin-top: 1em;
+    padding-left: 1em;
   }
 }
 
@@ -72,4 +73,9 @@ $alerts: map-merge($usa-alerts, $usa-custom-alerts);
 
 .usa-alert-no_icon {
   background-image: none;
+}
+
+.usa-alert-paragraph {
+  width: $text-max-width;
+  padding: 1em 3em 1em 1em;
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -113,8 +113,8 @@ dfn {
 
 .usa-content {
   p:not(.usa-font-lead),
-  ol,
-  ul {
+  ul:not(.usa-accordion):not(.usa-accordion-bordered),
+  ol:not(.usa-accordion):not(.usa-accordion-bordered) {
     max-width: $text-max-width;
   }
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -112,7 +112,9 @@ dfn {
 // Custom typography
 
 .usa-content {
-  p:not(.usa-font-lead) {
+  p:not(.usa-font-lead),
+  ol,
+  ul {
     max-width: $text-max-width;
   }
 }


### PR DESCRIPTION
### [:eyes: Preview on Federalist](https://federalist.fr.cloud.gov/preview/18f/web-design-standards/list-alerts-formatting/components/detail/alerts.html)

fixes #1924 

These were mostly done to fix things on the new performance pages in the docs. The added alert class can be used for alerts that show up in the middle of paragraphs (as opposed to spanning the top of a page).

This change could be considered breaking for users who intend for lists in `usa-content` to span the entire page so we may want to move it to the docs codebase until it can be packaged with a release. 