### PR TITLE
[WIP] Improve the way we import Sass and make it available to client code

### DIFF
--- a/sass-include-paths.js
+++ b/sass-include-paths.js
@@ -1,0 +1,10 @@
+var path = require('path');
+
+exports.firstParty = [path.join(__dirname, 'src', 'stylesheets')];
+
+exports.thirdParty = [
+  path.dirname(require.resolve('normalize.css'))
+].concat(require('bourbon').includePaths)
+ .concat(require('bourbon-neat').includePaths);
+
+exports.all = exports.firstParty.concat(exports.thirdParty);

--- a/spec/sass/build.spec.js
+++ b/spec/sass/build.spec.js
@@ -1,38 +1,19 @@
 'use strict';
 const assert = require('assert');
-const child = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const pkg = require('../../package.json');
-
-const distPath = path.resolve(
-  path.join(
-    __dirname,
-    '../../dist/css'
-  )
-);
-
-const build = function (done) {
-  return new Promise((resolve, reject) => {
-    child.spawn(
-        './node_modules/.bin/gulp',
-        [ 'sass' ],
-        { stdio: 'ignore' }
-      )
-      .on('error', reject)
-      .on('exit', code => resolve());
-  });
-};
+const { distCssPath, runGulp } = require('./util');
 
 before(function () {
   this.timeout(20000);
-  return build();
+  return runGulp('sass');
 });
 
 describe('build output', function () {
 
   it('generates CSS at dist/css/uswds.css', function () {
-    const distFilename = path.join(distPath, 'uswds.css');
+    const distFilename = path.join(distCssPath, 'uswds.css');
     assert.ok(
       fs.existsSync(distFilename),
       'the file does not exist: ' + distFilename
@@ -40,7 +21,7 @@ describe('build output', function () {
   });
 
   it('generates minified CSS at dist/css/uswds.min.css', function () {
-    const distFilename = path.join(distPath, 'uswds.min.css');
+    const distFilename = path.join(distCssPath, 'uswds.min.css');
     assert.ok(
       fs.existsSync(distFilename),
       'the file does not exist: ' + distFilename
@@ -71,12 +52,12 @@ describe('version output', function () {
   };
 
   it('includes the current version text in uswds.css', function () {
-    const distFilename = path.join(distPath, 'uswds.css');
+    const distFilename = path.join(distCssPath, 'uswds.css');
     return checkVersion(distFilename);
   });
 
   it('includes the current version text in uswds.min.css', function () {
-    const distFilename = path.join(distPath, 'uswds.min.css');
+    const distFilename = path.join(distCssPath, 'uswds.min.css');
     return checkVersion(distFilename);
   });
 

--- a/spec/sass/include.spec.js
+++ b/spec/sass/include.spec.js
@@ -1,22 +1,13 @@
 'use strict';
 const assert = require('assert');
 const sass = require('node-sass');
-const path = require('path');
-
-const includePath = path.resolve(
-  path.join(
-    __dirname,
-    '../../src/stylesheets'
-  )
-);
+const sassIncludePaths = require('../../sass-include-paths');
 
 const render = function (data) {
   return new Promise((resolve, reject) => {
     sass.render({
       data: data,
-      includePaths: [
-        includePath,
-      ],
+      includePaths: sassIncludePaths.all,
     }, error => {
       error ? reject(error) : resolve();
     });

--- a/spec/sass/include.spec.js
+++ b/spec/sass/include.spec.js
@@ -1,27 +1,28 @@
 'use strict';
 const assert = require('assert');
-const sass = require('node-sass');
 const sassIncludePaths = require('../../sass-include-paths');
-
-const render = function (data) {
-  return new Promise((resolve, reject) => {
-    sass.render({
-      data: data,
-      includePaths: sassIncludePaths.all,
-    }, error => {
-      error ? reject(error) : resolve();
-    });
-  });
-};
+const { runGulp, distScssPath, render } = require('./util');
 
 describe('include paths', function () {
 
   it('can be loaded with @import "uswds"', function () {
-    return render('@import "uswds";');
+    return render('@import "uswds";', sassIncludePaths.all);
   });
 
   it('can be loaded with @import "all"', function () {
-    return render('@import "all";');
+    return render('@import "all";', sassIncludePaths.all);
+  });
+
+});
+
+describe('standalone dist scss', function () {
+
+  before(() => {
+    return runGulp('copy-dist-sass');
+  });
+
+  it('can be loaded with @import "uswds"', function () {
+    return render('@import "uswds";', [ distScssPath ]);
   });
 
 });

--- a/spec/sass/util.js
+++ b/spec/sass/util.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const child = require('child_process');
+const sass = require('node-sass');
+
+exports.distPath = path.resolve(
+  path.join(
+    __dirname,
+    '../../dist'
+  )
+);
+
+exports.distCssPath = path.join(exports.distPath, 'css');
+
+exports.distScssPath = path.join(exports.distPath, 'scss');
+
+exports.runGulp = function (task) {
+  return new Promise((resolve, reject) => {
+    child.spawn(
+        './node_modules/.bin/gulp',
+        [ task ],
+        { stdio: 'ignore' }
+      )
+      .on('error', reject)
+      .on('exit', code => resolve());
+  });
+};
+
+exports.render = function (data, includePaths) {
+  return new Promise((resolve, reject) => {
+    sass.render({
+      data: data,
+      includePaths,
+    }, error => {
+      error ? reject(error) : resolve();
+    });
+  });
+};

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -1,9 +1,9 @@
 /*! uswds @version */
 
 // Vendor -------------- //
-@import 'lib/bourbon';
-@import 'lib/neat';
-@import 'lib/normalize';
+@import 'bourbon';
+@import 'neat';
+@import 'normalize';
 
 // Core -------------- //
 @import 'core/variables';


### PR DESCRIPTION
This is an attempt to fix #2032 while also (hopefully) simplifying the way we pull in SASS dependencies.

Instead of copying dependencies to the `src/stylesheets/lib` directory, we use them directly by changing our SASS include paths.  By not hard-coding the paths to our dependencies, this allows dependent modules to more easily reuse our code directly from git repositories, or even swap one version of our dependencies out for another if they really want to.

To do:

- [x] Add tests to make sure the SASS files in the release zip file (added in #2028) can still be imported without requiring any dependencies.
- [ ] Bourbon and Neat both have [`index.js`](https://github.com/thoughtbot/bourbon/blob/master/index.js) [files](https://github.com/thoughtbot/neat/blob/master/index.js) that allow client code to import them and discover their include paths (which we use in this PR).  It might be nice for us to provide similar functionality to clients of our own code, but I'm not really sure what best practices around this are. Some possibilities might be:
    * Move our CSS/SASS dependencies from `devDependencies` to `dependencies` so that anything importing `uswds` will also get the required CSS/SASS dependencies.
    * Document our CSS/SASS dependencies and leave it up to the importer to include them in their project.
- [ ] Ensure that the docs repo can still import and use `uswds` once this is done.
