### PR TITLE
'gulp eslint' exits with error on failure

### DIFF
--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -54,5 +54,6 @@ gulp.task('eslint', function (done) {
       'spec/**/*.js'
     ])
     .pipe(eslint())
-    .pipe(eslint.format());
+    .pipe(eslint.format())
+    .pipe(eslint.failAfterError());
 });


### PR DESCRIPTION
This fixes #2018.

Example output when eslint fails:

```
[19:56:29]
src/js/components/navigation.js
  47:28  error  Missing space before function parentheses  space-before-function-paren

✖ 1 problem (1 error, 0 warnings)

[19:56:29] 'eslint' errored after 970 ms
[19:56:29] ESLintError in plugin 'gulp-eslint'
Message:
    Failed with 1 error
```
