### PR TITLE
Fixing search role div around search forms

### DIFF
--- a/spec/unit/navigation/template.html
+++ b/spec/unit/navigation/template.html
@@ -44,15 +44,15 @@
         </li>
       </ul>
       <div class="usa-nav-secondary">
-        <form class="usa-search usa-search-small js-search-form">
-          <div role="search">
+        <div role="search">
+          <form class="usa-search usa-search-small js-search-form">
             <label class="usa-sr-only" for="search-field-small">Search small</label>
             <input id="search-field-small" type="search" name="search">
             <button type="submit">
               <span class="usa-sr-only">Search</span>
             </button>
-          </div>
-        </form>
+          </form>
+        </div>
         <ul class="usa-unstyled-list usa-nav-secondary-links">
           <li class="js-search-button-container">
             <button class="usa-header-search-button js-search-button">Search</button>

--- a/spec/unit/search/template.html
+++ b/spec/unit/search/template.html
@@ -1,13 +1,13 @@
 <header>
-  <form class="usa-search usa-search-small js-search-form">
-    <div role="search">
+  <div role="search">
+    <form class="usa-search usa-search-small js-search-form">
       <label class="usa-sr-only" for="search-field-small">Search small</label>
       <input id="search-field-small" type="search" name="search">
       <button type="submit">
         <span class="usa-sr-only">Search</span>
       </button>
-    </div>
-  </form>
+    </form>
+  </div>
 
   <div class="js-search-button-container">
     <button class="usa-header-search-button js-search-button">Search</button>

--- a/src/components/search/search--header.njk
+++ b/src/components/search/search--header.njk
@@ -1,9 +1,9 @@
-<form class="usa-search usa-search-small{% if search_js %} js-search-form{% endif %}">
-  <div role="search">
+<div role="search">
+  <form class="usa-search usa-search-small{% if search_js %} js-search-form{% endif %}">
     <label class="usa-sr-only" for="search-field-small">Search small</label>
     <input id="search-field-small" type="search" name="search">
     <button type="submit">
       <span class="usa-sr-only">Search</span>
     </button>
-  </div>
-</form>
+  </form>
+</div>

--- a/src/components/search/search.njk
+++ b/src/components/search/search.njk
@@ -3,15 +3,15 @@
 
   <div class="usa-grid">
     <div class="usa-width-one-half">
-      <form class="usa-search usa-search-big">
-        <div role="search">
+      <div role="search">
+        <form class="usa-search usa-search-big">
           <label class="usa-sr-only" for="search-field-big">Search big</label>
           <input id="search-field-big" type="search" name="search">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
           </button>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
   </div>
 
@@ -19,15 +19,15 @@
 
   <div class="usa-grid">
     <div class="usa-width-one-half">
-      <form class="usa-search">
-        <div role="search">
+      <div role="search">
+        <form class="usa-search">
           <label class="usa-sr-only" for="search-field">Search medium</label>
           <input id="search-field" type="search" name="search">
           <button type="submit">
             <span class="usa-search-submit-text">Search</span>
           </button>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
   </div>
 
@@ -35,15 +35,14 @@
 
   <div class="usa-grid">
     <div class="usa-width-one-half">
-      <form class="usa-search usa-search-small">
-        <div role="search">
+      <div role="search">
+        <form class="usa-search usa-search-small">
           <label class="usa-sr-only" for="search-field-small">Search small</label>
           <input id="search-field-small" type="search" name="search">
           <button type="submit">
             <span class="usa-sr-only">Search</span>
           </button>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
   </div>
-


### PR DESCRIPTION
fixes #1654 

The div that gives a search field `role="search"` was inside the `<form>` element but it should wrap the form as referenced in #1654 