### PR TITLE
Fixing dropdown arrow display in IE10/11

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -112,7 +112,8 @@ select {
   appearance: none;
   background-color: $color-white;
   background-image: url('#{$image-path}/arrow-both.png');
-  // Ensure browsers that don't support SVG in background-image (IE 11 and below) fall back to PNG. See https://www.broken-links.com/2010/06/14/using-svg-in-backgrounds-with-png-fallback/
+  // Ensure browsers that don't support SVG in background-image (IE 11 and below) fall back to PNG. 
+  // See https://www.broken-links.com/2010/06/14/using-svg-in-backgrounds-with-png-fallback/
   background-image: none, url('#{$image-path}/arrow-both.svg'), url('#{$image-path}/arrow-both.png');
   background-position: right 1.3rem center;
   background-repeat: no-repeat;

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -112,7 +112,7 @@ select {
   appearance: none;
   background-color: $color-white;
   background-image: url('#{$image-path}/arrow-both.png');
-  background-image: url('#{$image-path}/arrow-both.svg');
+  background-image: none, url('#{$image-path}/arrow-both.svg'), url('#{$image-path}/arrow-both.png');
   background-position: right 1.3rem center;
   background-repeat: no-repeat;
   background-size: 1rem;

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -112,6 +112,7 @@ select {
   appearance: none;
   background-color: $color-white;
   background-image: url('#{$image-path}/arrow-both.png');
+  // Ensure browsers that don't support SVG in background-image (IE 11 and below) fall back to PNG. See https://www.broken-links.com/2010/06/14/using-svg-in-backgrounds-with-png-fallback/
   background-image: none, url('#{$image-path}/arrow-both.svg'), url('#{$image-path}/arrow-both.png');
   background-position: right 1.3rem center;
   background-repeat: no-repeat;


### PR DESCRIPTION
Fixes #2265 

Found [this fix](https://www.broken-links.com/2010/06/14/using-svg-in-backgrounds-with-png-fallback/) and it appears to be working for me in IE11. 

I wasn't quite sure the best way to confirm it was using the SVG in browsers that support it but I unchecked that rule (forcing the PNG to load) and zoomed in to notice the render wasn't quite as sharp which would be the expected behavior for a non-svg in a case like this. 