### PR TITLE
Fix fractal buttons contrast

### DIFF
--- a/spec/axe.spec.js
+++ b/spec/axe.spec.js
@@ -22,7 +22,6 @@ const AXE_OPTIONS = JSON.stringify({
   },
 });
 const SKIP_COMPONENTS = [
-  'buttons',         // TODO: Resolve color contrast issues and remove.
   'search',          // TODO: Resolve discernible text issues and remove.
 ];
 const SMALL_DESKTOP = {

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -30,7 +30,8 @@
     <button class="usa-button-outline usa-button-hover">Hover</button>
   </div>
 
-  <div class="button_wrapper button_wrapper-dark">
+  <div class="button_wrapper" style="background: black">
+    <!-- These buttons should only appear on a dark background to meet WCAG AA color contrast requirements. -->
     <button class="usa-button-outline-inverse" type="button">Default</button>
     <button class="usa-button-outline-inverse usa-button-active">Active</button>
     <button class="usa-button-outline-inverse usa-button-hover">Hover</button>

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -30,7 +30,7 @@
     <button class="usa-button-outline usa-button-hover">Hover</button>
   </div>
 
-  <div class="button_wrapper" style="background: black">
+  <div class="button_wrapper usa-background-dark">
     <!-- These buttons should only appear on a dark background to meet WCAG AA color contrast requirements. -->
     <button class="usa-button-outline-inverse" type="button">Default</button>
     <button class="usa-button-outline-inverse usa-button-active">Active</button>


### PR DESCRIPTION
Fixes #2059.

As mentioned in https://github.com/18F/web-design-standards/issues/2059#issuecomment-318204822, it seems like the last row of secondary buttons was meant to have a dark background. It's even given a class called `button_wrapper-dark` but there's no CSS for it defined anywhere, so this row of buttons has a white background.

~~This removes that class and just adds an inline `style="background: black"` to fix things:~~

This replaces that class with `usa-background-dark`:

> ![buttons-with-usa-background-dark](https://user-images.githubusercontent.com/124687/28676163-f356eb70-72b7-11e7-9e71-e6fe581d37a3.png)

It's kind of weird that the background runs all the way to the end of the page. But it's also weird that none of the buttons in any of the rows have any margin separating them from the left edge of the page. I suspect some styling was once provided for both `button_wrapper` and `button_wrapper-dark` but it disappeared at some point and now we have kind of weird styling.
