### PR TITLE
fixes #2023 (search box above nav on IE11 bug)

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -419,7 +419,7 @@
     flex-direction: column;
 
     @include media($nav-width) {
-      display: initial;
+      display: block;
       float: right;
       margin-top: -4.8rem;
     }


### PR DESCRIPTION
IE 11 doesn't support display: initial. Since initial sets display to the elements default, I just explicitly set display to block which is the default display property of div.