### PR TITLE
[Header]: Fix unclosed search markup in header

### DIFF
--- a/src/components/search/search--header.njk
+++ b/src/components/search/search--header.njk
@@ -5,5 +5,5 @@
     <button type="submit">
       <span class="usa-sr-only">Search</span>
     </button>
-  </form>
-</div>
+  </div>
+</form>


### PR DESCRIPTION
Ensures the search form in the header closes properly by swapping the closing `</div>` and `</form>` tag which was causing an HTML validation error.

Fixes #2236.