### PR TITLE
Fix Contribuiting link in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository is for the Standards themselves. 18F maintains [another reposito
 * [Fractal](#fractal)
   * [Template compatibility](#template-compatibility)
 * [Need installation help?](#need-installation-help)
-* [Contributing to the code base](#contributing-to-the-codebase)
+* [Contributing to the code base](#contributing-to-the-code-base)
 * [Reuse of open-source style guides](#reuse-of-open-source-style-guides)
 * [Licenses and attribution](#licenses-and-attribution)
 


### PR DESCRIPTION
## Description

I noticed the link for the "Contributing to the code base" was broken in the Table of Contents and was pointing to #contributing-to-the-codebase instead of "contributing-to-the-code-base, so I just fixed it.

Maybe we could start using something like [Doctoc](https://www.npmjs.com/package/doctoc) so that we can more easily generate the Table of Contents? Let me know what you think and I can take care of that. 