### PR TITLE
[Date input] Remove pattern attribute from date input

### DIFF
--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -6,15 +6,15 @@
     <div class="usa-date-of-birth">
       <div class="usa-form-group usa-form-group-month">
         <label for="date_of_birth_1">Month</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" type="number" min="1" max="12" value="">
       </div>
       <div class="usa-form-group usa-form-group-day">
         <label for="date_of_birth_2">Day</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" type="number" min="1" max="31" value="">
       </div>
       <div class="usa-form-group usa-form-group-year">
         <label for="date_of_birth_3">Year</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
+        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" type="number" min="1900" max="2000" value="">
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
Fixes #2200.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/remove-pattern-date/components/detail/date-input.html)

## Acceptance criteria
- [x] Number pad still opens on mobile devices
- Checked on iPhone 7