### PR TITLE
[Select input]: Fix disappearing arrow on select dropdown after autofill in Chrome

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -126,6 +126,7 @@ select {
   // Show default webkit style on select element when autofilled to show icon
   &:-webkit-autofill {
     appearance: menulist;
+  }
 
   // Remove dotted outline from select element on focus in Firefox
   &:-moz-focusring {

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -122,6 +122,11 @@ select {
   &::-ms-expand {
     display: none;
   }
+
+  // Show default webkit style on select element when autofilled to show icon
+  &:-webkit-autofill {
+    appearance: menulist;
+  }
 }
 
 option:first-child {


### PR DESCRIPTION
Show default webkit style on select element when autofilled to show icon.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/fix-select-autofill-chrome)

Fixes: #567

