### PR TITLE
Add vertical space around sidenav at small widths

### DIFF
--- a/src/components/08-navigation/sidenav.config.yml
+++ b/src/components/08-navigation/sidenav.config.yml
@@ -1,5 +1,6 @@
 label: Side navigation
 status: ready
+preview: '@uswds-content'
 
 context:
   sidenav:

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -6,3 +6,10 @@
 .usa-sidenav-sub_list {
   @include usa-sidenav-sublist;
 }
+
+.usa-layout-docs-sidenav {
+  padding-top: 2.4rem;
+  @include media($large-screen) {
+    padding-top: 0;
+  }
+}

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -1,17 +1,19 @@
 
 .usa-sidenav-list {
   @include usa-sidenav-list;
-  @include margin(null (-$site-margins-mobile) null (-$site-margins-mobile));
   border-bottom: 1px solid;
   border-top: 1px solid;
 
-  @include media($medium-screen) {
-    @include margin(null 0);
+  @include media($large-screen) {
+    border-bottom: none;
+    border-top: none;
   }
 
-  @include media($large-screen) {
-    border: none;
-    margin: 0;
+  .usa-grid & {
+    @include margin(null (-$site-margins-mobile) null (-$site-margins-mobile));
+    @include media($medium-screen) {
+      @include margin(null 0);
+    }
   }
 }
 

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -11,6 +11,7 @@
 
   .usa-grid & {
     @include margin(null (-$site-margins-mobile) null (-$site-margins-mobile));
+
     @include media($medium-screen) {
       @include margin(null 0);
     }

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -1,6 +1,18 @@
 
 .usa-sidenav-list {
   @include usa-sidenav-list;
+  @include margin(null (-$site-margins-mobile) null (-$site-margins-mobile));
+  border-bottom: 1px solid;
+  border-top: 1px solid;
+
+  @include media($medium-screen) {
+    @include margin(null 0);
+  }
+
+  @include media($large-screen) {
+    border: none;
+    margin: 0;
+  }
 }
 
 .usa-sidenav-sub_list {

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -9,6 +9,7 @@
 
 .usa-layout-docs-sidenav {
   padding-top: 2.4rem;
+
   @include media($large-screen) {
     padding-top: 0;
   }

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -174,6 +174,17 @@
 
 @mixin usa-sidenav-list {
   @include unstyled-list();
+  @include margin(null (-$site-margins-mobile) null (-$site-margins-mobile));
+  border-bottom: 1px solid;
+  border-top: 1px solid;
+  @include media($medium-screen) {
+    @include margin(null 0);
+    max-width: none;
+  }
+  @include media($large-screen) {
+    border: none;
+    margin: 0;
+  }
 
   > li {
     background-color: transparent;
@@ -191,7 +202,7 @@
     display: block;
     font-family: $font-sans;
     line-height: 1.3;
-    padding: 0.85rem 1rem 0.85rem 1.8rem;
+    padding: 0.85rem 1rem 0.85rem $site-margins-mobile;
     text-decoration: none;
 
     &:hover {
@@ -207,10 +218,11 @@
     }
 
     &.usa-current { /* stylelint-disable-line selector-no-qualifying-type */
-      border-left: 0.4rem solid $color-primary;
+      $current-border: 0.4rem;
+      border-left: $current-border solid $color-primary;
       color: $color-primary;
       font-weight: $font-bold;
-      padding-left: 1.4rem;
+      padding-left: $site-margins-mobile - $current-border;
     }
   }
 }

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -207,11 +207,10 @@
     }
 
     &.usa-current { /* stylelint-disable-line selector-no-qualifying-type */
-      $current-link-border: 0.4rem;
-      border-left: $current-link-border solid $color-primary;
+      border-left: $current-highlight-border-width solid $color-primary;
       color: $color-primary;
       font-weight: $font-bold;
-      padding-left: $site-margins-mobile - $current-link-border;
+      padding-left: $site-margins-mobile - $current-highlight-border-width;
     }
   }
 }

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -177,10 +177,12 @@
   @include margin(null (-$site-margins-mobile) null (-$site-margins-mobile));
   border-bottom: 1px solid;
   border-top: 1px solid;
+
   @include media($medium-screen) {
     @include margin(null 0);
     max-width: none;
   }
+
   @include media($large-screen) {
     border: none;
     margin: 0;

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -207,10 +207,10 @@
     }
 
     &.usa-current { /* stylelint-disable-line selector-no-qualifying-type */
-      border-left: $current-highlight-border-width solid $color-primary;
+      border-left: $sidenav-current-border-width solid $color-primary;
       color: $color-primary;
       font-weight: $font-bold;
-      padding-left: $site-margins-mobile - $current-highlight-border-width;
+      padding-left: $site-margins-mobile - $sidenav-current-border-width;
     }
   }
 }

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -180,7 +180,6 @@
 
   @include media($medium-screen) {
     @include margin(null 0);
-    max-width: none;
   }
 
   @include media($large-screen) {
@@ -220,11 +219,11 @@
     }
 
     &.usa-current { /* stylelint-disable-line selector-no-qualifying-type */
-      $current-border: 0.4rem;
-      border-left: $current-border solid $color-primary;
+      $current-link-border: 0.4rem;
+      border-left: $current-link-border solid $color-primary;
       color: $color-primary;
       font-weight: $font-bold;
-      padding-left: $site-margins-mobile - $current-border;
+      padding-left: $site-margins-mobile - $current-link-border;
     }
   }
 }

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -174,18 +174,6 @@
 
 @mixin usa-sidenav-list {
   @include unstyled-list();
-  @include margin(null (-$site-margins-mobile) null (-$site-margins-mobile));
-  border-bottom: 1px solid;
-  border-top: 1px solid;
-
-  @include media($medium-screen) {
-    @include margin(null 0);
-  }
-
-  @include media($large-screen) {
-    border: none;
-    margin: 0;
-  }
 
   > li {
     background-color: transparent;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -143,6 +143,8 @@ $box-shadow:              0 0 2px $color-shadow !default;
 $focus-outline:           2px dotted $color-gray-light;
 $focus-spacing:           3px;
 $nav-width:               951px !default;
+$current-highlight-border-width: 0.4rem !default; // must be in rem for math
+
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface
 // Guidelines

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -128,22 +128,22 @@ $image-path:  '../img' !default;
 $asset-pipeline:      false !default;
 
 // Magic Numbers
-$text-max-width:          66ch !default; // 66 characters per line
-$lead-max-width:          77rem !default;
-$site-max-width:          1040px !default;
-$site-margins:            3rem !default;
-$site-margins-mobile:     1.5rem !default;
-$article-max-width:       600px !default;
-$input-max-width:         46rem !default;
-$label-border-radius:     2px !default;
-$checkbox-border-radius:  2px !default;
-$border-radius:           3px !default;
-$button-border-radius:    5px !default;
-$box-shadow:              0 0 2px $color-shadow !default;
-$focus-outline:           2px dotted $color-gray-light;
-$focus-spacing:           3px;
-$nav-width:               951px !default;
-$current-highlight-border-width: 0.4rem !default; // must be in rem for math
+$text-max-width:                66ch !default; // 66 characters per line
+$lead-max-width:                77rem !default;
+$site-max-width:                1040px !default;
+$site-margins:                  3rem !default;
+$site-margins-mobile:           1.5rem !default;
+$article-max-width:             600px !default;
+$input-max-width:               46rem !default;
+$label-border-radius:           2px !default;
+$checkbox-border-radius:        2px !default;
+$border-radius:                 3px !default;
+$button-border-radius:          5px !default;
+$box-shadow:                    0 0 2px $color-shadow !default;
+$focus-outline:                 2px dotted $color-gray-light;
+$focus-spacing:                 3px;
+$nav-width:                     951px !default;
+$sidenav-current-border-width:  0.4rem !default; // must be in rem for math
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface
 // Guidelines

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -145,7 +145,6 @@ $focus-spacing:           3px;
 $nav-width:               951px !default;
 $current-highlight-border-width: 0.4rem !default; // must be in rem for math
 
-
 // 44 x 44 pixels hit target following Apple iOS Human Interface
 // Guidelines
 $hit-area: 4.4rem !default;


### PR DESCRIPTION
👀 Preview: [link](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/dw-sidenav-separation/components/preview/layout--docs.html)

I wanted to add separation around the sidenav at small widths, but it's tricky because our grid imposes a margin of `0` on the first-child. I didn't want to get into fixing the grid, but I did want to make the sidenav work, so I 
- used padding instead of margin to add 24px at the top
- added a rule on the top and bottom to differentiate from the page content
- used negative margin to push the sidenav out to the viewport margin at narrow widths
- adjusted the sidenav `li` padding to align `li`s to the page margin. (page margin is 15px and the li padding was 18px, and it was just close enough to be annoying).

<img width="566" alt="screen shot 2017-10-30 at 1 51 02 pm" src="https://user-images.githubusercontent.com/11464021/32195036-5b57d962-bd79-11e7-923b-fc023dbfff43.png">

- - -

It still looks kinda stupid at medium width, but that seems to be more a limitation of our grid and its insistence that the `one-quarter` grid appear at 50% at medium width — and I didn't want to add some kind of high-specificity overrides.

<img width="623" alt="screen shot 2017-10-30 at 1 53 17 pm" src="https://user-images.githubusercontent.com/11464021/32195201-ddc83acc-bd79-11e7-8798-2c4e91451382.png">

- - -

Everything should be back to normal at full (amazingly, over 1200px!) width.

<img width="709" alt="screen shot 2017-10-30 at 1 53 00 pm" src="https://user-images.githubusercontent.com/11464021/32195227-f3e983ba-bd79-11e7-994d-3ccf661d88b7.png">

