### PR TITLE
Tables decrease specificity

### DIFF
--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -2,30 +2,29 @@ table {
   border-spacing: 0;
   margin: 2em 0;
   min-width: 100%;
+}
 
-  thead {
-    th,
-    td {
-      background-color: $color-gray-lightest;
-    }
-  }
-
+thead {
   th {
-    text-align: left;
-  }
-
-  tbody {
-    th {
-      font-weight: $font-normal;
-    }
+    font-weight: $font-bold;
   }
 
   th,
   td {
-    background-color: $color-white;
-    border: 1px solid $color-gray;
-    padding: 1.5rem;
+    background-color: $color-gray-lightest;
   }
+}
+
+th {
+  text-align: left;
+}
+
+th,
+td {
+  background-color: $color-white;
+  border: 1px solid $color-gray;
+  font-weight: $font-normal;
+  padding: 1.5rem;
 }
 
 .usa-table-borderless {

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -29,10 +29,6 @@ td {
 
 .usa-table-borderless {
   thead {
-    tr {
-      background-color: transparent;
-    }
-
     th {
       border-top: 0;
     }


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact standards.usa.gov’s look, feel, or functionality, please open a pull request on the web-design-standards-docs repo (https://github.com/18F/web-design-standards-docs).

-->

## Description

In order to make it easier for users to develop with the standards, CSS specificity in elements and components should be kept as low as possible so things are easy to override.

Fixes: https://github.com/18F/web-design-standards/issues/1428

## Additional information

This could be a breaking change in the following case:
- A user is using the standards and some other CSS library on one project.
- The other library, imported after the standards, makes some changes to `td`, `th` default styling.
Before: The standards would have overridden that default styling due to being nested in the `table` tag.
Now: The styling will not be overridden if declared after the un-nested standards tags.

This could also apply when not using a library, but that would mean the user actively has CSS code that doesn't do anything (which is definitely something that could potentially happen). 

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
