### PR TITLE
Fix disabled buttons

### DIFF
--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -4,11 +4,18 @@
 {%- endif %}
 
 <button class="{{ classes }}">Default</button>
-{% if (category != 'big') -%}
+{% if (category != 'disabled') and (category != 'big') -%}
   <button class="{{ classes }} usa-button-hover">Hover</button>
   <button class="{{ classes }} usa-button-active">Active</button>
   <button class="{{ classes }} usa-focus">Focus</button>
   <button class="{{ classes }}" disabled>Disabled</button>
+  {% if (category == 'primary') -%}
+    <button class="usa-button-disabled" disabled>Disabled (deprecated)</button>
+  {%- elif (category == 'secondary') -%}
+    <button class="usa-button-secondary-disabled" disabled>Disabled (deprecated)</button>
+  {%- elif (category == 'secondary-inverse') -%}
+    <button class="usa-button-secondary-inverse-disabled" disabled>Disabled (deprecated)</button>
+  {%- endif %}
 {%- endif %}
 
 {% if (classes == 'usa-button-secondary-inverse') %}

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -4,17 +4,11 @@
 {%- endif %}
 
 <button class="{{ classes }}">Default</button>
-{% if (category != 'disabled') and (category != 'big') -%}
+{% if (category != 'big') -%}
   <button class="{{ classes }} usa-button-hover">Hover</button>
   <button class="{{ classes }} usa-button-active">Active</button>
   <button class="{{ classes }} usa-focus">Focus</button>
-  {% if (category == 'secondary') -%}
-    <button class="usa-button-secondary-disabled">Disabled</button>
-  {% elif (category == 'secondary-inverse') -%}
-    <button class="usa-button-secondary-inverse-disabled">Disabled</button>
-  {% else -%}
-    <button class="usa-button-disabled">Disabled</button>
-  {%- endif %}
+  <button class="{{ classes }}" disabled>Disabled</button>
 {%- endif %}
 
 {% if (classes == 'usa-button-secondary-inverse') %}

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -192,6 +192,8 @@ html .usa-button-secondary-disabled,          // Deprecated
 html .usa-button-secondary-inverse-disabled,  // Deprecated
 .usa-button-secondary-inverse:disabled {
   background-color: transparent;
+  color: $color-gray;
+  box-shadow: $button-stroke $color-gray;
 }
 
 @mixin button-unstyled {

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -154,7 +154,7 @@ button,
   }
 
   &:disabled {
-    @include disabledesque
+    @include disabledesque;
   }
 }
 /* stylelint-disable */

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -4,6 +4,24 @@ $button-stroke: inset 0 0 0 2px;
 
 // Buttons
 
+// This mixin is only needed until we fully remove the
+// deprecated usa-button-disabled style.
+@mixin disabledesque {
+  background-color: $color-gray-lighter;
+  pointer-events: none;
+
+  &:hover,
+  &.usa-button-hover,
+  &:active,
+  &.usa-button-active,
+  &:focus,
+  &.usa-focus {
+    background-color: $color-gray-lighter;
+    border: 0;
+    box-shadow: none;
+  }
+}
+
 /* stylelint-disable selector-no-qualifying-type */
 .usa-button,
 .usa-button-primary,
@@ -134,25 +152,20 @@ button,
     font-size: 1.9rem;
     padding: 1.5rem 3rem;
   }
+
+  &:disabled {
+    @include disabledesque
+  }
 }
 /* stylelint-disable */
 
-.usa-button:disabled {
-  background-color: $color-gray-lighter;
-  pointer-events: none;
-
-  &:hover,
-  &.usa-button-hover,
-  &:active,
-  &.usa-button-active,
-  &:focus,
-  &.usa-focus {
-    background-color: $color-gray-lighter;
-    border: 0;
-    box-shadow: none;
-  }
+.usa-button-disabled  // Deprecated
+{
+  @include disabledesque
 }
 
+.usa-button-secondary-disabled,          // Deprecated
+.usa-button-secondary-inverse-disabled,  // Deprecated
 .usa-button-secondary:disabled,
 .usa-button-secondary-inverse:disabled,
 .usa-button-outline-inverse:disabled {   // Outline inverse to be deprecated in 2.0
@@ -171,10 +184,12 @@ button,
   }
 }
 
+html .usa-button-secondary-disabled,          // Deprecated
 .usa-button-secondary:disabled {
   background-color: $color-white;
 }
 
+html .usa-button-secondary-inverse-disabled,  // Deprecated
 .usa-button-secondary-inverse:disabled {
   background-color: transparent;
 }


### PR DESCRIPTION
**Note: This is a PR against #2151, not `develop`!**

[ 😎 PREVIEW ](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/fix-disabled-buttons/components/detail/buttons--primary.html)

This attempts to fix the problems with disabled buttons explained in https://github.com/18F/web-design-standards/pull/2151#issuecomment-332958442.

There's multiple ways we can go about fixing this:

1. Bring back the `usa-button-disabled` class and all its variants, which seem to have been removed in #2098 (where this regression seems to have originated).  I think this may be necessary to classify our release as a minor version update, since otherwise it's a breaking change, as clients will have to change the way they mark up disabled buttons.

2. Don't bring back any of the classes that were removed, and modify our CSS/fractal component markup as needed to make them work with the `disabled` attribute and the button's base class instead. This will result in a cleaner markup API but it's a breaking change, so I recommend not doing it unless we upgrade our major version (i.e., release 2.0).

3. Attempt to have the best of both worlds by introducing the new markup API described in (2), but keeping the old `usa-button-disabled` class and its variants mentioned in (1) and documenting them as deprecated.

@donjo @msecret thoughts on this?
