### PR TITLE
Mobile nav: allow for a mobile-specific navigation by hiding it on desktop

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -103,6 +103,12 @@
     display: none;
   }
 }
+.usa-nav-desktop {
+  display: none;
+  @include media($nav-width) {
+    display: block;
+  }
+}
 
 // Primary navigation ------------- //
 

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -96,6 +96,14 @@
   }
 }
 
+// Mobile-only navigation --------- //
+
+.usa-nav-mobile {
+  @include media($nav-width) {
+    display: none;
+  }
+}
+
 // Primary navigation ------------- //
 
 .usa-nav-primary {


### PR DESCRIPTION
## Description

The standards.usa.gov site is using a class called "sidenav-mobile" to allow a mobile-specific navigation that gets hidden on desktop. This approach would be useful to other sites using the standards, but the CSS that hides the menu on desktop is not part of the library (it's specific to standards.usa.gov). If that CSS could be added to the library, then sites would be able to use this approach simply by using a certain class in their markup, instead of needing to add custom CSS.

In this PR I used the class: usa-nav-mobile

EDIT after 2nd commit: I realized that in order to be useful, another class would be needed to target the desktop-only menu. So I've added the corresponding code for a usa-nav-desktop class.

## Additional information

If you think this is worth adding to the library, there should also probably be some documentation of the use of this class, so that it doesn't end up as a hidden feature that nobody knows about. I could use some suggestions about the best place for that, and am happy to add to this PR as needed.
