### PR TITLE
Fix navigation accessibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "nswatch": "^0.2.0",
     "run-sequence": "^1.1.5",
     "should": "^11.2.1",
+    "sinon": "^2.3.8",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }

--- a/spec/1.x/navigation.spec.js
+++ b/spec/1.x/navigation.spec.js
@@ -36,17 +36,6 @@ describe('1.x navigation component', function () {
     assert.equal(isVisible(overlay), true);
   });
 
-  it('focuses the close button when the menu button is clicked', function () {
-    menuButton.click();
-    assert.equal(document.activeElement, closeButton);
-  });
-
-  it('focuses the menu button when the close button is clicked', function () {
-    menuButton.click();
-    closeButton.click();
-    assert.equal(document.activeElement, menuButton);
-  });
-
   it('hides the nav when the close button is clicked', function () {
     menuButton.click();
     closeButton.click();

--- a/spec/1.x/navigation.spec.js
+++ b/spec/1.x/navigation.spec.js
@@ -36,6 +36,17 @@ describe('1.x navigation component', function () {
     assert.equal(isVisible(overlay), true);
   });
 
+  it('focuses the close button when the menu button is clicked', function () {
+    menuButton.click();
+    assert.equal(document.activeElement, closeButton);
+  });
+
+  it('focuses the menu button when the close button is clicked', function () {
+    menuButton.click();
+    closeButton.click();
+    assert.equal(document.activeElement, menuButton);
+  });
+
   it('hides the nav when the close button is clicked', function () {
     menuButton.click();
     closeButton.click();

--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -2,6 +2,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const sinon = require('sinon');
 const navigation = require('../../../src/js/components/navigation');
 const accordion = require('../../../src/js/components/accordion');
 
@@ -64,6 +65,39 @@ describe('navigation toggle', function () {
     menuButton.click();
     navLink.click();
     assert.equal(isVisible(nav), false);
+  });
+
+  it('focuses the close button when the menu button is clicked', function () {
+    menuButton.click();
+    assert.equal(document.activeElement, closeButton);
+  });
+
+  it('focuses the menu button when the close button is clicked', function () {
+    menuButton.click();
+    closeButton.click();
+    assert.equal(document.activeElement, menuButton);
+  });
+
+  it('collapses nav if needed on window resize', function () {
+    menuButton.click();
+    sinon.stub(closeButton, 'getBoundingClientRect').returns({ width: 0 });
+    try {
+      window.dispatchEvent(new CustomEvent('resize'));
+    } finally {
+      closeButton.getBoundingClientRect.restore();
+    }
+    assert.equal(isVisible(nav), false);
+  });
+
+  it('does not collapse nav if not needed on window resize', function () {
+    menuButton.click();
+    sinon.stub(closeButton, 'getBoundingClientRect').returns({ width: 100 });
+    try {
+      window.dispatchEvent(new CustomEvent('resize'));
+    } finally {
+      closeButton.getBoundingClientRect.restore();
+    }
+    assert.equal(isVisible(nav), true);
   });
 
   it('does not show the nav when a nav link is clicked', function () {

--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -11,6 +11,7 @@ const TEMPLATE = fs.readFileSync(path.join(__dirname, 'template.html'));
 describe('navigation toggle', function () {
   const body = document.body;
 
+  let sandbox;
   let nav;
   let overlay;
   let closeButton;
@@ -32,6 +33,7 @@ describe('navigation toggle', function () {
     menuButton = body.querySelector('.usa-menu-btn');
     accordionButton = nav.querySelector('.usa-accordion-button');
     navLink = nav.querySelector('a');
+    sandbox = sinon.sandbox.create();
   });
 
   afterEach(function () {
@@ -39,6 +41,7 @@ describe('navigation toggle', function () {
     body.className = '';
     navigation.off();
     accordion.off();
+    sandbox.restore();
   });
 
   it('shows the nav when the menu button is clicked', function () {
@@ -80,23 +83,15 @@ describe('navigation toggle', function () {
 
   it('collapses nav if needed on window resize', function () {
     menuButton.click();
-    sinon.stub(closeButton, 'getBoundingClientRect').returns({ width: 0 });
-    try {
-      window.dispatchEvent(new CustomEvent('resize'));
-    } finally {
-      closeButton.getBoundingClientRect.restore();
-    }
+    sandbox.stub(closeButton, 'getBoundingClientRect').returns({ width: 0 });
+    window.dispatchEvent(new CustomEvent('resize'));
     assert.equal(isVisible(nav), false);
   });
 
   it('does not collapse nav if not needed on window resize', function () {
     menuButton.click();
-    sinon.stub(closeButton, 'getBoundingClientRect').returns({ width: 100 });
-    try {
-      window.dispatchEvent(new CustomEvent('resize'));
-    } finally {
-      closeButton.getBoundingClientRect.restore();
-    }
+    sandbox.stub(closeButton, 'getBoundingClientRect').returns({ width: 100 });
+    window.dispatchEvent(new CustomEvent('resize'));
     assert.equal(isVisible(nav), true);
   });
 

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -44,6 +44,19 @@ const toggleNav = function (active) {
   return active;
 };
 
+const resize = () => {
+  const isActive = document.body.classList.contains(ACTIVE_CLASS);
+  const closer = document.body.querySelector(CLOSERS);
+
+  if (isActive && closer && closer.getBoundingClientRect().width === 0) {
+    // The mobile nav is active, but the close box isn't visible, which
+    // means the user's viewport has been resized so that it is no longer
+    // in mobile mode. Let's make the page state consistent by
+    // deactivating the mobile nav.
+    toggleNav.call(closer);
+  }
+};
+
 const navigation = behavior({
   [ CLICK ]: {
     [ OPENERS ]: toggleNav,
@@ -66,6 +79,14 @@ const navigation = behavior({
       }
     },
   },
+}, {
+  init() {
+    resize();
+    window.addEventListener('resize', resize, false);
+  },
+  teardown() {
+    window.removeEventListener('resize', resize, false);
+  }
 });
 
 /**

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -18,10 +18,12 @@ const TOGGLES = [ NAV, OVERLAY ].join(', ');
 const ACTIVE_CLASS = 'usa-mobile_nav-active';
 const VISIBLE_CLASS = 'is-visible';
 
+const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
+
 const toggleNav = function (active) {
   const body = document.body;
   if (typeof active !== 'boolean') {
-    active = !body.classList.contains(ACTIVE_CLASS);
+    active = !isActive();
   }
   body.classList.toggle(ACTIVE_CLASS, active);
 
@@ -50,10 +52,9 @@ const toggleNav = function (active) {
 };
 
 const resize = () => {
-  const isActive = document.body.classList.contains(ACTIVE_CLASS);
   const closer = document.body.querySelector(CLOSE_BUTTON);
 
-  if (isActive && closer && closer.getBoundingClientRect().width === 0) {
+  if (isActive() && closer && closer.getBoundingClientRect().width === 0) {
     // The mobile nav is active, but the close box isn't visible, which
     // means the user's viewport has been resized so that it is no longer
     // in mobile mode. Let's make the page state consistent by
@@ -79,7 +80,7 @@ const navigation = behavior({
       }
 
       // If the mobile navigation menu is active, we want to hide it.
-      if (document.body.classList.contains(ACTIVE_CLASS)) {
+      if (isActive()) {
         toggleNav.call(this, false);
       }
     },

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -35,9 +35,16 @@ const toggleNav = function (active) {
     const closeButton = context.querySelector(CLOSE_BUTTON);
     const menuButton = context.querySelector(OPENERS);
     if (active && closeButton) {
+      // The mobile nav was just activated, so focus on the close button,
+      // which is just before all the nav elements in the tab order.
       closeButton.focus();
     } else if (!active && document.activeElement === closeButton &&
                menuButton) {
+      // The mobile nav was just deactivated, and focus was on the close
+      // button, which is no longer visible. We don't want the focus to
+      // disappear into the void, so focus on the menu button if it's
+      // visible (this may have been what the user was just focused on,
+      // if they triggered the mobile nav by mistake).
       menuButton.focus();
     }
   }

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -87,13 +87,13 @@ const navigation = behavior({
     },
   },
 }, {
-  init() {
+  init () {
     resize();
     window.addEventListener('resize', resize, false);
   },
-  teardown() {
+  teardown () {
     window.removeEventListener('resize', resize, false);
-  }
+  },
 });
 
 /**

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -88,7 +88,6 @@ const navigation = behavior({
   },
 }, {
   init () {
-    resize();
     window.addEventListener('resize', resize, false);
   },
   teardown () {

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -31,10 +31,14 @@ const toggleNav = function (active) {
     el.classList.toggle(VISIBLE_CLASS);
   });
 
-  if (active && context) {
+  if (context) {
     const closeButton = context.querySelector(CLOSE_BUTTON);
-    if (closeButton) {
+    const menuButton = context.querySelector(OPENERS);
+    if (active && closeButton) {
       closeButton.focus();
+    } else if (!active && document.activeElement === closeButton &&
+               menuButton) {
+      menuButton.focus();
     }
   }
   return active;

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -7,7 +7,6 @@ const accordion = require('./accordion');
 const CLICK = require('../events').CLICK;
 const PREFIX = require('../config').prefix;
 
-const CONTEXT = 'header';
 const NAV = `.${PREFIX}-nav`;
 const NAV_LINKS = `${NAV} a`;
 const OPENERS = `.${PREFIX}-menu-btn`;
@@ -26,34 +25,33 @@ const toggleNav = function (active) {
   }
   body.classList.toggle(ACTIVE_CLASS, active);
 
-  const context = this.closest(CONTEXT);
   forEach(select(TOGGLES), el => {
     el.classList.toggle(VISIBLE_CLASS, active);
   });
 
-  if (context) {
-    const closeButton = context.querySelector(CLOSE_BUTTON);
-    const menuButton = context.querySelector(OPENERS);
-    if (active && closeButton) {
-      // The mobile nav was just activated, so focus on the close button,
-      // which is just before all the nav elements in the tab order.
-      closeButton.focus();
-    } else if (!active && document.activeElement === closeButton &&
-               menuButton) {
-      // The mobile nav was just deactivated, and focus was on the close
-      // button, which is no longer visible. We don't want the focus to
-      // disappear into the void, so focus on the menu button if it's
-      // visible (this may have been what the user was just focused on,
-      // if they triggered the mobile nav by mistake).
-      menuButton.focus();
-    }
+  const closeButton = body.querySelector(CLOSE_BUTTON);
+  const menuButton = body.querySelector(OPENERS);
+
+  if (active && closeButton) {
+    // The mobile nav was just activated, so focus on the close button,
+    // which is just before all the nav elements in the tab order.
+    closeButton.focus();
+  } else if (!active && document.activeElement === closeButton &&
+             menuButton) {
+    // The mobile nav was just deactivated, and focus was on the close
+    // button, which is no longer visible. We don't want the focus to
+    // disappear into the void, so focus on the menu button if it's
+    // visible (this may have been what the user was just focused on,
+    // if they triggered the mobile nav by mistake).
+    menuButton.focus();
   }
+
   return active;
 };
 
 const resize = () => {
   const isActive = document.body.classList.contains(ACTIVE_CLASS);
-  const closer = document.body.querySelector(CLOSERS);
+  const closer = document.body.querySelector(CLOSE_BUTTON);
 
   if (isActive && closer && closer.getBoundingClientRect().width === 0) {
     // The mobile nav is active, but the close box isn't visible, which

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -28,7 +28,7 @@ const toggleNav = function (active) {
 
   const context = this.closest(CONTEXT);
   forEach(select(TOGGLES), el => {
-    el.classList.toggle(VISIBLE_CLASS);
+    el.classList.toggle(VISIBLE_CLASS, active);
   });
 
   if (context) {
@@ -60,7 +60,7 @@ const resize = () => {
     // means the user's viewport has been resized so that it is no longer
     // in mobile mode. Let's make the page state consistent by
     // deactivating the mobile nav.
-    toggleNav.call(closer);
+    toggleNav.call(closer, false);
   }
 };
 
@@ -82,12 +82,13 @@ const navigation = behavior({
 
       // If the mobile navigation menu is active, we want to hide it.
       if (document.body.classList.contains(ACTIVE_CLASS)) {
-        toggleNav.call(this);
+        toggleNav.call(this, false);
       }
     },
   },
 }, {
   init () {
+    resize();
     window.addEventListener('resize', resize, false);
   },
   teardown () {

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -51,6 +51,7 @@
   padding: 2rem;
   width: $sliding-panel-width;
   z-index: $z-index-nav;
+  visibility: hidden;
 
   @include media($nav-width) {
     @include padding(5rem 0 0 null);
@@ -62,11 +63,14 @@
     overflow-y: visible;
     position: relative;
     width: auto;
+    visibility: visible;
   }
 
   &.is-visible {
     @include transform(translateX(0));
-    @include transition(all 0.3s ease-in-out);
+    @include transition(transform 0.3s ease-in-out);
+
+    visibility: visible;
   }
 
   nav {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,6 +1967,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -2624,6 +2628,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 formidable@1.0.x:
   version "1.0.17"
@@ -4459,6 +4469,10 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -4743,6 +4757,10 @@ mute-stream@0.0.6:
 nan@^2.3.0, nan@^2.3.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natives@^1.1.0:
   version "1.1.0"
@@ -5194,7 +5212,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.5.3:
+path-to-regexp@^1.5.3, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -5999,6 +6017,10 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 sass-graph@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.1.2.tgz#965104be23e8103cb7e5f710df65935b317da57b"
@@ -6209,6 +6231,19 @@ sigmund@^1.0.1, sigmund@~1.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.8.tgz#31de06fed8fba3a671e576dd96d0a5863796f25c"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -6660,6 +6695,10 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -6798,6 +6837,10 @@ type-check@~0.3.1, type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.14:
   version "1.6.15"


### PR DESCRIPTION
This fixes a number of accessibility-related bugs with navigation:

* Fixes #2029 
* Fixes #1653 
* Fixes #1649

It also addresses a few other focus issues that are documented in the GitHub/code comments below.

To do:
- [x] Add tests.
- [x] ~~Consider ensuring that keyboard focus can't leave the navigation menu once it's activated. The menu essentially seems to function like a dialog box, and behaves much like one from a mouse/touch standpoint, so we might want to make sure it behaves like one from a keyboard standpoint as well.~~ Filed separately as #2031.