### PR TITLE
Alerts: Fix color contrast A11y of links

### DIFF
--- a/src/components/alerts/alerts.njk
+++ b/src/components/alerts/alerts.njk
@@ -2,28 +2,28 @@
   <div class="usa-alert usa-alert-success">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Success Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-warning">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Warning Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-error" role="alert">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Error Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-info">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Information Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 

--- a/src/components/alerts/alerts.njk
+++ b/src/components/alerts/alerts.njk
@@ -2,28 +2,28 @@
   <div class="usa-alert usa-alert-success">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Success Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-warning">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Warning Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-error" role="alert">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Error Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 
   <div class="usa-alert usa-alert-info">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Information Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="http://example.com">consectetur adipiscing</a> elit, sed do eiusmod.</p>
+      <p class="usa-alert-text">Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.</p>
     </div>
   </div>
 

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -22,6 +22,15 @@ $alerts: map-merge($usa-alerts, $usa-custom-alerts);
     background-size: 5.2rem;
   }
 
+  a {
+    color: $color-primary-darker;
+
+    &:focus,
+    &:hover {
+      color: $color-primary-darkest;
+    }
+  }
+
   ul {
     margin-bottom: 0;
     margin-top: 1em;


### PR DESCRIPTION
This addresses https://github.com/18F/web-design-standards/issues/1907, changing the link color within Alerts to the darker variation of the `primary` color, which meets WCAG2.0 AA.

![image](https://cloud.githubusercontent.com/assets/371943/26596635/65dfb3c8-453d-11e7-866b-33dfcf4ab4e3.png)
