### PR TITLE
Add link to browser support in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,9 @@ For JavaScript contributions, we will review the code coverage percentage and ch
 
 High code coverage numbers are generally good, and we would prefer that our coverage increases over time. We will not categorically reject contributions that reduce code coverage, but we may ask contributors to refactor their code, add new unit tests, or modify existing tests to avoid significant reductions in coverage.
 
+## Browser support
+See [browser support](https://standards.usa.gov/getting-started/developers/#browser-support) in the “Getting started: Developers” guidelines.
+
 ## Our use of branches
 
 See the [release documentation](RELEASE.md#release-process) for more information on our git/GitHub release workflow.


### PR DESCRIPTION
Adds link to browser support in the CONTRIBUTING guidelines. The docs site will have the single source of truth so content is not in multiple places, which will make maintenance more difficult.

Fixes #2251. 

Related: https://github.com/18F/web-design-standards-docs/pull/459