### PR TITLE
[Select input]: Remove duplicate focus border within dropdown box in Firefox

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -122,6 +122,12 @@ select {
   &::-ms-expand {
     display: none;
   }
+
+  // Remove dotted outline from select element on focus in Firefox
+  &:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 $color-black;
+  }
 }
 
 option:first-child {


### PR DESCRIPTION
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/fix-select-firefox)

Fixes #411.