### PR TITLE
Collapse navigation on nav link click

### DIFF
--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -53,6 +53,14 @@ describe('navigation toggle', function () {
     assert.equal(isVisible(overlay), false);
   });
 
+  it('hides the nav when a nav link is clicked', function () {
+    const navLink = nav.querySelector('a');
+
+    menuButton.click();
+    navLink.click();
+    assert.equal(isVisible(nav), false);
+  });
+
   describe('off()', function () {
     it('removes event listeners', function () {
       assert.equal(isVisible(nav), false);

--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const navigation = require('../../../src/js/components/navigation');
+const accordion = require('../../../src/js/components/accordion');
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, 'template.html'));
 
@@ -13,6 +14,8 @@ describe('navigation toggle', function () {
   let overlay;
   let closeButton;
   let menuButton;
+  let accordionButton;
+  let navLink;
 
   const isVisible = (el) => {
     return el.classList.contains('is-visible');
@@ -20,17 +23,21 @@ describe('navigation toggle', function () {
 
   beforeEach(function () {
     body.innerHTML = TEMPLATE;
+    accordion.on();
     navigation.on();
     nav = body.querySelector('.usa-nav');
     overlay = body.querySelector('.usa-overlay');
     closeButton = body.querySelector('.usa-nav-close');
     menuButton = body.querySelector('.usa-menu-btn');
+    accordionButton = nav.querySelector('.usa-accordion-button');
+    navLink = nav.querySelector('a');
   });
 
   afterEach(function () {
     body.innerHTML = '';
     body.className = '';
     navigation.off();
+    accordion.off();
   });
 
   it('shows the nav when the menu button is clicked', function () {
@@ -54,11 +61,20 @@ describe('navigation toggle', function () {
   });
 
   it('hides the nav when a nav link is clicked', function () {
-    const navLink = nav.querySelector('a');
-
     menuButton.click();
     navLink.click();
     assert.equal(isVisible(nav), false);
+  });
+
+  it('does not show the nav when a nav link is clicked', function () {
+    navLink.click();
+    assert.equal(isVisible(nav), false);
+  });
+
+  it('collapses accordions when a nav link is clicked', function () {
+    accordionButton.click();
+    navLink.click();
+    assert.equal(accordionButton.getAttribute('aria-expanded'), 'false');
   });
 
   describe('off()', function () {

--- a/src/components/08-navigation/nav-primary.config.yml
+++ b/src/components/08-navigation/nav-primary.config.yml
@@ -9,7 +9,9 @@ context:
         id: nav-section-one
         links: &subnav_links
           - text: Sub-link one
+            href: '#'
           - text: Sub-link two
+            href: '#'
       - text: Section two
         id: nav-section-two
         links: *subnav_links

--- a/src/components/layouts/_base.njk
+++ b/src/components/layouts/_base.njk
@@ -19,7 +19,7 @@
     {% endblock %}
 
     {% block header -%}
-      {% render '@header--basic' %}
+      {% render '@header--basic', {header: header}, true %}
     {% endblock %}
 
     {% block body -%}

--- a/src/components/layouts/docs.config.yml
+++ b/src/components/layouts/docs.config.yml
@@ -1,2 +1,17 @@
 label: Documentation
 handle: layout--docs
+
+context:
+  header:
+    primary:
+      search: false
+      links:
+        - text: Sections
+          id: nav-section-one
+          links: &subnav_links
+            - text: Section heading (h2)
+              href: '#section-heading-h2'
+            - text: Subsection heading (h3)
+              href: '#section-heading-h3'
+            - text: Subsection heading (h4)
+              href: '#section-heading-h4'

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -2,12 +2,14 @@
 const behavior = require('../utils/behavior');
 const forEach = require('array-foreach');
 const select = require('../utils/select');
+const accordion = require('./accordion');
 
 const CLICK = require('../events').CLICK;
 const PREFIX = require('../config').prefix;
 
 const CONTEXT = 'header';
 const NAV = `.${PREFIX}-nav`;
+const NAV_LINKS = `${NAV} a`;
 const OPENERS = `.${PREFIX}-menu-btn`;
 const CLOSE_BUTTON = `.${PREFIX}-nav-close`;
 const OVERLAY = `.${PREFIX}-overlay`;
@@ -42,6 +44,23 @@ const navigation = behavior({
   [ CLICK ]: {
     [ OPENERS ]: toggleNav,
     [ CLOSERS ]: toggleNav,
+    [ NAV_LINKS ]: function() {
+      // A navigation link has been clicked! We want to collapse any
+      // hierarchical navigation UI it's a part of, so that the user
+      // can focus on whatever they've just selected.
+
+      // Some navigation links are inside accordions; when they're
+      // clicked, we want to collapse those accordions.
+      const acc = this.closest(accordion.ACCORDION);
+      if (acc) {
+        accordion.getButtons(acc).forEach(btn => accordion.hide(btn));
+      }
+
+      // If the mobile navigation menu is active, we want to hide it.
+      if (document.body.classList.contains(ACTIVE_CLASS)) {
+        toggleNav.call(this);
+      }
+    },
   },
 });
 

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -44,7 +44,7 @@ const navigation = behavior({
   [ CLICK ]: {
     [ OPENERS ]: toggleNav,
     [ CLOSERS ]: toggleNav,
-    [ NAV_LINKS ]: function() {
+    [ NAV_LINKS ]: function () {
       // A navigation link has been clicked! We want to collapse any
       // hierarchical navigation UI it's a part of, so that the user
       // can focus on whatever they've just selected.


### PR DESCRIPTION
This attempts to fix #1962.

## To do

- [x] Ensure that focus works properly when a link is clicked.
- [x] Consider adding another example to the fractal site which includes anchor links, and ensure it works properly.
- [x] Add more tests.
  Tests can be run with `mocha --opts spec/mocha.opts spec/unit/navigation/navigation.spec.js`.
