### PR TITLE
update password guidance

### DIFF
--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -15,12 +15,7 @@
     </div>
 
     <label for="password">New password</label>
-    <input id="password" name="password" type="password"
-      aria-describedby="validation_list"
-      data-validate-length=".{8,}"
-      data-validate-uppercase="[A-Z]"
-      data-validate-numerical="\d"
-      data-validation-element="#validation_list">
+    <input id="password" name="password" type="password">
 
     <label for="confirmPassword">Confirm password</label>
     <input id="confirmPassword" name="confirmPassword" type="password">

--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -5,14 +5,13 @@
 
     <div class="usa-alert usa-alert-info">
       <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">Passwords must:</h3>
+        <h3 class="usa-alert-heading">Password information</h3>
+        <p class="usa-alert-text">
+          Length requirements
+          <br>
+          Character constraints, if any
+        </p>
       </div>
-      <ul class="usa-checklist" id="validation_list">
-        <li data-validator="length">Be at least 8 characters</li>
-        <li data-validator="uppercase">Have at least 1 uppercase character</li>
-        <li data-validator="numerical">Have at least 1 numerical character</li>
-        <li>Another requirement</li>
-      </ul>
     </div>
 
     <label for="password">New password</label>

--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -5,13 +5,14 @@
 
     <div class="usa-alert usa-alert-info">
       <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">Password information</h3>
-        <p class="usa-alert-text">
-          Length requirements
-          <br>
-          Character constraints, if any
-        </p>
+        <h3 class="usa-alert-heading">Passwords must:</h3>
       </div>
+      <ul class="usa-checklist" id="validation_list">
+        <li data-validator="length">Be at least 8 characters</li>
+        <li data-validator="uppercase">Have at least 1 uppercase character</li>
+        <li data-validator="numerical">Have at least 1 numerical character</li>
+        <li>Another requirement</li>
+      </ul>
     </div>
 
     <label for="password">New password</label>


### PR DESCRIPTION
Updates the password guidance as referenced in 18F/web-design-standards-docs#371

Because the previous example did not align with NIST password guidelines we decided that the Standards should not take an opinion on what the password reset guidance should be, just where you could potentially provide that information. 

We could link to additional resources for formulating password guidelines on the docs site page for password reset.