### PR TITLE
Use a data URL for the embed example

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -25,6 +25,7 @@ components.set('default.context', context);
 components.engine(require('@frctl/nunjucks')({
   filters: {
     jsonify: d => JSON.stringify(d, null, '  '),
+    dataurl: (d, type) => `data:${type},${encodeURIComponent(d)}`,
   },
   paths: [
     'src/components',

--- a/spec/axe.spec.js
+++ b/spec/axe.spec.js
@@ -20,6 +20,9 @@ const AXE_OPTIONS = JSON.stringify({
     // ignore that rule.
     'bypass': { enabled: false },
   },
+  exclude: [
+    [ 'iframe[src^="data:"]' ],
+  ],
 });
 const SKIP_COMPONENTS = [
   'buttons',         // TODO: Resolve color contrast issues and remove.

--- a/spec/axe.spec.js
+++ b/spec/axe.spec.js
@@ -14,15 +14,21 @@ const { fractalLoad } = require('./delayed-root-suite');
 const HOSTNAME = os.hostname().toLowerCase();
 const REMOTE_CHROME_URL = process.env[ 'REMOTE_CHROME_URL' ];
 const AXE_JS = fs.readFileSync(__dirname + '/../node_modules/axe-core/axe.js');
+const AXE_CONTEXT = JSON.stringify({
+  exclude: [
+    // For some reason aXe takes a lot longer if it needs to dive into
+    // iframes with data: URIs. The content of these iframes is just for
+    // non-USWDS example content anyways, so just skip them to speed things
+    // up.
+    [ 'iframe[src^="data:"]' ],
+  ],
+});
 const AXE_OPTIONS = JSON.stringify({
   rules: {
     // Not all our examples need "skip to main content" links, so
     // ignore that rule.
     'bypass': { enabled: false },
   },
-  exclude: [
-    [ 'iframe[src^="data:"]' ],
-  ],
 });
 const SKIP_COMPONENTS = [
   'buttons',         // TODO: Resolve color contrast issues and remove.
@@ -76,7 +82,7 @@ function loadAxe (cdp) {
 
 function runAxe (cdp) {
   return cdp.Runtime.evaluate({
-    expression: `(${RUN_AXE_FUNC_JS})(${AXE_OPTIONS})`,
+    expression: `(${RUN_AXE_FUNC_JS})(${AXE_CONTEXT}, ${AXE_OPTIONS})`,
     awaitPromise: true,
   }).then(details => {
     if (details.result.type !== 'string') {
@@ -125,9 +131,9 @@ function loadPage ({ cdp, url }) {
 // This function is only here so it can be easily .toString()'d
 // and run in the context of a web page by Chrome. It will not
 // be run in the node context.
-const RUN_AXE_FUNC_JS = function runAxe (options) {
+const RUN_AXE_FUNC_JS = function runAxe (context, options) {
   return new Promise((resolve, reject) => {
-    window.axe.run(options, (err, results) => {
+    window.axe.run(context, options, (err, results) => {
       if (err) return reject(err);
       resolve(JSON.stringify(results.violations));
     });

--- a/src/components/utilities/embed-container/embed-container.config.yml
+++ b/src/components/utilities/embed-container/embed-container.config.yml
@@ -1,2 +1,19 @@
 preview: '@uswds-content'
 label: Responsive embed container
+context:
+  iframe_content: |
+    <!DOCTYPE html>
+    <meta charset="utf-8">
+    <style>
+    html {
+      background-color: black;
+      color: white;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    </style>
+    <title>16:9 aspect ratio example iframe</title>
+    <p>16:9 aspect ratio example iframe</p>

--- a/src/components/utilities/embed-container/embed-container.njk
+++ b/src/components/utilities/embed-container/embed-container.njk
@@ -1,3 +1,9 @@
-<div class="usa-embed-container">
-  <iframe src="https://www.youtube.com/embed/iLD4Bu6I2I8" frameborder="0" allowfullscreen title="Introducing the US Web Design Standards (YouTube)"></iframe>
+<div class="usa-embed-container" aria-label="16:9">
+  <iframe src="{{ iframe_content | dataurl('text/html') }}" title="16:9 aspect ratio example iframe" frameborder="0"></iframe>
 </div>
+
+<p>
+  The responsive embed container can be used to ensure that its
+  contents scale to the width of its parent element while retaining
+  an aspect ratio of 16:9.
+</p>


### PR DESCRIPTION
This fixes #2058 by using a local `data:` URL for the embed example.

I also added some text below the embed in the example, to make sure that text displays under the embed properly, rather than e.g. on top of it or something weird.
