### PR TITLE
[WIP] Scroll expanded accordion into view if needed

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -3,6 +3,7 @@ const behavior = require('../utils/behavior');
 const filter = require('array-filter');
 const forEach = require('array-foreach');
 const toggle = require('../utils/toggle');
+const isElementInViewport = require('../utils/is-in-viewport');
 
 const CLICK = require('../events').CLICK;
 const PREFIX = require('../config').prefix;
@@ -69,7 +70,14 @@ const accordion = behavior({
   [ CLICK ]: {
     [ BUTTON ]: function (event) {
       event.preventDefault();
-      return toggleButton(this);
+      toggleButton(this);
+
+      if (this.getAttribute(EXPANDED) === 'true') {
+        // We were just expanded, but if another accordion was also just
+        // collapsed, we may no longer be in the viewport. This ensures
+        // that we are still visible, so the user isn't confused.
+        if (!isElementInViewport(this)) this.scrollIntoView();
+      }
     },
   },
 }, {

--- a/src/js/utils/is-in-viewport.js
+++ b/src/js/utils/is-in-viewport.js
@@ -1,0 +1,11 @@
+// https://stackoverflow.com/a/7557433
+module.exports = function isElementInViewport (el) {
+  var rect = el.getBoundingClientRect();
+
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
+  );
+}


### PR DESCRIPTION
Fixes #2021.

This implements the solution I suggested in #2021, which just calls `.scrollIntoView()` on a button that was just clicked, but only if it's no longer in the viewport after any required collapsing & expanding occurs.

To test it out, you can actually just visit [`/components/detail/kitchen-sink`](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/accordion-scroll-into-view/components/detail/kitchen-sink.html) on the Fractal site, scroll down to "Accordions - Borderless", **resize the width of the preview viewport using the gutter slider thingy so it's as narrow as possible**, and click on "Fifth Amendment" (the "First Amendment" accordion should already be expanded when the page is first loaded).  Without this fix, the "Fifth Amendment" accordion button is no longer visible just after you click on it; with this fix, it *is* visible.

To do:
- [ ] If this solution seems like the right thing to do UX-wise, I should add tests.
