### PR TITLE
Actually use validator component.

### DIFF
--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -6,5 +6,6 @@ module.exports = {
   password:   require('./password'),
   search:     require('./search'),
   skipnav:    require('./skipnav'),
+  validator:  require('./validator'),
 };
 

--- a/src/js/components/password.js
+++ b/src/js/components/password.js
@@ -1,6 +1,5 @@
 'use strict';
 const behavior = require('../utils/behavior');
-const validate = require('../utils/validate-input');
 const toggleFormInput = require('../utils/toggle-form-input');
 
 const CLICK = require('../events').CLICK;
@@ -16,8 +15,5 @@ const toggle = function (event) {
 module.exports = behavior({
   [ CLICK ]: {
     [ LINK ]: toggle,
-  },
-  'keyup change': {
-    '.js-validate_password': validate,
   },
 });


### PR DESCRIPTION
This is an attempt to fix #1990.

Because I'm very unfamiliar with the USWDS codebase, though, I'm _probably_ doing something wrong here.

It seems #1990 was occurring because `components/password.js` was attaching the `validate` function to a key event handler; it was being passed a keyboard event, but expected an HTML element, which is why the exception was being thrown.

Tests didn't catch this because the tests were hooking up the validator component to the sample template, though. And that was working fine.

So, this changes things so that the validation aspect of password fields is handled by the validator component, *not* the password component. The password component *is* still needed for toggling password visibility on forms, though, so I didn't get rid of it.

## However...

However, I *think* this means that the [`js-validate_password`](https://github.com/18F/web-design-standards/search?utf8=%E2%9C%93&q=js-validate_password&type=Code) class may no longer be needed, since JS code no longer needs it.  (The validation logic is now handled by the validator component, which is triggered by the `input[data-validation-element]` selector instead.)

If that's the case, it would require also updating the example(s) that use this component in the documentation, and maybe incrementing the minor version of USWDS.

## But...

What confuses me is why the validator component wasn't already "enabled" in the first place.  Because it wasn't included in `components/index.js`, its event listener wasn't being added to `document.body` in `start.js`, which meant that _documenting_ the validator component as per #1432 would be futile, since we'd effectively be documenting dead code. This PR fixes that, but I'm puzzled as to why the code was like that in the first place.

Perhaps it's something that should have been done as part of #1836, but might have been overlooked due to the size and complexity of that PR?
