### PR TITLE
Adjust radio button focus outline spacing

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -226,7 +226,7 @@ legend {
 
 [type=radio]:focus + label::before {
   outline: $focus-outline;
-  outline-offset: 5px;
+  outline-offset: $focus-spacing * 2; // Double the offset to account for circular shape
 }
 
 [type=checkbox]:disabled + label {


### PR DESCRIPTION
fixes #2145 

**Release note**: Adjusted the focus outline spacing on radio buttons. Because of the way the `outline-offset` is applied to circular shapes, the outline around radio buttons was a bit tighter than the rest of the elements. Doubling the offset on radio buttons ensures there is the same amount of space from the edge of the circle to the dotted line.
 
<img width="263" alt="screen shot 2017-10-27 at 11 58 03 am" src="https://user-images.githubusercontent.com/776987/32115888-1f22d7d4-bb0e-11e7-942f-2697d6c096e9.png">
<img width="225" alt="screen shot 2017-10-27 at 11 57 53 am" src="https://user-images.githubusercontent.com/776987/32115889-1f300fe4-bb0e-11e7-9b7f-279079f6ef45.png">
