### PR TITLE
Finishing big button polish

### DIFF
--- a/src/components/hero/hero.config.yml
+++ b/src/components/hero/hero.config.yml
@@ -5,10 +5,7 @@ context:
   hero:
     callout: 'Hero callout:'
     title: Call attention to a current priority
-    link:
-      text: Link to more about that priority
-      href: 'javascript:void(0)'
+    paragraph: Support the callout with some short explanatory text. You don't need more than a couple of sentences.
     button:
       text: Learn about what we do
       href: 'javascript:void(0)'
-

--- a/src/components/hero/hero.njk
+++ b/src/components/hero/hero.njk
@@ -8,8 +8,8 @@
         {{ hero.title }}
       </h2>
 
-      {% if hero.link %}
-      <a class="usa-hero-link" href="{{ hero.link.href }}">{{ hero.link.text }}</a>
+      {% if hero.paragraph %}
+      <p class="usa-hero-paragraph">{{ hero.paragraph }}</p>
       {% endif %}
 
       {% if hero.button %}

--- a/src/components/hero/hero.njk
+++ b/src/components/hero/hero.njk
@@ -9,7 +9,7 @@
       </h2>
 
       {% if hero.paragraph %}
-      <p class="usa-hero-paragraph">{{ hero.paragraph }}</p>
+      <p>{{ hero.paragraph }}</p>
       {% endif %}
 
       {% if hero.button %}

--- a/src/components/hero/hero.njk
+++ b/src/components/hero/hero.njk
@@ -13,7 +13,7 @@
       {% endif %}
 
       {% if hero.button %}
-      <a class="usa-button usa-button-big" href="{{ hero.button.href }}">{{ hero.button.text }}</a>
+      <a class="usa-button" href="{{ hero.button.href }}">{{ hero.button.text }}</a>
       {% endif %}
     </div>
   </div>

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -29,20 +29,9 @@
   > *:first-child {
     @include margin(0 null $spacing-medium null);
   }
-
-  .usa-button {
-    padding: 1.5rem 3rem;
-    margin-top: $spacing-medium;
-    width: 100%;
-  }
 }
 
 .usa-hero-callout-alt {
   color: $color-white;
   display: block;
-}
-
-.usa-hero-paragraph {
-  margin-bottom: 0.5rem;
-  margin-top: 0.5rem;
 }

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -32,6 +32,7 @@
 
   .usa-button {
     font-size: $small-font-size;
+    padding: 1.5rem 3rem;
     margin-top: 7rem;
     width: 100%;
   }

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -27,13 +27,12 @@
   }
 
   > *:first-child {
-    @include margin(0 null $site-margins null);
+    @include margin(0 null $spacing-medium null);
   }
 
   .usa-button {
-    font-size: $small-font-size;
     padding: 1.5rem 3rem;
-    margin-top: 7rem;
+    margin-top: $spacing-medium;
     width: 100%;
   }
 }
@@ -41,4 +40,9 @@
 .usa-hero-callout-alt {
   color: $color-white;
   display: block;
+}
+
+.usa-hero-paragraph {
+  margin-bottom: 0.5rem;
+  margin-top: 0.5rem;
 }

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -149,8 +149,9 @@ button,
   }
 
   &.usa-button-big {
-    font-size: 1.9rem;
-    padding: 1.5rem 3rem;
+    border-radius: $button-border-radius * 2; //Double the radius for larger button
+    font-size: 2.4rem;
+    padding: 1.5rem 5rem;
   }
 
   &:disabled {


### PR DESCRIPTION
Fixes #2144 

When 1.4 was created we missed a few changes on the big button class necessary for it to match the designs below. 

![screen shot 2017-10-27 at 4 04 31 pm](https://user-images.githubusercontent.com/776987/32125227-85ea6456-bb30-11e7-957c-a07291d5b96e.png)

Changes: 
- Font size increased to 24pt
- Border radius doubled from default
- Horizontal padding increased (in the Sketch file the big button is 30px wider on each side than the standard button so I applied that here. However, our current standard buttons are not as wide in code as they are in Sketch. I'm inclined to default to the narrower presentation we're currently running with)

cc/ @thisisdano  