### PR TITLE
fix spelling on button css class

### DIFF
--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -190,7 +190,7 @@ button,
   }
 }
 
-.usa-button-secondar:disabled {
+.usa-button-secondary:disabled {
   background-color: $color-white;
 }
 


### PR DESCRIPTION
forgot a `y` on `secondary`

thanks @sawyerh 