### PR TITLE
Include sass files in the release zip file

### DIFF
--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -51,6 +51,9 @@ gulp.task('build', function (done) {
       'images',
       'fonts',
     ],
+    // We need to copy the SASS to dist *after* the sass task, to ensure
+    // that vendor libraries have been copied to the SASS directory first.
+    'copy-dist-sass',
     done
   );
 

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -43,6 +43,15 @@ gulp.task('copy-vendor-sass', function () {
   return stream;
 });
 
+gulp.task('copy-dist-sass', function () {
+  dutil.logMessage('copy-dist-sass', 'Copying all SASS to dist dir');
+
+  var stream = gulp.src('src/stylesheets/**/*.scss')
+    .pipe(gulp.dest('dist/scss'));
+
+  return stream;
+});
+
 gulp.task(task, [ 'copy-vendor-sass' ], function () {
 
   dutil.logMessage(task, 'Compiling Sass');


### PR DESCRIPTION
This fixes #1739 by including our SCSS files, along with vendor dependencies like Neat and Bourbon, in the release zip file.

To do:

- [x] Verify with @evetsreklaw that the bundled SCSS works well with Dreamweaver CC.
- [ ] Add documentation so folks who want to use the SCSS without node can do so (we may need to do this as a separate issue/PR in the docs repository).
