### PR TITLE
Better headless chrome tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,36 @@ bin)/gulp` instead of `gulp`.)
 Note that running the tests also requires an installation of
 Chrome v59 or higher (v60 if you're on Windows).
 
+#### Visual regression testing
+
+The Standards come with optional tooling for detecting visual regressions,
+which can be especially useful if you're refactoring CSS.
+
+These tests work by comparing current screenshots of the Standards' Fractal
+components to "golden" screenshots that represent what the components are
+supposed to look like.
+
+Golden screenshots are stored on your local development system *only*;
+they're not version controlled.
+
+To generate the golden screenshots, run:
+
+```
+node spec/visual-regression-tester.js --updateGolden
+```
+
+Then, make any CSS refactorings (or switch to a branch that has them).
+
+To compare the current state of your CSS to the golden screenshots, run:
+
+```
+node spec/visual-regression-tester.js
+```
+
+If the current screenshots don't match their golden counterparts, you will
+be directed to an HTML file that visually shows the differences between
+any conflicting screenshots.
+
 ### Building
 
 To build the `uswds` package in preparation for releases, run:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "object-assign": "^4.1.1",
     "receptor": "^1.0.0",
     "resolve-id-refs": "^0.1.0",
-    "typescript": "^2.4.1"
+    "typescript": "^2.4.1",
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
     "@18f/stylelint-rules": "^1.2.0",

--- a/spec/axe-tester.js
+++ b/spec/axe-tester.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const AXE_JS = fs.readFileSync(__dirname + '/../node_modules/axe-core/axe.js');
+
+const AXE_CONTEXT = JSON.stringify({
+  exclude: [
+    // For some reason aXe takes a lot longer if it needs to dive into
+    // iframes with data: URIs. The content of these iframes is just for
+    // non-USWDS example content anyways, so just skip them to speed things
+    // up.
+    [ 'iframe[src^="data:"]' ],
+  ],
+});
+
+const AXE_OPTIONS = JSON.stringify({
+  rules: {
+    // Not all our examples need "skip to main content" links, so
+    // ignore that rule.
+    'bypass': { enabled: false },
+  },
+});
+
+// This function is only here so it can be easily .toString()'d
+// and run in the context of a web page by Chrome. It will not
+// be run in the node context.
+const RUN_AXE_FUNC_JS = function runAxe (context, options) {
+  return new Promise((resolve, reject) => {
+    window.axe.run(context, options, (err, results) => {
+      if (err) return reject(err);
+      resolve(JSON.stringify(results.violations));
+    });
+  });
+}.toString();
+
+function load (cdp) {
+  return cdp.Runtime.evaluate({
+    expression: `${AXE_JS};`,
+  }).then(details => {
+    assert.deepEqual(details, { result: { type: 'undefined' } },
+                     'Evaluating aXe source code should succeed');
+  });
+}
+
+function run (cdp) {
+  return cdp.Runtime.evaluate({
+    expression: `(${RUN_AXE_FUNC_JS})(${AXE_CONTEXT}, ${AXE_OPTIONS})`,
+    awaitPromise: true,
+  }).then(details => {
+    if (details.result.type !== 'string') {
+      return Promise.reject(new Error(
+        'Unexpected result from aXe JS evaluation: ' +
+        JSON.stringify(details.result, null, 2)
+      ));
+    }
+    const viols = JSON.parse(details.result.value);
+    if (viols.length > 0) {
+      return Promise.reject(new Error(
+        `Found ${viols.length} aXe violations: ` +
+        JSON.stringify(viols, null, 2) +
+        `\nTo debug these violations, install aXe at:\n\n` +
+        `  https://www.deque.com/products/axe/\n`
+      ));
+    }
+    return Promise.resolve();
+  });
+}
+
+module.exports = {
+  load,
+  run,
+};

--- a/spec/chrome-fractal-tester.js
+++ b/spec/chrome-fractal-tester.js
@@ -22,12 +22,10 @@ function getRemoteChrome () {
   const info = urlParse(REMOTE_CHROME_URL);
   if (info.protocol !== 'http:')
     throw new Error(`Unsupported protocol: ${info.protocol}`);
-  return new Promise(resolve => {
-    resolve({
-      host: info.hostname,
-      port: info.port,
-      kill () { return Promise.resolve(); },
-    });
+  return Promise.resolve({
+    host: info.hostname,
+    port: info.port,
+    kill () { return Promise.resolve(); },
   });
 }
 

--- a/spec/chrome-fractal-tester.js
+++ b/spec/chrome-fractal-tester.js
@@ -55,6 +55,10 @@ function loadPage ({ cdp, url }) {
   }));
 }
 
+function getHandles () {
+  return Array.from(fractal.components.flatten().map(c => c.handle));
+}
+
 const getChrome = REMOTE_CHROME_URL ? getRemoteChrome : launchChromeLocally;
 const server = fractal.web.server({ sync: false });
 const autobind = self => name => { self[ name ] = self[ name ].bind(self); };
@@ -64,7 +68,7 @@ class ChromeFractalTester {
     this.chrome = null;
     this.chromeHost = null;
     this.serverUrl = null;
-    this.handles = Array.from(fractal.components.flatten().map(c => c.handle));
+    this.handles = getHandles();
     [ 'setup',
       'createChromeDevtoolsProtocol',
       'loadFractalPreview',
@@ -102,5 +106,9 @@ class ChromeFractalTester {
     return this.chrome.kill();
   }
 }
+
+ChromeFractalTester.getHandles = () => {
+  return fractal.components.load().then(getHandles);
+};
 
 module.exports = ChromeFractalTester;

--- a/spec/chrome-fractal-tester.js
+++ b/spec/chrome-fractal-tester.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const os = require('os');
+const urlParse = require('url').parse;
+const chromeLauncher = require('chrome-launcher');
+const CDP = require('chrome-remote-interface');
+const fractal = require('../fractal');
+
+const HOSTNAME = os.hostname().toLowerCase();
+const REMOTE_CHROME_URL = process.env[ 'REMOTE_CHROME_URL' ];
+
+function launchChromeLocally (headless=true) {
+  return chromeLauncher.launch({
+    chromeFlags: [
+      '--disable-gpu',
+      headless ? '--headless' : '',
+    ],
+  });
+}
+
+function getRemoteChrome () {
+  const info = urlParse(REMOTE_CHROME_URL);
+  if (info.protocol !== 'http:')
+    throw new Error(`Unsupported protocol: ${info.protocol}`);
+  return new Promise(resolve => {
+    resolve({
+      host: info.hostname,
+      port: info.port,
+      kill () { return Promise.resolve(); },
+    });
+  });
+}
+
+function loadPage ({ cdp, url }) {
+  const { Page, Network } = cdp;
+
+  return Promise.all([
+    Page.enable(),
+    Network.enable(),
+  ]).then(() => new Promise((resolve, reject) => {
+    Network.responseReceived(({ response }) => {
+      if (response.status < 400) return;
+      reject(new Error(
+        `${response.url} returned HTTP ${response.status}!`
+      ));
+    });
+    Network.loadingFailed(details => {
+      reject(new Error('A network request failed to load: ' +
+                       JSON.stringify(details, null, 2)));
+    });
+    Page.loadEventFired(() => {
+      resolve();
+    });
+    Page.navigate({ url });
+  }));
+}
+
+const getChrome = REMOTE_CHROME_URL ? getRemoteChrome : launchChromeLocally;
+const server = fractal.web.server({ sync: false });
+const autobind = self => name => { self[ name ] = self[ name ].bind(self); };
+
+class ChromeFractalTester {
+  constructor () {
+    this.chrome = null;
+    this.chromeHost = null;
+    this.serverUrl = null;
+    [ 'setup',
+      'createChromeDevtoolsProtocol',
+      'loadFractalPreview',
+      'teardown' ].forEach(autobind(this));
+  }
+
+  setup () {
+    // Note that we're not killing the server; this is because
+    // the remote chrome instance (if we're using one) may be
+    // keeping some network connections to the server alive, which
+    // makes it harder to kill, so it's easier to just let mocha
+    // terminate the process when it's done running tests.
+    return server.start()
+      .then(getChrome)
+      .then(newChrome => {
+        this.chrome = newChrome;
+        this.chromeHost = this.chrome.host || 'localhost';
+        this.serverUrl = `http://${HOSTNAME}:${server.port}`;
+      });
+  }
+
+  createChromeDevtoolsProtocol () {
+    return CDP({
+      host: this.chromeHost,
+      port: this.chrome.port,
+    });
+  }
+
+  loadFractalPreview (cdp, handle) {
+    const url = `${this.serverUrl}/components/preview/${handle}`;
+    return loadPage({ url, cdp });
+  }
+
+  teardown () {
+    return this.chrome.kill();
+  }
+}
+
+module.exports = ChromeFractalTester;

--- a/spec/chrome-fractal-tester.js
+++ b/spec/chrome-fractal-tester.js
@@ -64,6 +64,7 @@ class ChromeFractalTester {
     this.chrome = null;
     this.chromeHost = null;
     this.serverUrl = null;
+    this.handles = Array.from(fractal.components.flatten().map(c => c.handle));
     [ 'setup',
       'createChromeDevtoolsProtocol',
       'loadFractalPreview',

--- a/spec/headless-chrome.spec.js
+++ b/spec/headless-chrome.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fractal = require('../fractal');
 const { fractalLoad } = require('./delayed-root-suite');
 const VisualRegressionTester = require('./visual-regression-tester');
 const ChromeFractalTester = require('./chrome-fractal-tester');
@@ -43,8 +42,8 @@ const DEVICES = [
 ];
 
 fractalLoad.then(() => {
-  const handles = Array.from(fractal.components.flatten().map(c => c.handle));
   const chromeFractalTester = new ChromeFractalTester();
+  const { handles } = chromeFractalTester;
 
   describe('fractal component', () => {
     before('setup ChromeFractalTester', chromeFractalTester.setup);

--- a/spec/headless-chrome.spec.js
+++ b/spec/headless-chrome.spec.js
@@ -52,6 +52,10 @@ fractalLoad.then(() => {
     after('teardown ChromeFractalTester', chromeFractalTester.teardown);
 
     if (process.env.ENABLE_SCREENSHOTS) {
+      if (process.env.UPDATE_GOLDEN_SCREENSHOTS) {
+        VisualRegressionTester.cleanSync(handles, DEVICES);
+      }
+
       after('create visual regression testing metadata',
             () => VisualRegressionTester.writeMetadata(handles, DEVICES));
     }

--- a/spec/headless-chrome.spec.js
+++ b/spec/headless-chrome.spec.js
@@ -6,42 +6,41 @@ const VisualRegressionTester = require('./visual-regression-tester');
 const ChromeFractalTester = require('./chrome-fractal-tester');
 const axeTester = require('./axe-tester');
 
+class Device {
+  constructor (name, metrics) {
+    this.name = name;
+    this.metrics = Object.assign({
+      deviceScaleFactor: 1,
+      mobile: false,
+      fitWindow: false,
+    }, metrics);
+  }
+
+  get description () {
+    const m = this.metrics;
+    const parts = [ `${m.width}x${m.height}` ];
+
+    if (m.deviceScaleFactor !== 1) parts.push(`@ ${m.deviceScaleFactor}x`);
+    if (m.mobile) parts.push('mobile');
+
+    return `${this.name} (${parts.join(' ')})`;
+  }
+}
+
 const SKIP_COMPONENTS = [
   // Any components that need to be temporarily skipped can be put
   // here. They will be regarded as a "pending test" by Mocha.
 ];
 const DEVICES = [
-  {
-    name: 'small-desktop',
-    metrics: {
-      width: 412,
-      height: 732,
-      deviceScaleFactor: 1,
-      mobile: false,
-      fitWindow: false,
-    },
-  },
-  {
-    name: 'large-desktop',
-    metrics: {
-      width: 1280,
-      height: 732,
-      deviceScaleFactor: 1,
-      mobile: false,
-      fitWindow: false,
-    },
-  },
+  new Device('small-desktop', {
+    width: 412,
+    height: 732,
+  }),
+  new Device('large-desktop', {
+    width: 1280,
+    height: 732,
+  }),
 ];
-
-DEVICES.forEach(d => {
-  const m = d.metrics;
-  const parts = [ `${m.width}x${m.height}` ];
-
-  if (m.deviceScaleFactor !== 1) parts.push(`@ ${m.deviceScaleFactor}x`);
-  if (m.mobile) parts.push('mobile');
-
-  d.description = `${d.name} (${parts.join(' ')})`;
-});
 
 fractalLoad.then(() => {
   const handles = Array.from(fractal.components.flatten().map(c => c.handle));

--- a/spec/screenshots/index.html
+++ b/spec/screenshots/index.html
@@ -78,7 +78,7 @@ details[open] > summary::before {
     <summary>
       The latest screenshot for the Fractal component
       <code data-var="handle"></code> does not match its golden
-      counterpart.
+      counterpart on the device <code data-var="device"></code>.
     </summary>
 
     <div class="usa-grid failure-details">

--- a/spec/visual-regression-tester.js
+++ b/spec/visual-regression-tester.js
@@ -164,6 +164,11 @@ if (!module.parent) {
         stdio: 'inherit',
       }).on('exit', code => { process.exit(code); });
     })
+    .command([ 'list' ], 'list tests', () => {}, argv => {
+      require('./chrome-fractal-tester').getHandles().then(handles => {
+        console.log(handles.join('\n'));
+      });
+    })
     .help()
     .argv;
 }

--- a/spec/visual-regression-tester.js
+++ b/spec/visual-regression-tester.js
@@ -16,7 +16,7 @@ const goldenName = (handle, device) => `${handle}_${device.name}.png`;
 
 const screenshotsPath = filename => path.join(SCREENSHOTS_DIR, filename);
 
-const safeDeleteSync = f => { if (fs.existsSync(f)) { fs.unlinkSync(f) } };
+const safeDeleteSync = f => { if (fs.existsSync(f)) fs.unlinkSync(f); };
 
 class VisualRegressionTester {
   constructor ({ handle, device }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,6 +1237,10 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -1737,6 +1741,14 @@ cross-spawn@^4.0.0:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -2439,6 +2451,18 @@ evp_bytestokey@^1.0.0:
   dependencies:
     create-hash "^1.1.1"
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execall@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
@@ -2616,6 +2640,12 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
 
 findup-sync@^0.4.2:
   version "0.4.3"
@@ -2817,6 +2847,10 @@ get-stdin@^4.0.1:
 get-stdin@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -3746,7 +3780,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -4099,6 +4133,15 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 localtunnel@1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/localtunnel/-/localtunnel-1.8.2.tgz#913051e8328b51f75ad8a22ad1f5c5b8c599a359"
@@ -4107,6 +4150,13 @@ localtunnel@1.8.2:
     openurl "1.1.0"
     request "2.78.0"
     yargs "3.29.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
@@ -4636,6 +4686,12 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -4701,6 +4757,10 @@ mime@1.2.4:
 mime@1.3.4, "mime@>= 0.0.1", mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
 minimalistic-assert@^1.0.0:
   version "1.0.0"
@@ -4978,6 +5038,12 @@ normalize.css@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-3.0.3.tgz#acc00262e235a2caa91363a2e5e3bfa4f8ad05c6"
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
@@ -5148,6 +5214,14 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
+
 os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
@@ -5162,6 +5236,20 @@ osenv@0, osenv@^0.1.0, osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
 
 package-json@^2.0.0:
   version "2.4.0"
@@ -5255,6 +5343,10 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -5262,6 +5354,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-object@^2.3.0:
   version "2.3.0"
@@ -5301,6 +5397,12 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.9"
@@ -5746,6 +5848,13 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0, read-pkg@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -5753,6 +5862,14 @@ read-pkg@^1.0.0, read-pkg@^1.1.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 "readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17, readable-stream@~1.0.26:
   version "1.0.34"
@@ -6241,6 +6358,16 @@ shasum@^1.0.0:
     json-stable-stringify "~0.0.0"
     sha.js "~2.4.4"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
@@ -6612,6 +6739,14 @@ strip-bom@^1.0.0:
   dependencies:
     first-chunk-stream "^1.0.0"
     is-utf8 "^0.2.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -7239,6 +7374,10 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+
 which@1, which@^1.0.5, which@^1.1.1, which@^1.2.12, which@^1.2.8, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
@@ -7387,6 +7526,12 @@ yargs-parser@^4.1.0:
   dependencies:
     camelcase "^3.0.0"
 
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@3.29.0:
   version "3.29.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.29.0.tgz#1aab9660eae79d8b8f675bcaeeab6ee34c2cf69c"
@@ -7451,6 +7596,24 @@ yargs@^4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
+
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
This adds some neat stuff to our aXe and visual regression tests like:

* Running the visual regression tests on both small and large desktop sizes (until now, we ran them only on small desktops)
* Factoring out some of the code into separate modules to make everything more understandable and less spaghetti-like
* Making `spec/visual-regression-tester.js` an executable script that can be used to directly execute visual regression tests, rather than requiring developers to run `mocha` with special environment variables
* Actually documented how to use the tester in `CONTRIBUTING.md`.