### PR TITLE
[Typography]: Change text max width to 66ch (character units)

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -128,7 +128,7 @@ $image-path:  '../img' !default;
 $asset-pipeline:      false !default;
 
 // Magic Numbers
-$text-max-width:          53rem !default;
+$text-max-width:          66ch !default; // 66 characters per line
 $lead-max-width:          77rem !default;
 $site-max-width:          1040px !default;
 $site-margins:            3rem !default;

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -110,7 +110,7 @@ dfn {
 // Custom typography
 
 .usa-content {
-  p:not(.usa-font-lead),
+  p,
   ul:not(.usa-accordion):not(.usa-accordion-bordered),
   ol:not(.usa-accordion):not(.usa-accordion-bordered) {
     max-width: $text-max-width;


### PR DESCRIPTION
Change the text max width to 66ch (character units) to be more explicit and resilient with use of other font families, styles, and sizes.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/update-character-max-width)

Fixes #1866.