### PR TITLE
Update form templates to new visual design

### DIFF
--- a/src/components/07-form/controls/dropdown.njk
+++ b/src/components/07-form/controls/dropdown.njk
@@ -2,7 +2,7 @@
   <form class="usa-form">
     <label for="options">Dropdown label</label>
     <select name="options" id="options">
-      <option value="">- Select -</option>
+      <option value>- Select -</option>
       <option value="value1">Option A</option>
       <option value="value2">Option B</option>
       <option value="value3">Option C</option>

--- a/src/components/07-form/templates/address-form.njk
+++ b/src/components/07-form/templates/address-form.njk
@@ -5,7 +5,8 @@
       <label for="mailing-address-1">Street address 1</label>
       <input id="mailing-address-1" name="mailing-address-1" type="text">
 
-      <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">(Optional)</span></label>
+      <label for="mailing-address-2" class="usa-input-optional">
+        Street address 2</label>
       <input id="mailing-address-2" name="mailing-address-2" type="text">
 
       <div>
@@ -17,7 +18,7 @@
         <div class="usa-input-grid usa-input-grid-small">
           <label for="state">State</label>
           <select id="state" name="state">
-            <option value></option>
+            <option value>- Select -</option>
             <option value="AL">Alabama</option>
             <option value="AK">Alaska</option>
             <option value="AZ">Arizona</option>

--- a/src/components/07-form/templates/name-form.njk
+++ b/src/components/07-form/templates/name-form.njk
@@ -2,19 +2,17 @@
   <form class="usa-form">
     <fieldset>
       <legend>Name</legend>
-      <label for="title">Title</label>
+      <label for="title" class="usa-input-optional">Title</label>
       <input class="usa-input-tiny" id="title" name="title" type="text">
 
-      <label for="first-name" class="usa-input-required">First name</label>
+      <label for="first-name">First name</label>
       <input id="first-name" name="first-name" type="text" required="" aria-required="true">
 
-      <label for="middle-name">Middle name</label>
+      <label for="middle-name" class="usa-input-optional">Middle name</label>
       <input id="middle-name" name="middle-name" type="text">
 
-      <label for="last-name" class="usa-input-required">Last name</label>
+      <label for="last-name">Last name</label>
       <input id="last-name" name="last-name" type="text" required="" aria-required="true">
 
-      <label for="suffix">Suffix</label>
-      <input class="usa-input-tiny" id="suffix" name="suffix" type="text">
     </fieldset>
   </form>

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -93,7 +93,7 @@ select {
 
 .usa-input-optional:after {
   color: $color-gray-medium;
-  content: ' - Optional';
+  content: ' - optional';
   font-style: italic;
 }
 

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -91,6 +91,12 @@ select {
   content: ' (*Required)';
 }
 
+.usa-input-optional:after {
+  color: $color-gray-medium;
+  content: ' - Optional';
+  font-style: italic;
+}
+
 label {
   display: block;
   margin-top: 3rem;


### PR DESCRIPTION
## Description

Changes the form templates to include "Optional" tags on form fields rather then "Required" tags. 

I added a input-optional class to be used in similar fashion as the input-required class. I think keeping the two consistent like this is better.

<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact standards.usa.gov’s look, feel, or functionality, please open a pull request on the web-design-standards-docs repo (https://github.com/18F/web-design-standards-docs).

-->

## Additional information

Requires https://github.com/18F/web-design-standards/pull/2115 to be complete as that PR modifies the dropdown menu which is part of this issue.

![screen shot 2017-08-22 at 11 54 55 am](https://user-images.githubusercontent.com/1701077/29582074-3680e180-8730-11e7-8d48-7432da81fa44.png)
![screen shot 2017-08-22 at 11 54 45 am](https://user-images.githubusercontent.com/1701077/29582073-36778f36-8730-11e7-92e5-dc05bfc42ba2.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
