### PR TITLE
[Header]: Update usa-overlay transition

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -102,7 +102,7 @@ $z-index-nav:     9000;
   @include position(fixed, 0);
   background: $color-black;
   opacity: 0;
-  transition: all 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
   visibility: hidden;
   z-index: $z-index-overlay;
 


### PR DESCRIPTION
## Description

Occasionally there is a brief flash of the `.usa-overlay` background on page load (as described here: https://github.com/18F/web-design-standards/issues/2274). By updating the CSS transition of `.usa-overlay` to only target `opacity`, it appears that the occasional flash is removed.

To recreate issue: https://federalist-proxy.app.cloud.gov/preview/18f/federalist-uswds-template/update-uswds/

For preview of fix: https://federalist-proxy.app.cloud.gov/preview/18f/federalist-uswds-template/bh-overlay-fix/
