### PR TITLE
[Tables]: Fix table style and accessibility

### DIFF
--- a/src/components/04-tables/tables.njk
+++ b/src/components/04-tables/tables.njk
@@ -56,7 +56,7 @@
       </tr>
       <tr>
         <th scope="row">Declaration of Sentiments</th>
-        <td>MadeA document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
+        <td>A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
         <td>1848</td>
       </tr>
       <tr>

--- a/src/components/04-tables/tables.njk
+++ b/src/components/04-tables/tables.njk
@@ -1,7 +1,5 @@
-
-  <h6>Bordered Table</h6>
-
   <table>
+    <caption>Bordered table</caption>
     <thead>
       <tr>
         <th scope="col">Document title</th>
@@ -33,9 +31,8 @@
     </tbody>
   </table>
 
-  <h6>Borderless Table</h6>
-
   <table class="usa-table-borderless">
+    <caption>Borderless table</caption>
     <thead>
       <tr>
         <th scope="col">Document Title</th>

--- a/src/components/04-tables/tables.njk
+++ b/src/components/04-tables/tables.njk
@@ -32,7 +32,7 @@
   </table>
 
   <table class="usa-table-borderless">
-    <caption>Borderless table</caption>
+    <caption>Borderless table: A borderless table can be useful when you want the information to feel more a part of the text it accompanies and extends.</caption>
     <thead>
       <tr>
         <th scope="col">Document Title</th>

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -39,6 +39,12 @@ td {
     border-left: 0;
     border-right: 0;
   }
+
+  th {
+    &:first-child {
+     padding-left: 0;
+    }
+  }
 }
 
 caption {

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -42,6 +42,8 @@ td {
 }
 
 caption {
+  @include h5;
+  font-family: $font-serif;
   margin-bottom: 0.5em;
   text-align: left;
 }

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -41,3 +41,9 @@ td {
     border-right: 0;
   }
 }
+
+caption {
+  @include h6;
+  margin-bottom: 0.5em;
+  text-align: left;
+}

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -1,7 +1,6 @@
 table {
   border-spacing: 0;
   margin: 2em 0;
-  min-width: 100%;
 }
 
 thead {

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -44,6 +44,6 @@ td {
 caption {
   @include h5;
   font-family: $font-serif;
-  margin-bottom: 0.5em;
+  margin-bottom: 1.2rem;
   text-align: left;
 }

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -29,7 +29,7 @@ td {
 .usa-table-borderless {
   thead {
     th {
-      background-color: $color-white;
+      background-color: transparent;
       border-top: 0;
     }
   }

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -42,7 +42,7 @@ td {
 
   th {
     &:first-child {
-     padding-left: 0;
+      padding-left: 0;
     }
   }
 }

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -43,7 +43,6 @@ td {
 }
 
 caption {
-  @include h6;
   margin-bottom: 0.5em;
   text-align: left;
 }

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -24,12 +24,13 @@ td {
   background-color: $color-white;
   border: 1px solid $color-gray;
   font-weight: $font-normal;
-  padding: 1.5rem;
+  padding: 1rem 1.5rem;
 }
 
 .usa-table-borderless {
   thead {
     th {
+      background-color: $color-white;
       border-top: 0;
     }
   }


### PR DESCRIPTION
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/fix-tables)

## Visual design
- Reduces top/bottom spacing on table cells to match the latest visual designs. 
- Removes the gray background on borderless table.
- Removes `min-width: 100%` from tables so it doesn't take up the whole width for smaller data. Fixes #1621. Smaller table example:
<img width="489" alt="screen shot 2017-10-25 at 5 02 06 pm" src="https://user-images.githubusercontent.com/5249443/32028942-39a115b2-b9a6-11e7-88e5-8f8785aca6e3.png">

## Accessibility
- Fixes accessibility issue where the table title should be a caption (Fixes #1495). 
- Left aligns `<caption>` and adds a bottom margin

**Question**: How do we style the `<caption>`? 

I was going back and forth whether style the caption to look like the h6 style, add an h6 into the caption to give it that style (but I don't want to promote people to copy and paste this). I ended up just floating it left and adding a reasonable bottom margin and leaving the basic text styling. Does the left aligned caption make sense or should we leave the browser default centered? @thisisdano 
