### PR TITLE
Update Banner Component - US Flag

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -2,7 +2,7 @@
   <div class="usa-accordion">
     <header class="usa-banner-header">
       <div class="usa-grid usa-banner-inner">
-      <img src="{{ uswds.path }}/img/favicons/favicon-57.png" alt="U.S. flag">
+      <img src="{{ uswds.path }}/img/usa-flag.svg" alt="U.S. flag">
       <p>An official website of the United States government</p>
       <button class="usa-accordion-button usa-banner-button"
         aria-expanded="false" aria-controls="gov-banner">

--- a/src/img/usa-flag.svg
+++ b/src/img/usa-flag.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1235" height="650" viewBox="0 0 7410 3900">
+<rect width="7410" height="3900" fill="#b22234"/>
+<path d="M0,450H7410m0,600H0m0,600H7410m0,600H0m0,600H7410m0,600H0" stroke="#fff" stroke-width="300"/>
+<rect width="2964" height="2100" fill="#3c3b6e"/>
+<g fill="#fff">
+<g id="s18">
+<g id="s9">
+<g id="s5">
+<g id="s4">
+<path id="s" d="M247,90 317.534230,307.082039 132.873218,172.917961H361.126782L176.465770,307.082039z"/>
+<use xlink:href="#s" y="420"/>
+<use xlink:href="#s" y="840"/>
+<use xlink:href="#s" y="1260"/>
+</g>
+<use xlink:href="#s" y="1680"/>
+</g>
+<use xlink:href="#s4" x="247" y="210"/>
+</g>
+<use xlink:href="#s9" x="494"/>
+</g>
+<use xlink:href="#s18" x="988"/>
+<use xlink:href="#s9" x="1976"/>
+<use xlink:href="#s5" x="2470"/>
+</g>
+</svg>

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -69,11 +69,10 @@
   img {
     float: left;
     margin-right: 1rem;
-    margin-top: 1px;
+    padding-top: 0.5rem;
     width: 2.4rem;
 
     @include media($small-screen) {
-      margin-right: 0.7rem;
       width: 2rem;
     }
   }


### PR DESCRIPTION
## Description

I noticed upon zooming in on the US Flag that there were only 11 stripes and 9 stars. I swapped it for a public domain [SVG](https://en.wikipedia.org/wiki/File:Flag_of_the_United_States.svg) and now it will appear correctly, albeit a bit small. 

**Normal**
<img width="372" alt="screen shot 2017-07-14 at 4 25 58 pm" src="https://user-images.githubusercontent.com/2279260/28229552-2cbbccd4-68b1-11e7-899b-b9105f490688.png">

**Zoomed in**
<img width="829" alt="screen shot 2017-07-14 at 4 14 23 pm" src="https://user-images.githubusercontent.com/2279260/28229512-0889940e-68b1-11e7-8a16-aa787090c62e.png">

I think it would be a good idea to migrate all of the favicons over as well. Preserving the accuracy of flags is important.

## Additional information

[SVG Browser Support](http://caniuse.com/#feat=svg)

Something I noticed is that there were rules for the US Flag img that were being over-written by specificity. Due to this I simply put a padding instead of margin-top (which would always be overwritten by a previous, but more-specific class)
![notice](https://user-images.githubusercontent.com/2279260/28229766-14e841c2-68b2-11e7-8ffc-d2f348baedcf.png)




- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.