### PR TITLE
make the focus variables default so that they can be overridden by us…

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -140,8 +140,8 @@ $checkbox-border-radius:        2px !default;
 $border-radius:                 3px !default;
 $button-border-radius:          5px !default;
 $box-shadow:                    0 0 2px $color-shadow !default;
-$focus-outline:                 2px dotted $color-gray-light;
-$focus-spacing:                 3px;
+$focus-outline:                 2px dotted $color-gray-light !default;
+$focus-spacing:                 3px !default;
 $nav-width:                     951px !default;
 $sidenav-current-border-width:  0.4rem !default; // must be in rem for math
 


### PR DESCRIPTION
…er set variables

<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact standards.usa.gov’s look, feel, or functionality, please open a pull request on the web-design-standards-docs repo (https://github.com/18F/web-design-standards-docs).

-->

## Description

I'm not sure why these variables are not set with the !default parameter. It would be nice to provide the user the flexibility to override these like the other variables.

## Additional information

Include any of the following (as necessary): 

* Relevant research and support documents
* Type of content review needed: stylistic or copy editing
* Screenshot images
* Notes

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
