### PR TITLE
save exact version of uswds package instead of range

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -176,7 +176,7 @@ git checkout -b release-{{ version }} origin/develop
 ```
 - [ ] Change the uswds dependency in `package.json` to the new version from `npm`
 ```
-npm install --save uswds@{{ version }}
+npm install --save-exact uswds@{{ version }}
 ```
 - [ ] Commit this change to the release branch
 


### PR DESCRIPTION
During the release process we want to save an exact version of the standards package `"uswds": "1.4.4",` instead of a range of versions `"uswds": "^1.4.4",`