### PR TITLE
[Hero component]: Change button to use primary button

### DIFF
--- a/src/components/hero/hero.njk
+++ b/src/components/hero/hero.njk
@@ -13,7 +13,7 @@
       {% endif %}
 
       {% if hero.button %}
-      <a class="usa-button usa-button-big usa-button-secondary" href="{{ hero.button.href }}">{{ hero.button.text }}</a>
+      <a class="usa-button usa-button-big" href="{{ hero.button.href }}">{{ hero.button.text }}</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Changes the hero template from using `usa-button-secondary` to just `usa-button` (primary). This button used to be red but some changes were made to the buttons that made  `usa-button-secondary` into the outline button.

Preview: https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/fix-landing-button/components/detail/layout--landing.html

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
