### PR TITLE
Updating Gov Banner

### DIFF
--- a/spec/unit/banner/template.html
+++ b/spec/unit/banner/template.html
@@ -15,13 +15,17 @@
           <p>
             <strong>The .gov means it’s official.</strong>
             <br>
-            Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+            Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
           </p>
         </div>
       </div>
       <div class="usa-banner-guidance-ssl usa-width-one-half">
         <div class="usa-media_block-body">
-          <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+          <p>
+            <strong>The site is secure.</strong>
+            <br>
+            The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+          </p>
         </div>
       </div>
     </div>

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -1,8 +1,36 @@
 <div class="usa-banner">
-  <header class="usa-banner-header">
-    <div class="usa-grid usa-banner-inner">
+  <div class="usa-accordion">
+    <header class="usa-banner-header">
+      <div class="usa-grid usa-banner-inner">
       <img src="{{ uswds.path }}/img/favicons/favicon-57.png" alt="U.S. flag">
       <p>An official website of the United States government</p>
+      <button class="usa-accordion-button usa-banner-button"
+        aria-expanded="false" aria-controls="gov-banner">
+        <span class="usa-banner-button-text">Here's how you know</span>
+      </button>
+      </div>
+    </header>
+    <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+      <div class="usa-banner-guidance-gov usa-width-one-half">
+        <img class="usa-banner-icon usa-media_block-img" src="{{ uswds.path }}/img/icon-dot-gov.svg" alt="Dot gov">
+        <div class="usa-media_block-body">
+          <p>
+            <strong>The .gov means it’s official.</strong>
+            <br>
+            Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
+          </p>
+        </div>
+      </div>
+      <div class="usa-banner-guidance-ssl usa-width-one-half">
+        <img class="usa-banner-icon usa-media_block-img" src="{{ uswds.path }}/img/icon-https.svg" alt="Https">
+        <div class="usa-media_block-body">
+          <p>
+            <strong>The site is secure.</strong>
+            <br>
+            The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+          </p>
+        </div>
+      </div>
     </div>
-  </header>
+  </div>
 </div>


### PR DESCRIPTION
fixes 18f/web-design-standards-docs#315
fixes #1748 

This updates the gov banner text with more accurate information (derived from USA.gov).

This may still need to be updated on other sites but should show the updated version in Fractal.

Thanks @konklone!  