### PR TITLE
Bind only to click events, not touchstart.

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -1,5 +1,15 @@
 module.exports = {
-  CLICK: ('ontouchstart' in document.documentElement)
-    ? 'touchstart'
-    : 'click',
+  // This used to be conditionally dependent on whether the
+  // browser supported touch events; if it did, `CLICK` was set to
+  // `touchstart`.  However, this had downsides:
+  //
+  // * It pre-empted mobile browsers' default behavior of detecting
+  //   whether a touch turned into a scroll, thereby preventing
+  //   users from using some of our components as scroll surfaces.
+  //
+  // * Some devices, such as the Microsoft Surface Pro, support *both*
+  //   touch and clicks. This meant the conditional effectively dropped
+  //   support for the user's mouse, frustrating users who preferred
+  //   it on those systems.
+  CLICK: 'click',
 };


### PR DESCRIPTION
This fixes #1993 and #2013 by binding event listeners to `click` instead of `touchstart`, even on devices that support touch.

A full rationale for the change is at https://github.com/18F/web-design-standards/issues/1993#issuecomment-313410624, though I also included a synopsis of it in the comments in this PR.

I've tested this out on multiple iOS devices, Firefox and Chrome on Android, and multiple desktop browsers and it seems to work fine.