### PR TITLE
Give unique IDs to password fields on form templates

### DIFF
--- a/src/components/07-form/form.config.yml
+++ b/src/components/07-form/form.config.yml
@@ -1,2 +1,2 @@
 label: Forms
-preview: '@uswds-content'
+preview: '@uswds-framed'

--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -14,7 +14,7 @@
       </div>
     </div>
 
-    <label for="password">New password</label>
+    <label for="password-reset">New password</label>
     <input id="password-reset" name="password" type="password">
 
     <label for="confirmPassword">Confirm password</label>

--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -15,7 +15,7 @@
     </div>
 
     <label for="password">New password</label>
-    <input id="password" name="password" type="password">
+    <input id="password-reset" name="password" type="password">
 
     <label for="confirmPassword">Confirm password</label>
     <input id="confirmPassword" name="confirmPassword" type="password">

--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -22,7 +22,7 @@
     <p class="usa-form-note">
       <a href="javascript:void(0);"
         class="usa-show_multipassword"
-        aria-controls="password confirmPassword">Show my typing</a>
+        aria-controls="password-reset confirmPassword">Show my typing</a>
     </p>
 
     <input type="submit" value="Reset password">

--- a/src/components/07-form/templates/sign-in-form.njk
+++ b/src/components/07-form/templates/sign-in-form.njk
@@ -7,7 +7,7 @@
     <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off">
 
     <label for="password">Password</label>
-    <input id="password" name="password" type="password">
+    <input id="password-sign-in" name="password" type="password">
     <p class="usa-form-note">
       <a title="Show password" href="javascript:void(0);"
         class="usa-show_password"

--- a/src/components/07-form/templates/sign-in-form.njk
+++ b/src/components/07-form/templates/sign-in-form.njk
@@ -11,7 +11,7 @@
     <p class="usa-form-note">
       <a title="Show password" href="javascript:void(0);"
         class="usa-show_password"
-        aria-controls="password">Show password</a>
+        aria-controls="password-sign-in">Show password</a>
     </p>
 
     <input type="submit" value="Sign in">

--- a/src/components/07-form/templates/sign-in-form.njk
+++ b/src/components/07-form/templates/sign-in-form.njk
@@ -6,7 +6,7 @@
     <label for="username">Username or email address</label>
     <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off">
 
-    <label for="password">Password</label>
+    <label for="password-sign-in">Password</label>
     <input id="password-sign-in" name="password" type="password">
     <p class="usa-form-note">
       <a title="Show password" href="javascript:void(0);"


### PR DESCRIPTION
This is mainly necessary to fix 18F/web-design-standards-docs#449 (otherwise test won't pass because the same ID is being used multiple times on the page where we display both templates together)

Side note: switched the `preview:` variable to the preferred format for this type of content. 