### PR TITLE
Fix code of conduct URL in CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We’re so glad you’re thinking about contributing to an 18F open source project! If you’re unsure about anything, just ask — or submit your issue or pull request anyway. The worst that can happen is we’ll politely ask you to change something. We appreciate all friendly contributions.
 
-One of our goals is to ensure a welcoming environment for all contibutors to our projects. Our staff follows the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md), and all contributors should do the same.
+One of our goals is to ensure a welcoming environment for all contibutors to our projects. Our staff follows the [18F Code of Conduct](https://18f.gsa.gov/code-of-conduct/), and all contributors should do the same.
 
 We encourage you to read this project’s CONTRIBUTING policy (you are here), its [LICENSE](https://github.com/18F/web-design-standards/blob/develop/LICENSE.md), [README](https://github.com/18F/web-design-standards/blob/develop/README.md) and its [Workflow](https://github.com/18F/web-design-standards/wiki/Workflow) process.
 


### PR DESCRIPTION
This fixes #1974.

Unfortunately, the existing CoC link 404's for public contributors due to
the fact that the 18F/code-of-conduct repository is currently private.

For more details on this issue, see:

  https://github.com/18F/code-of-conduct/issues/4

This PR changes the link to point at 18F's publicly-visible copy of
the latest OGC-approved Code of Conduct, located at:

  https://18f.gsa.gov/code-of-conduct/

This page also contains a link to the CoC repository, so that
contributors can still comment on or suggest changes to it
there (well, at least it's once made public again).

It's assumed that once the new CoC becomes approved by OGC, the
aforementioned copy will be updated as needed, so the
link will still be accurate.
