### PR TITLE
Fix extended header navigation overlap

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -23,11 +23,8 @@ $z-index-nav:     9000;
   }
 
   .usa-search {
-    margin-bottom: 1.5rem;
-
     @include media($nav-width) {
       float: right;
-      margin-bottom: 0;
       max-width: 21.5rem;
     }
   }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -123,7 +123,6 @@
 
   @include media($nav-width) {
     display: inline;
-    margin-top: 0;
   }
 
   li {

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -118,10 +118,12 @@
 
 .usa-nav-primary {
   @include usa-sidenav-list;
+  margin-top: 1.5rem;
   order: 2;
 
   @include media($nav-width) {
     display: inline;
+    margin-top: 0;
   }
 
   li {
@@ -303,14 +305,17 @@
 // Secondary navigation ----------- //
 
 .usa-nav-secondary {
+  margin-top: 1.5rem;
+
   @include media($nav-width) {
+    margin-top: 0;
     position: absolute;
     right: $site-margins;
     top: -5.7rem; // XXX magic number
   }
 
   .usa-search {
-    @include margin(3rem null);
+    @include margin(1.5rem null 0 null);
 
     @include media($nav-width) {
       @include margin(-0.9rem null 0 0);
@@ -320,8 +325,11 @@
 }
 
 .usa-nav-secondary-links {
+  margin-top: 2.4rem;
+
   @include media($nav-width) {
     float: left;
+    margin-top: 0;
   }
 
   li {

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -447,6 +447,10 @@
   img {
     width: 1.3rem;
   }
+
+  + * {
+    clear: both;
+  }
 }
 
 .usa-mobile_nav-active {

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -310,7 +310,7 @@
   }
 
   .usa-search {
-    @include margin(1.5rem null);
+    @include margin(3rem null);
 
     @include media($nav-width) {
       @include margin(-0.9rem null 0 0);

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -310,7 +310,7 @@
   }
 
   .usa-search {
-    @include margin(3rem null);
+    @include margin(1.5rem null);
 
     @include media($nav-width) {
       @include margin(-0.9rem null 0 0);
@@ -434,7 +434,7 @@
 
 .usa-nav-close {
   @include button-unstyled;
-  @include margin(-1.2rem -1.5rem 2.4rem auto);
+  @include margin(-1.2rem -1.5rem 1.5rem auto);
   float: right;
   height: $hit-area;
   text-align: center;


### PR DESCRIPTION
Fix extended header navigation overlap between the close button and next first item by clearing anything immediately following the navigation close button.

Fixes #2222.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards/fix-nav-overlap/components/detail/header--extended.html)

**Vizdee question** 🌈: While I was reviewing this, I noticed the component sticker sheet (Sketch) has a tighter spacing between the close button and nav, while the original designs (which our current code follows) had wider spacing and want to confirm the desired spacing, which I can tack on here if we want it tighter like the sketch file. What do you think @thisisdano?

## Current Sketch file
<img width="404" alt="screen shot 2017-11-14 at 9 57 13 am" src="https://user-images.githubusercontent.com/5249443/32796106-9563d098-c922-11e7-9d9d-8107d3bc8276.png">

## Previous designs (and current code)
<img width="353" alt="screen shot 2017-11-14 at 9 57 32 am" src="https://user-images.githubusercontent.com/5249443/32796121-9c7fbbbc-c922-11e7-9f6c-92d70c0ca8fc.png">
