### PR TITLE
Add variants for labels to be consistent

### DIFF
--- a/src/components/03-labels/labels.config.yml
+++ b/src/components/03-labels/labels.config.yml
@@ -1,0 +1,16 @@
+label: Labels
+status: ready
+preview: '@uswds-framed'
+
+variants:
+  - name: default
+    label: Info
+    context:
+      label:
+        classes: ""
+
+  - name: big
+    label: Big
+    context:
+      label:
+        classes: "usa-label-big"

--- a/src/components/03-labels/labels.njk
+++ b/src/components/03-labels/labels.njk
@@ -1,5 +1,1 @@
-<h6>Small</h6>
-<span class="usa-label">New</span>
-
-<h6>Large</h6>
-<span class="usa-label-big">New</span>
+<span class="usa-label {{ label.classes }}">New</span>


### PR DESCRIPTION
All components should make use of variants if they have them to
stay consistent.

