### PR TITLE
Pin Bourbon at 4.2.7 to squelch deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@frctl/nunjucks": "^1.0.3",
     "babel-preset-es2015": "^6.24.0",
     "babelify": "^7.3.0",
-    "bourbon": "^4.2.6",
+    "bourbon": "4.2.7",
     "bourbon-neat": "https://github.com/thoughtbot/neat/archive/neat-1.8.0-node-sass.tar.gz",
     "cracks": "^3.1.2",
     "cross-spawn": "^2.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,9 +893,9 @@ boom@2.x.x:
   version "1.8.0"
   resolved "https://github.com/thoughtbot/neat/archive/neat-1.8.0-node-sass.tar.gz#cac50f0721b9caa6d184e05133c7c75283ff4446"
 
-bourbon@^4.2.6:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-4.3.4.tgz#4da380029e92c0c8f9764c779451a134b11e7cc3"
+bourbon@4.2.7:
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-4.2.7.tgz#48a805dff475fbf61e002a64e1e4db68d2f82fba"
 
 boxen@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Basically, our `package.json` declared we use bourbon at `^4.2.6`, the  caret meaning "any new minor release that comes out after that".  However, `4.3.0` is the version that started spamming the deprecation warnings mentioned in #1904. So if we pin bourbon to `4.2.7`--the latest release before `4.3.0`--then we can squelch the warnings.

I recommend merging this and then upgrading bourbon *intentionally* from now on, e.g. issuing future PRs that upgrade bourbon *while also taking care of deprecation warnings*.  This is how we normally deal with upgrades in imperative code (e.g. django, react, etc.) and I think it makes sense to approach things similarly here, but let me know if you disagree.

That said, I'm unclear on whether this actually _fixes_ or merely _works around_ #1904.  How do SASS dependencies work when others use our SASS?  If @adborden's project uses Bourbon 5.0 beta and USWDS uses Bourbon 4.2.6, is that a problem?  Alternatively, if his project isn't using any version of Bourbon on its own, and is merely including USWDS and the version of Bourbon that's tied to it, then I suspect this _would_ actually fix the issue.  I just don't know enough about how dependencies work in SASS to have an accurate opinion.

That said, I still think this PR is worth merging because OMG these deprecation warnings are driving me batty. I'm worried the other quick-and-easy option, adding `$output-bourbon-deprecation-warnings: false !default;` to our SASS will just result in us building up tons of technical debt that will be a massive chore to pay back once we _do_ want to upgrade to Bourbon 5.0, so this seems like the only reasonable alternative I can think of.

Thoughts?
