### PR TITLE
Add "engines" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "uswds",
   "version": "1.2.0",
   "description": "Open source UI components and visual style guide for U.S. government websites",
+  "engines": {
+    "node": ">= 4"
+  },
   "main": "dist/js/uswds.min.js",
   "jsnext:main": "src/js/start.js",
   "scripts": {


### PR DESCRIPTION
This states our preferred Node.js version to be 4 or greater, which:

1. Will warn users if they install via npm or Yarn on an older version of Node.js
1. Provides compatibility with other apps that bundle our JS using [babel-preset-env](https://github.com/18F/web-design-standards/issues/1938) (related: #1938)