### PR TITLE
Add basic type-checking via TypeScript.

### DIFF
--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -1,3 +1,4 @@
+var child_process = require('child_process');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 var dutil = require('./doc-util');
@@ -41,6 +42,24 @@ gulp.task(task, function (done) {
 
   return stream;
 
+});
+
+gulp.task('typecheck', function () {
+  return new Promise((resolve, reject) => {
+    child_process.spawn(
+      './node_modules/.bin/tsc',
+      { stdio: 'inherit' }
+    )
+    .on('error', reject)
+    .on('exit', code => {
+      if (code === 0) {
+        dutil.logMessage('typecheck', 'TypeScript likes our code!');
+        resolve();
+      } else {
+        reject(new Error('TypeScript failed, see output for details!'));
+      }
+     });
+  });
 });
 
 gulp.task('eslint', function (done) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "gulp release",
     "spec": "npm run mocha -- 'spec/**/*.spec.js'",
     "start": "fractal start --sync",
-    "test": "gulp eslint stylelint test",
+    "test": "gulp eslint typecheck stylelint test",
     "version": "npm run prepublish",
     "watch": "nswatch"
   },
@@ -48,6 +48,7 @@
   },
   "homepage": "https://github.com/18F/web-design-standards#readme",
   "dependencies": {
+    "@types/node": "^8.0.14",
     "array-filter": "^1.0.0",
     "array-foreach": "^1.0.2",
     "browserify": "^13.0.0",
@@ -57,7 +58,8 @@
     "lodash.debounce": "^4.0.7",
     "object-assign": "^4.1.1",
     "receptor": "^1.0.0",
-    "resolve-id-refs": "^0.1.0"
+    "resolve-id-refs": "^0.1.0",
+    "typescript": "^2.4.1"
   },
   "devDependencies": {
     "@18f/stylelint-rules": "^1.2.0",

--- a/src/js/utils/select.js
+++ b/src/js/utils/select.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * @name isElement
+ * @desc returns whether or not the given argument is a DOM element.
+ * @param {any} value
+ * @return {boolean}
+ */
 const isElement = value => {
   return value && typeof value === 'object' && value.nodeType === 1;
 };
@@ -8,8 +14,9 @@ const isElement = value => {
  * @name select
  * @desc selects elements from the DOM by class selector or ID selector.
  * @param {string} selector - The selector to traverse the DOM with.
- * @param {HTMLElement} context - The context to traverse the DOM in.
- * @return {Array.HTMLElement} - An array of DOM nodes or an empty array.
+ * @param {Document|HTMLElement?} context - The context to traverse the DOM
+ *   in. If not provided, it defaults to the document.
+ * @return {HTMLElement[]} - An array of DOM nodes or an empty array.
  */
 module.exports = function select (selector, context) {
 
@@ -17,7 +24,7 @@ module.exports = function select (selector, context) {
     return [];
   }
 
-  if (context === undefined || !isElement(context)) {
+  if (!context || !isElement(context)) {
     context = window.document;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
+  },
+  "include": [
+    "src/js/utils/select.js"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@types/node@^8.0.14":
+  version "8.0.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.14.tgz#4a19dc6bb61d16c01cbadc7b30ac23518fff176b"
+
 JSONStream@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
@@ -6809,6 +6813,10 @@ type-is@~1.6.14:
 typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
 ua-parser-js@0.7.12:
   version "0.7.12"


### PR DESCRIPTION
This fixes #2005 by adding a simple TypeScript task that checks a whitelist of files, defined in `tsconfig.json`, for type safety. Right now we just test [`src/js/utils/select.js`](https://github.com/18F/web-design-standards/blob/develop/src/js/utils/select.js) because it was fairly simple and already had JSDoc comments in it, which is what [TypeScript's `--checkJs` mode](https://github.com/Microsoft/TypeScript/wiki/Type-Checking-JavaScript-Files) uses to infer typings.

To make sure it works, and/or to see what TypeScript's type feedback is like, try tinkering with `select.js` in weird ways. If you remove the `context = window.document` line, for instance, you should get a `Object is possibly 'null'.` error because we've enabled TypeScript's [strict null checking](https://ariya.io/2016/10/typescript-2-and-strict-null-checking).
