### PR TITLE
Make visual regression tester CLI more helpful

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ they're not version controlled.
 To generate the golden screenshots, run:
 
 ```
-node spec/visual-regression-tester.js --updateGolden
+node spec/visual-regression-tester.js test --updateGolden
 ```
 
 Then, make any CSS refactorings (or switch to a branch that has them).
@@ -111,7 +111,7 @@ Then, make any CSS refactorings (or switch to a branch that has them).
 To compare the current state of your CSS to the golden screenshots, run:
 
 ```
-node spec/visual-regression-tester.js
+node spec/visual-regression-tester.js test
 ```
 
 If the current screenshots don't match their golden counterparts, you will

--- a/spec/visual-regression-tester.js
+++ b/spec/visual-regression-tester.js
@@ -140,7 +140,9 @@ module.exports = VisualRegressionTester;
 
 if (!module.parent) {
   require('yargs')
-    .command([ 'test', '*' ], 'run visual regression tests', yargs => {
+    .strict()
+    .demandCommand()
+    .command([ 'test' ], 'run visual regression tests', yargs => {
       yargs.alias('g', 'grep')
         .describe('g', 'only run tests matching a pattern')
         .nargs('g', 1);


### PR DESCRIPTION
This fixes #2126. Now any time an unrecognized command or option is passed in, a helpful error message is displayed, instead of being silently ignored.

That said, the only way I could get the program to output an "unrecognized command" error message was by requiring that an explicit command name be passed in, rather than defaulting to `test`. So I've updated the instructions to explicitly use the `test` command.
