### PR TITLE
Update Circle Config to 2.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,33 +1,52 @@
-machine:
-  node:
-    version: 6
+version: 2
 
-test:
-  pre:
-    - npm install -g codeclimate-test-reporter
-    # https://discuss.circleci.com/t/using-the-latest-version-of-chrome-on-circleci/871/4
-    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    - sudo dpkg -i google-chrome.deb
-    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-    - rm google-chrome.deb
-  override:
-    # Run the package and docs test suite
-    - npm test
-    # Run semantic version checks against the previous release
-    # - npm run cracks
-    # Generate code coverage report
-    - npm run cover
-    # Build the release files
-    - npm run build
-  post:
-    # Ensure that build:package worked
-    - ls -agolf dist/
-    - codeclimate-test-reporter < coverage/lcov.info
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6
+    steps:
+      - checkout
+      - run:
+          name: Install codeclimate
+          command: npm install -g codeclimate-test-reporter
+      - run:
+          name: Install node dependencies
+          command: npm install
+      - run:
+          name: Run test
+          command: npm test
+      - run:
+          name: Run code coverage report
+          command: npm run cover
+      - run:
+          name: Build the Standards package
+          command: npm run build
+      - run:
+          name: Checking build
+          command:
+            - ls -agolf dist/
+            - codeclimate-test-reporter < coverage/lcov.info
 
-deployment:
-  npm:
-    branch: master
-    owner: 18F
-    commands:
-      - npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-      - npm publish
+  deploy:
+    docker:
+      - image: circleci/node:6
+    steps:
+      - checkout
+      - run:
+          name: Publish to NPM
+          command:
+            - npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
+            - npm publish
+
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:6-browsers
     steps:
       - checkout
       - run:
@@ -29,7 +29,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:6-browsers
     steps:
       - checkout
       - run:
@@ -37,7 +37,6 @@ jobs:
           command:
             - npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
             - npm publish
-
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -23,9 +23,9 @@ jobs:
           command: npm run build
       - run:
           name: Checking build
-          command:
-            - ls -agolf dist/
-            - codeclimate-test-reporter < coverage/lcov.info
+          command: |
+            ls -agolf dist/
+            codeclimate-test-reporter < coverage/lcov.info
 
   deploy:
     docker:
@@ -34,9 +34,9 @@ jobs:
       - checkout
       - run:
           name: Publish to NPM
-          command:
-            - npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            - npm publish
+          command: |
+            npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
+            npm publish
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Install codeclimate
-          command: npm install -g codeclimate-test-reporter
+          command: sudo npm install -g codeclimate-test-reporter
       - run:
           name: Install node dependencies
           command: npm install


### PR DESCRIPTION
Updates Circle Config to 2.0

Note: It may be difficult to test the "publish to NPM" part of the new config until we do something new in master that would actually trigger that part of the config. Will have to be wary of that the next time we release. I did at least confirm that those lines don't run when it's _not_ master