### PR TITLE
[Fractal] Add viewport meta tag to preview template for mobile devices

### DIFF
--- a/src/components/_uswds.njk
+++ b/src/components/_uswds.njk
@@ -2,6 +2,7 @@
 <html lang="en-US">
   <head>
     <title>{{ _self.title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{{ uswds.path }}/css/uswds.min.css">
   </head>
   <body>


### PR DESCRIPTION
The preview views do not have viewport meta tags so you can't view it on simulated mobile devices accurately. This fixes that by adding the viewport meta tag to the preview template.

### Before
<img width="458" alt="screen shot 2017-11-09 at 9 12 44 am" src="https://user-images.githubusercontent.com/5249443/32620433-9a3034fc-c532-11e7-858b-7ec6434b0481.png">

### After
<img width="441" alt="screen shot 2017-11-09 at 9 12 54 am" src="https://user-images.githubusercontent.com/5249443/32620456-a0fab71c-c532-11e7-9a77-0028f7db0769.png">
