### PR TITLE
Remove deprecated Bourbon mixins and remove warnings

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -38,7 +38,9 @@
 
 .usa-nav {
   $sliding-panel-width: 26rem;
+
   @include position(fixed, 0 0 0 auto);
+
   background: $color-white;
   border-left: 1px solid $color-gray-light;
   border-right: 0;

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -38,10 +38,7 @@
 
 .usa-nav {
   $sliding-panel-width: 26rem;
-
   @include position(fixed, 0 0 0 auto);
-  @include transform(translateX($sliding-panel-width));
-
   background: $color-white;
   border-left: 1px solid $color-gray-light;
   border-right: 0;
@@ -49,24 +46,24 @@
   flex-direction: column;
   overflow-y: auto;
   padding: 2rem;
+  transform: translateX($sliding-panel-width);
   width: $sliding-panel-width;
   z-index: $z-index-nav;
 
   @include media($nav-width) {
     @include padding(5rem 0 0 null);
-    @include transform(translateX(0));
-
     border-left: none;
     display: block;
     float: right;
     overflow-y: visible;
     position: relative;
+    transform: translateX(0);
     width: auto;
   }
 
   &.is-visible {
-    @include transform(translateX(0));
-    @include transition(all 0.3s ease-in-out);
+    transform: translateX(0);
+    transition: all 0.3s ease-in-out;
   }
 
   nav {

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -8,19 +8,19 @@
 // own partials, then @import '{path/to/uswds/}core/variables'.
 
 // Typography
-// Removing the !default from $em-base so we are not inheriting that 
+// Removing the !default from $em-base so we are not inheriting that
 // value from Bourbon.
 $em-base:             10px;
-$base-font-size:      rem(17px) !default;
-$small-font-size:     rem(14px) !default;
-$lead-font-size:      rem(20px) !default;
-$title-font-size:     rem(52px) !default;
-$h1-font-size:        rem(40px) !default;
-$h2-font-size:        rem(30px) !default;
-$h3-font-size:        rem(20px) !default;
-$h4-font-size:        rem(17px) !default;
-$h5-font-size:        rem(15px) !default;
-$h6-font-size:        rem(13px) !default;
+$base-font-size:      1.7rem !default;
+$small-font-size:     1.4rem !default;
+$lead-font-size:      2rem !default;
+$title-font-size:     5.2rem !default;
+$h1-font-size:        4rem !default;
+$h2-font-size:        3rem !default;
+$h3-font-size:        2rem !default;
+$h4-font-size:        1.7rem !default;
+$h5-font-size:        1.5rem !default;
+$h6-font-size:        1.3rem !default;
 $base-line-height:    1.5 !default;
 $heading-line-height: 1.3 !default;
 $lead-line-height:    1.7 !default;
@@ -113,7 +113,7 @@ $site-margins:        3rem !default;
 $site-margins-mobile: 1.5rem !default;
 $article-max-width:   600px !default;
 $input-max-width:     46rem !default;
-$border-radius:       rem(3px) !default;
+$border-radius:       3px !default;
 $box-shadow:          0 0 2px $color-shadow !default;
 $focus-shadow:        0 0 3px $color-focus, 0 0 7px $color-focus !default;
 $nav-width:           951px !default;

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -1,7 +1,7 @@
 // scss-lint:disable QualifyingElement, PropertyCount
 
 $input-line-height: 1.3;
-$input-border-width: 1px;
+$input-border-width: 0.1rem; // Using rem instead of px so function uses same units
 $input-padding-vertical: 1rem;
 
 // input heights will vary by browser and type
@@ -9,7 +9,7 @@ $input-padding-vertical: 1rem;
 $input-height-exact: (
   ($base-font-size * $input-line-height) +
   ($input-padding-vertical * 2) +
-  (rem($input-border-width * 2))
+  ($input-border-width * 2)
 );
 
 // truncated to 1 decimal place


### PR DESCRIPTION
This removes any instance of the code that uses deprecated bourbon mixins. Seeing all those warnings is not a great experience. 

Fixes: https://github.com/18F/web-design-standards/issues/1904
Related: https://github.com/18F/web-design-standards/pull/2003

cc @toolness 