### PR TITLE
Consistent form control labels

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -88,13 +88,12 @@ select {
 
 .usa-input-required:after {
   color: $color-secondary-darkest;
-  content: ' (*Required)';
+  content: ' (*required)';
 }
 
 .usa-input-optional:after {
   color: $color-gray-medium;
-  content: ' - optional';
-  font-style: italic;
+  content: ' (optional)';
 }
 
 label {


### PR DESCRIPTION
Fixes #2183 

Applying the knowledge from #1504 I adjusted the content supplied by the `usa-input-required` and `usa-input-optional` to be as similar as possible.

- I went with lowercase for both words because an uppercase `O` next to a `(` is hard to read.
- Kept the `*` in required for the accessibility reasons
- Colors stayed the same. 
- Removed italics from optional 