### PR TITLE
[WIP] Add experimental support for local visual regression testing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+spec/screenshots/metadata.js

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ build/
 src/stylesheets/lib
 
 # ignore saved screenshots
-screenshots/
+spec/screenshots/*.png
+spec/screenshots/metadata.js

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ build/
 
 # ignore gulp-generated vendor files
 src/stylesheets/lib
+
+# ignore saved screenshots
+screenshots/

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "node-sass": "^3.4.2",
     "normalize.css": "^3.0.3",
     "nswatch": "^0.2.0",
+    "resemblejs": "^2.2.4",
     "run-sequence": "^1.1.5",
     "should": "^11.2.1",
     "sinon": "^2.3.8",

--- a/spec/axe.spec.js
+++ b/spec/axe.spec.js
@@ -198,6 +198,51 @@ fractalLoad.then(() => {
           return cdp.Emulation.setDeviceMetricsOverride(SMALL_DESKTOP)
             .then(() => runAxe(cdp));
         });
+
+        if (process.env.ENABLE_SCREENSHOTS) {
+          const ROOT_DIR = `${__dirname}/..`;
+          const REL_DIR = `screenshots`;
+          const ABS_DIR = `${ROOT_DIR}/${REL_DIR}`;
+          const REL_PATH = `${REL_DIR}/${item.handle}.png`;
+          const ABS_PATH = `${ROOT_DIR}/${REL_PATH}`;
+          let doCompare = fs.existsSync(ABS_PATH);
+
+          it(doCompare ? 'is identical to previous screenshot'
+                       : 'saves screenshot for comparison later', () => {
+            const metrics = JSON.parse(JSON.stringify(SMALL_DESKTOP));
+            const { Page, Emulation } = cdp;
+
+            metrics.fitWindow = true;
+
+            return Emulation.setDeviceMetricsOverride(metrics)
+              .then(() => Page.getLayoutMetrics())
+              .then((result) => {
+                metrics.height = result.contentSize.height;
+                return Emulation.setDeviceMetricsOverride(metrics);
+              })
+              .then(() => Page.captureScreenshot({ format: 'png' }))
+              .then(result => {
+                const data = Buffer.from(result.data, 'base64');
+
+                if (doCompare) {
+                  const goldenData = fs.readFileSync(ABS_PATH);
+                  if (!goldenData.equals(data)) {
+                    return Promise.reject(new Error(
+                      `Screenshot of "${item.handle}" does not match ` +
+                      `${REL_PATH}! If ${REL_PATH} represents an old ` +
+                      `screenshot that is no longer valid, please delete it.`
+                    ));
+                  }
+                } else {
+                  if (!fs.existsSync(ABS_DIR)) {
+                    fs.mkdirSync(ABS_DIR);
+                  }
+
+                  fs.writeFileSync(ABS_PATH, data);
+                }
+              });
+          });
+        }
       });
     }
   });

--- a/spec/screenshots/index.html
+++ b/spec/screenshots/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<link rel="stylesheet" href="../../dist/css/uswds.css">
 <style>
 .screenshot img {
   border: 1px dotted gray;
@@ -7,7 +8,31 @@
 }
 </style>
 <title>Visual regression screenshot viewer</title>
-<h1>Visual regression screenshot viewer</h1>
+
+<!-- Header -->
+
+<header class="usa-header usa-header-basic" role="banner">
+  <div class="usa-nav-container">
+    <div class="usa-navbar">
+      <div class="usa-logo" id="logo">
+        <em class="usa-logo-text">
+          <a href="#" title="Home" aria-label="Visual regression screenshot viewer">
+            <!-- Until https://github.com/18F/web-design-standards/issues/1729
+                 is fixed, we need to keep this title ridiculously terse. -->
+            Screenshot Viewer
+          </a>
+        </em>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- Main content -->
+
+<main class="usa-grid usa-section usa-content"></main>
+
+<!-- Templates -->
+
 <template id="metadata-not-found">
   <h2>Visual regression metadata not found!</h2>
   <p>
@@ -16,6 +41,7 @@
     <code>README.md</code> for this project.
   </p>
 </template>
+
 <template id="no-failures">
   <h2>No failures!</h2>
   <p>
@@ -23,8 +49,9 @@
     screenshotted appear to match their golden counterparts.
   </p>
 </template>
+
 <template id="failure">
-  <h2>"<code data-var="handle"></code>" failure</h2>
+  <h2><code data-var="handle"></code> failure</h2>
   <p>
     The latest screenshot for the Fractal component
     <code data-var="handle"></code> does not match its golden
@@ -45,5 +72,8 @@
     <img src="" data-var-src="failName">
   </a>
 </template>
+
+<!-- Scripts -->
+
 <script src="metadata.js"></script>
 <script src="main.js"></script>

--- a/spec/screenshots/index.html
+++ b/spec/screenshots/index.html
@@ -2,6 +2,11 @@
 <meta charset="utf-8">
 <link rel="stylesheet" href="../../dist/css/uswds.css">
 <style>
+.failure-details {
+  padding-top: 1em;
+  font-size: smaller;
+}
+
 .screenshot img {
   border: 1px dotted gray;
   max-width: 100%;
@@ -69,42 +74,49 @@ details[open] > summary::before {
 
 <template id="failure">
   <h2><code data-var="handle"></code> failure</h2>
-  <p>
-    The latest screenshot for the Fractal component
-    <code data-var="handle"></code> does not match its golden
-    counterpart.
-  <p>
-  <details>
+  <details open>
     <summary>
-      This is <code data-var="handle"></code>'s golden screenshot
-      (i.e., what it <em>should</em> look like).
+      The latest screenshot for the Fractal component
+      <code data-var="handle"></code> does not match its golden
+      counterpart.
     </summary>
-    <p>
-      <a href="" data-var-href="goldenName" class="screenshot">
-        <img src="" data-var-src="goldenName">
-      </a>
-    </p>
-  </details>
-  <details>
-    <summary>
-      This is <code data-var="handle"></code>'s latest screenshot
-      (i.e., what it looks like now).
-    </summary>
-    <p>
-      <a href="" data-var-href="failName" class="screenshot">
-        <img src="" data-var-src="failName">
-      </a>
-    </p>
-  </details>
-  <details>
-    <summary>
-      This is a visual diff between the golden and latest screenshots.
-    </summary>
-    <p>
-      <a class="screenshot">
-        <img src="" data-var-src="diffUrl">
-      </a>
-    </p>
+
+    <div class="usa-grid failure-details">
+      <div class="usa-width-one-third">
+        <p>
+          <a href="" data-var-href="goldenName" class="screenshot">
+            <img src="" data-var-src="goldenName" alt="Golden screenshot">
+          </a>
+        </p>
+        <p>
+          This is <code data-var="handle"></code>'s golden screenshot
+          (i.e., what it <em>should</em> look like).
+        </p>
+      </div>
+
+      <div class="usa-width-one-third">
+        <p>
+          <a href="" data-var-href="failName" class="screenshot">
+            <img src="" data-var-src="failName" alt="Latest screenshot">
+          </a>
+        </p>
+        <p>
+          This is <code data-var="handle"></code>'s latest screenshot
+          (i.e., what it looks like now).
+        </p>
+      </div>
+
+      <div class="usa-width-one-third">
+        <p>
+          <a class="screenshot">
+            <img src="" data-var-src="diffUrl" alt="Visual diff">
+          </a>
+        </p>
+        <p>
+          This is a visual diff between the golden and latest screenshots.
+        </p>
+      </div>
+    </div>
   </details>
 </template>
 

--- a/spec/screenshots/index.html
+++ b/spec/screenshots/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.screenshot img {
+  border: 1px dotted gray;
+  max-width: 100%;
+}
+</style>
+<title>Visual regression screenshot viewer</title>
+<h1>Visual regression screenshot viewer</h1>
+<template id="metadata-not-found">
+  <h2>Visual regression metadata not found!</h2>
+  <p>
+    I couldn't find the visual regression metadata file. For
+    instructions on how to use this tool, see the
+    <code>README.md</code> for this project.
+  </p>
+</template>
+<template id="no-failures">
+  <h2>No failures!</h2>
+  <p>
+    All <span data-var="count"></span> Fractal component(s) that were
+    screenshotted appear to match their golden counterparts.
+  </p>
+</template>
+<template id="failure">
+  <h2>"<code data-var="handle"></code>" failure</h2>
+  <p>
+    The latest screenshot for the Fractal component
+    <code data-var="handle"></code> does not match its golden
+    counterpart.
+  <p>
+  <p>
+    This is <code data-var="handle"></code>'s golden screenshot
+    (i.e., what it <em>should</em> look like):
+  </p>
+  <a href="" data-var-href="goldenName" class="screenshot">
+    <img src="" data-var-src="goldenName">
+  </a>
+  <p>
+    And this is <code data-var="handle"></code>'s latest screenshot
+    (i.e., what it looks like now):
+  </p>
+  <a href="" data-var-href="goldenName" class="screenshot">
+    <img src="" data-var-src="failName">
+  </a>
+</template>
+<script src="metadata.js"></script>
+<script src="main.js"></script>

--- a/spec/screenshots/index.html
+++ b/spec/screenshots/index.html
@@ -6,6 +6,23 @@
   border: 1px dotted gray;
   max-width: 100%;
 }
+
+summary {
+  display: block;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+summary::before {
+  content: '\25B6';
+  padding-right: 0.5em;
+}
+
+details[open] > summary::before {
+  content: '\25BC';
+}
 </style>
 <title>Visual regression screenshot viewer</title>
 
@@ -57,20 +74,28 @@
     <code data-var="handle"></code> does not match its golden
     counterpart.
   <p>
-  <p>
-    This is <code data-var="handle"></code>'s golden screenshot
-    (i.e., what it <em>should</em> look like):
-  </p>
-  <a href="" data-var-href="goldenName" class="screenshot">
-    <img src="" data-var-src="goldenName">
-  </a>
-  <p>
-    And this is <code data-var="handle"></code>'s latest screenshot
-    (i.e., what it looks like now):
-  </p>
-  <a href="" data-var-href="goldenName" class="screenshot">
-    <img src="" data-var-src="failName">
-  </a>
+  <details>
+    <summary>
+      This is <code data-var="handle"></code>'s golden screenshot
+      (i.e., what it <em>should</em> look like).
+    </summary>
+    <p>
+      <a href="" data-var-href="goldenName" class="screenshot">
+        <img src="" data-var-src="goldenName">
+      </a>
+    </p>
+  </details>
+  <details>
+    <summary>
+      This is <code data-var="handle"></code>'s latest screenshot
+      (i.e., what it looks like now).
+    </summary>
+    <p>
+      <a href="" data-var-href="goldenName" class="screenshot">
+        <img src="" data-var-src="failName">
+      </a>
+    </p>
+  </details>
 </template>
 
 <!-- Scripts -->

--- a/spec/screenshots/index.html
+++ b/spec/screenshots/index.html
@@ -91,8 +91,18 @@ details[open] > summary::before {
       (i.e., what it looks like now).
     </summary>
     <p>
-      <a href="" data-var-href="goldenName" class="screenshot">
+      <a href="" data-var-href="failName" class="screenshot">
         <img src="" data-var-src="failName">
+      </a>
+    </p>
+  </details>
+  <details>
+    <summary>
+      This is a visual diff between the golden and latest screenshots.
+    </summary>
+    <p>
+      <a class="screenshot">
+        <img src="" data-var-src="diffUrl">
       </a>
     </p>
   </details>
@@ -100,5 +110,6 @@ details[open] > summary::before {
 
 <!-- Scripts -->
 
+<script src="../../node_modules/resemblejs/resemble.js"></script>
 <script src="metadata.js"></script>
 <script src="main.js"></script>

--- a/spec/screenshots/main.js
+++ b/spec/screenshots/main.js
@@ -1,0 +1,44 @@
+const TEMPLATE_VAR_ATTRS = [
+  'src',
+  'href',
+];
+
+function renderTemplate (id, context) {
+  context = context || {};
+  const template = document.getElementById(id);
+  const { content } = template;
+  const $ = selector => content.querySelectorAll(selector);
+  Object.keys(context).forEach(name => {
+    $(`[data-var="${name}"]`).forEach(el => {
+      el.textContent = context[ name ];
+    });
+    TEMPLATE_VAR_ATTRS.forEach(attr => {
+      $(`[data-var-${attr}="${name}"]`).forEach(el => {
+        el.setAttribute(attr, context[ name ]);
+      });
+    });
+  });
+  return document.importNode(content, true);
+}
+
+window.onload = () => {
+  const { body } = document;
+
+  // Did we load the metadata?
+  if (!window.metadata) {
+    return body.appendChild(renderTemplate('metadata-not-found'));
+  }
+
+  // Were there any failures?
+  const failures = window.metadata.filter(info => info.failed);
+  if (failures.length === 0) {
+    return body.appendChild(renderTemplate('no-failures', {
+      count: window.metadata.length,
+    }));
+  }
+
+  // Show the failures.
+  failures.forEach(info => {
+    body.appendChild(renderTemplate('failure', info));
+  });
+};

--- a/spec/screenshots/main.js
+++ b/spec/screenshots/main.js
@@ -22,23 +22,23 @@ function renderTemplate (id, context) {
 }
 
 window.onload = () => {
-  const { body } = document;
+  const main = document.querySelector('main');
 
   // Did we load the metadata?
   if (!window.metadata) {
-    return body.appendChild(renderTemplate('metadata-not-found'));
+    return main.appendChild(renderTemplate('metadata-not-found'));
   }
 
   // Were there any failures?
   const failures = window.metadata.filter(info => info.failed);
   if (failures.length === 0) {
-    return body.appendChild(renderTemplate('no-failures', {
+    return main.appendChild(renderTemplate('no-failures', {
       count: window.metadata.length,
     }));
   }
 
   // Show the failures.
   failures.forEach(info => {
-    body.appendChild(renderTemplate('failure', info));
+    main.appendChild(renderTemplate('failure', info));
   });
 };

--- a/spec/screenshots/main.js
+++ b/spec/screenshots/main.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const TEMPLATE_VAR_ATTRS = [
   'src',
   'href',
@@ -39,6 +41,17 @@ window.onload = () => {
 
   // Show the failures.
   failures.forEach(info => {
-    main.appendChild(renderTemplate('failure', info));
+    resemble(info.goldenName).compareTo(info.failName).onComplete(data => {
+      if (data.error) {
+        // TODO: Add error handling here. Odds are the user is viewing
+        // this page via a file: URL on a browser that has strict file
+        // permissions, e.g. Chrome.
+        console.log('resemble.js error:', data.error);
+        info.diffUrl = '';
+      } else {
+        info.diffUrl = data.getImageDataUrl();
+      }
+      main.appendChild(renderTemplate('failure', info));
+    });
   });
 };

--- a/spec/visual-regression-tester.js
+++ b/spec/visual-regression-tester.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.join(__dirname, '..');
+const SCREENSHOTS_DIR = path.join(ROOT_DIR, 'screenshots');
+
+const clone = obj => JSON.parse(JSON.stringify(obj));
+
+const autobind = self => name => { self[ name ] = self[ name ].bind(self); };
+
+class VisualRegressionTester {
+  constructor ({ handle, metrics }) {
+    this.handle = handle;
+    this.metrics = metrics;
+    this.goldenPath = path.join(SCREENSHOTS_DIR, `${handle}.png`);
+    this.relGoldenPath = path.relative(ROOT_DIR, this.goldenPath);
+    [ 'screenshot',
+      'ensureMatchesGoldenFile',
+      'saveToGoldenFile' ].forEach(autobind(this));
+  }
+
+  screenshot (cdp) {
+    const { Page, Emulation } = cdp;
+    const metrics = clone(this.metrics);
+
+    metrics.fitWindow = true;
+
+    return Emulation.setDeviceMetricsOverride(metrics)
+      .then(() => Page.getLayoutMetrics())
+      .then((result) => {
+        metrics.height = result.contentSize.height;
+        return Emulation.setDeviceMetricsOverride(metrics);
+      })
+      .then(() => Page.captureScreenshot({ format: 'png' }))
+      .then(result => Buffer.from(result.data, 'base64'));
+  }
+
+  doesGoldenFileExist () {
+    return fs.existsSync(this.goldenPath);
+  }
+
+  ensureMatchesGoldenFile (buf) {
+    const goldenData = fs.readFileSync(this.goldenPath);
+    if (!goldenData.equals(buf)) {
+      return Promise.reject(new Error(
+        `Screenshot of "${this.handle}" does not match ` +
+        `${this.relGoldenPath}! If this file represents an old ` +
+        `screenshot that is no longer valid, please delete it.`
+      ));
+    }
+    return Promise.resolve();
+  }
+
+  saveToGoldenFile (buf) {
+    if (!fs.existsSync(SCREENSHOTS_DIR)) {
+      fs.mkdirSync(SCREENSHOTS_DIR);
+    }
+
+    fs.writeFileSync(this.goldenPath, buf);
+    return Promise.resolve();
+  }
+}
+
+module.exports = VisualRegressionTester;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,15 +1276,13 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@*, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+chalk@*, chalk@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
   dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 chalk@^0.5.0:
   version "0.5.1"
@@ -1296,13 +1294,15 @@ chalk@^0.5.0:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
 
 chokidar@1.6.1, chokidar@^1.6.0:
   version "1.6.1"
@@ -1904,7 +1904,7 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.1, debug@2.X, debug@^2.1.1, debug@^2.2.0:
+debug@2.6.1, debug@^2.1.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -1916,7 +1916,7 @@ debug@2.6.3:
   dependencies:
     ms "0.7.2"
 
-debug@^2.6.8:
+debug@2.X, debug@^2.2.0, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -6008,6 +6008,10 @@ require-main-filename@^1.0.1:
 requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
+resemblejs@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/resemblejs/-/resemblejs-2.2.4.tgz#83525e2adb77df77c8ad086a1b2510f032760c08"
 
 resolve-dir@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
This adds experimental support for *local* visual regression testing (#1698).

By "local" I mean that the reference images that detect whether visual regressions have occurred are stored locally on a developer's system, and not committed to version control.

Here's an example of what the output looks like, when I add `outline: 4px solid black` to the radio button label CSS:

![visual-regression-tool-screenshot-2](https://user-images.githubusercontent.com/124687/28739415-e5894f80-73c8-11e7-9c08-8e62fed2513c.png)

The visual diff is courtesy [Resemble.js](https://huddle.github.io/Resemble.js/).

Implementation-wise, it's essentially a kludge that sits atop the aXe test suite introduced in #2055. This is because the aXe test suite already takes care of loading every fractal component in headless Chrome, so it was easy to add another test that does a bit of screenshotting.

## Development workflow

It's easiest to explain how this works using an example.

1. A developer runs the following command:

    ```
    ENABLE_SCREENSHOTS=yup mocha --opts spec/mocha.opts spec/axe.spec.js
    ```

    For every Fractal component, the test runner detects if a screenshot for it exists in the `screenshots` directory. If not, it takes a screenshot of the component and saves it there. This is called "update" mode, and the screenshot generated is called the **golden** screenshot.

    On the other hand, if the screenshot *does* exist, it takes a screenshot of the component and compares it to the existing screenshot, raising an error if they do not match. This is called "compare" mode. For reference, the screenshot is saved to a different file, called the **fail** screenshot. Some metadata is also saved, so that an HTML5 front-end can be used to visually compare the two.

2. The developer makes refactoring changes to any SCSS files.

3. The developer re-runs the command from (1) to make sure no visual regressions have occurred. If they have occurred, a helpful failure message is shown, which points the user to an HTML5 file where they can visually compare the differences.

This can also be used by reviewers; for instance, if someone is reviewing a PR for a CSS refactoring, they can check out `develop`, run the screenshotter to generate the golden screenshots, then switch to the PR branch and re-run the screenshotter in compare mode.

## Why local?

1. I consider local visual regression testing to be a prerequisite for a service/CI-based approach. Developers should be able to make changes and get quick feedback about visual regressions--i.e., they shouldn't have to push to GitHub and wait for a service to tell them whether there's something amiss.

2. Visual regression testing is new to us, and it *seems* like something that's liable to produce false positives. If we integrate it into CI as something that *must* pass at all times, we run the risk of eventually ignoring it, if the false positive rate is too high. So I'd rather start out with it being an opt-in that can be used to suggest *potential* visual regressions, rather than being used as an undisputed source of truth.

3. To compare screenshots in a non-local way, we might have to guarantee that screenshots generated on different developers' systems will be identical, but that's very hard to do. For example, some aspects of Fractal components may be delegated to user-agent stylesheets, which may then be delegated to OS-specific stylesheets. We're using the Chrome DevTool Protocol's [`Emulation` domain](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/) to smooth out these differences, but some may still persist. And that's not accounting for the ways different operating systems might [antialias text](https://www.joelonsoftware.com/2007/06/12/font-smoothing-anti-aliasing-and-sub-pixel-rendering/), which could introduce more complications.

## To do

Some of these can be punted to later PRs.

- [ ] Determine whether this is actually useful.
- [ ] Take screenshots at multiple sizes.
- [ ] Document the mechanism (especially the `ENABLE_SCREENSHOTS` environment variable).
