### PR TITLE
Reduce ambiguity in footer-big secondary links

### DIFF
--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -11,7 +11,7 @@
           </li>
           <li><a href="javascript:void(0);">Secondary link</a></li>
           <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link that's a bit longer than most of the others</a></li>
           <li><a href="javascript:void(0);">Secondary link</a></li>
         </ul>
         <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
@@ -19,7 +19,7 @@
             <h4>Topic</h4>
           </li>
           <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link that's pretty long</a></li>
           <li><a href="javascript:void(0);">Secondary link</a></li>
           <li><a href="javascript:void(0);">Secondary link</a></li>
         </ul>

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -357,8 +357,8 @@ li.usa-footer-primary-content {
 
     li:not(.usa-footer-primary-link) {
       line-height: 1.35;
-      padding-bottom: rem(6px);
-      padding-top: rem(6px);
+      padding-bottom: .35em;
+      padding-top: .35em;
     }
 
     .usa-footer-primary-link {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -341,7 +341,7 @@ li.usa-footer-primary-content {
   }
 
   ul {
-    padding-bottom: 2.5rem;
+    padding-bottom: rem(24px);
 
     @include media($medium-screen) {
       padding-bottom: 0;
@@ -355,8 +355,10 @@ li.usa-footer-primary-content {
       }
     }
 
-    li {
-      line-height: 2em;
+    li:not(.usa-footer-primary-link) {
+      line-height: 1.35;
+      padding-bottom: rem(6px);
+      padding-top: rem(6px);
     }
 
     .usa-footer-primary-link {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -357,8 +357,8 @@ li.usa-footer-primary-content {
 
     li:not(.usa-footer-primary-link) {
       line-height: $heading-line-height;
-      padding-bottom: .35em;
-      padding-top: .35em;
+      padding-bottom: 0.35em;
+      padding-top: 0.35em;
     }
 
     .usa-footer-primary-link {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -341,7 +341,7 @@ li.usa-footer-primary-content {
   }
 
   ul {
-    padding-bottom: rem(24px);
+    padding-bottom: 2.4rem;
 
     @include media($medium-screen) {
       padding-bottom: 0;
@@ -356,7 +356,7 @@ li.usa-footer-primary-content {
     }
 
     li:not(.usa-footer-primary-link) {
-      line-height: 1.35;
+      line-height: $heading-line-height;
       padding-bottom: .35em;
       padding-top: .35em;
     }

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -8,9 +8,9 @@
 // Core -------------- //
 @import 'core/variables';
 @import 'core/fonts';
+@import 'core/grid';
 @import 'core/utilities';
 @import 'core/base';
-@import 'core/grid';
 
 // Elements -------------- //
 // Styles basic HTML elements


### PR DESCRIPTION
This reduces the line height of secondary links in the footer, and compensates vertical rhythm with with padding so multi-line links have less leading than the space between adjacent links.

**Note: this ALSO addresses an issue where changing the import order in the `uswds.scss` broke the grid — and maybe other stuff too.**

![line-height](https://user-images.githubusercontent.com/11464021/32079740-d98cfe32-ba60-11e7-9fe5-707a4fcbcb32.png)
