### PR TITLE
Put 'menu' after logo in tab ordering

### DIFF
--- a/src/components/site-title/site-title.njk
+++ b/src/components/site-title/site-title.njk
@@ -1,5 +1,4 @@
 <div class="usa-navbar">
-  <button class="usa-menu-btn">Menu</button>
   <div class="usa-logo" id="logo">
     <em class="usa-logo-text">
       <a href="{{ header.link.href | default('/') }}"
@@ -9,4 +8,5 @@
       </a>
     </em>
   </div>
+  <button class="usa-menu-btn">Menu</button>
 </div>


### PR DESCRIPTION
This puts the "menu" button *after* the header logo in the DOM for all our examples, which makes the menu's tab ordering match the visual ordering. This is related to #1651 but doesn't actually fix the particular issue that one describes (that one is a bit harder to fix than this).

I've verified that this looks and works okay on Chrome and IE11.