### PR TITLE
Scope underlining to a subset of footer links to allow underlining in the footer

### DIFF
--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -9,37 +9,37 @@
           <li class="usa-footer-primary-link">
             <h4>Topic</h4>
           </li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link that's a bit longer than most of the others</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's a bit longer than most of the others</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
         </ul>
         <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
           <li class="usa-footer-primary-link">
             <h4>Topic</h4>
           </li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link that's pretty long</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's pretty long</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
         </ul>
         <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
           <li class="usa-footer-primary-link">
             <h4>Topic</h4>
           </li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
         </ul>
         <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
           <li class="usa-footer-primary-link">
             <h4>Topic</h4>
           </li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
-          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
         </ul>
       </nav>
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -21,8 +21,8 @@
     }
   }
 
-  a {
-    font-weight: normal;
+  .usa-footer-primary-link ~ li a,
+  .usa-footer-secondary-link {
     text-decoration: none;
   }
 }


### PR DESCRIPTION
Fixes #2219 
Preview: https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/dw-footer-a/components/detail/footer--big.html

- - -

### Changes
- Adds `.usa-footer-secondary-link` class to secondary links in the `.usa-footer-big` footer
- Allows underlining in the footer links, except in custom scope (ie `.usa-footer-primary-link`, `.usa-footer-secondary-link`, and `address`)