### PR TITLE
Fix focus state on hover

### DIFF
--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -28,3 +28,9 @@ body {
 [hidden] {
   display: none !important; /* stylelint-disable-line declaration-no-important */
 }
+
+*:focus,
+.usa-focus {
+  outline: $focus-outline;
+  outline-offset: $focus-spacing;
+}

--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -31,6 +31,5 @@ body {
 
 *:focus,
 .usa-focus {
-  outline: $focus-outline;
-  outline-offset: $focus-spacing;
+  @include focus;
 }

--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -28,9 +28,3 @@ body {
 [hidden] {
   display: none !important; /* stylelint-disable-line declaration-no-important */
 }
-
-*:focus,
-.usa-focus {
-  outline: $focus-outline;
-  outline-offset: $focus-spacing;
-}

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -36,6 +36,12 @@
   text-transform: uppercase;
 }
 
+// Focus state mixin
+@mixin focus {
+  outline: $focus-outline;
+  outline-offset: $focus-spacing;
+}
+
 // Mobile-first media query helper
 @mixin media($bp) {
   @media screen and (min-width: #{$bp}) {

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -22,9 +22,20 @@ a {
     color: $color-primary-darker;
   }
 
+  &:focus {
+    outline: $focus-outline;
+    outline-offset: $focus-spacing;
+  }
+
   &:visited {
     color: $color-visited;
   }
+}
+
+*:focus,
+.usa-focus {
+  outline: $focus-outline;
+  outline-offset: $focus-spacing;
 }
 
 @mixin external-link($external-link, $external-link-hover) {

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -23,8 +23,7 @@ a {
   }
 
   &:focus {
-    outline: $focus-outline;
-    outline-offset: $focus-spacing;
+    @include focus;
   }
 
   &:visited {

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -32,12 +32,6 @@ a {
   }
 }
 
-*:focus,
-.usa-focus {
-  outline: $focus-outline;
-  outline-offset: $focus-spacing;
-}
-
 @mixin external-link($external-link, $external-link-hover) {
   &::after {
     background: url('#{$image-path}/#{$external-link}.png') no-repeat 0 0;

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -8,9 +8,9 @@
 // Core -------------- //
 @import 'core/variables';
 @import 'core/fonts';
+@import 'core/utilities';
 @import 'core/base';
 @import 'core/grid';
-@import 'core/utilities';
 
 // Elements -------------- //
 // Styles basic HTML elements


### PR DESCRIPTION
Fixes focus state by adding it after a link i.e. `a:focus` bc `*:focus` was causing it to disappear on hover.

Moves focus code from `base.scss` to `typography.scss`. 
- Is there a reason it should be in `base.scss` that I'm not aware of?

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/fix-focus)

Fixes #2184.

## Ways to improve
We can make focus a mixin so the 2 CSS declarations are not in two separate places or add `a:focus` into the other block, but I also like for link behavior to be together in the link code block.

### Question 
Is `*:focus` working on any other component?